### PR TITLE
Push Notifications

### DIFF
--- a/ignite-base/App/Containers/AllComponentsScreen.js
+++ b/ignite-base/App/Containers/AllComponentsScreen.js
@@ -40,7 +40,7 @@ export default class AllComponentsScreen extends React.Component {
   componentWillReceiveProps (nextProps) {
     // Request premissions only if the user has logged in.
     const { loggedIn } = nextProps
-    if ( loggedIn ) {
+    if (loggedIn) {
       console.log('Requesting push notification permissions.')
       PushNotification.requestPermissions()
     }

--- a/ignite-base/App/Containers/AllComponentsScreen.js
+++ b/ignite-base/App/Containers/AllComponentsScreen.js
@@ -9,6 +9,7 @@ import Routes from '../Navigation/Routes'
 // external libs
 import Icon from 'react-native-vector-icons/FontAwesome'
 import Animatable from 'react-native-animatable'
+import PushNotification from 'react-native-push-notification'
 
 // I18n
 import I18n from '../I18n/I18n.js'
@@ -33,6 +34,15 @@ export default class AllComponentsScreen extends React.Component {
   componentWillMount () {
     this.props.navigator.state.tapHamburger = () => {
       this.props.navigator.drawer.toggle()
+    }
+  }
+
+  componentWillReceiveProps (nextProps) {
+    // Request premissions only if the user has logged in.
+    const { loggedIn } = nextProps
+    if ( loggedIn ) {
+      console.log('Requesting push notification permissions.')
+      PushNotification.requestPermissions()
     }
   }
 

--- a/ignite-base/App/Root.js
+++ b/ignite-base/App/Root.js
@@ -4,11 +4,48 @@ import configureStore from './Store/Store'
 import { Provider } from 'react-redux'
 import Actions from './Actions/Creators'
 import Drawer from 'react-native-drawer'
+import PushNotification from 'react-native-push-notification'
 
 // Styles
 import styles from './Containers/Styles/RootStyle'
 
 const store = configureStore()
+
+// https://github.com/zo0r/react-native-push-notification
+PushNotification.configure({
+
+    // (optional) Called when Token is generated (iOS and Android)
+    onRegister: function(token) {
+        console.log( 'TOKEN:', token );
+    },
+
+    // (required) Called when a remote or local notification is opened or received
+    onNotification: function(notification) {
+        console.log( 'NOTIFICATION:', notification );
+    },
+
+    // ANDROID ONLY: (optional) GCM Sender ID.
+    senderID: "YOUR GCM SENDER ID",
+
+    // IOS ONLY (optional): default: all - Permissions to register.
+    permissions: {
+        alert: true,
+        badge: true,
+        sound: true
+    },
+
+    // Should the initial notification be popped automatically
+    // default: true
+    popInitialNotification: true,
+
+    /**
+      * IOS ONLY: (optional) default: true
+      * - Specified if permissions will requested or not,
+      * - if not, you must call PushNotificationsHandler.requestPermissions() later
+      */
+    requestPermissions: false,
+});
+
 
 export default class RNBase extends React.Component {
 

--- a/ignite-base/App/Root.js
+++ b/ignite-base/App/Root.js
@@ -14,38 +14,37 @@ const store = configureStore()
 // https://github.com/zo0r/react-native-push-notification
 PushNotification.configure({
 
-    // (optional) Called when Token is generated (iOS and Android)
-    onRegister: function(token) {
-        console.log( 'TOKEN:', token );
-    },
+  // (optional) Called when Token is generated (iOS and Android)
+  onRegister: (token) => {
+    console.log('TOKEN:', token)
+  },
 
-    // (required) Called when a remote or local notification is opened or received
-    onNotification: function(notification) {
-        console.log( 'NOTIFICATION:', notification );
-    },
+  // (required) Called when a remote or local notification is opened or received
+  onNotification: (notification) => {
+    console.log('NOTIFICATION:', notification)
+  },
 
-    // ANDROID ONLY: (optional) GCM Sender ID.
-    senderID: "YOUR GCM SENDER ID",
+  // ANDROID ONLY: (optional) GCM Sender ID.
+  senderID: 'YOUR GCM SENDER ID',
 
-    // IOS ONLY (optional): default: all - Permissions to register.
-    permissions: {
-        alert: true,
-        badge: true,
-        sound: true
-    },
+  // IOS ONLY (optional): default: all - Permissions to register.
+  permissions: {
+    alert: true,
+    badge: true,
+    sound: true
+  },
 
-    // Should the initial notification be popped automatically
-    // default: true
-    popInitialNotification: true,
+  // Should the initial notification be popped automatically
+  // default: true
+  popInitialNotification: true,
 
-    /**
-      * IOS ONLY: (optional) default: true
-      * - Specified if permissions will requested or not,
-      * - if not, you must call PushNotificationsHandler.requestPermissions() later
-      */
-    requestPermissions: false,
-});
-
+  /**
+    * IOS ONLY: (optional) default: true
+    * - Specified if permissions will requested or not,
+    * - if not, you must call PushNotificationsHandler.requestPermissions() later
+    */
+  requestPermissions: false
+})
 
 export default class RNBase extends React.Component {
 

--- a/ignite-base/android/app/build.gradle
+++ b/ignite-base/android/app/build.gradle
@@ -78,12 +78,12 @@ def enableProguardInReleaseBuilds = false
 
 android {
     compileSdkVersion 23
-    buildToolsVersion "23.0.1"
+    buildToolsVersion "23.0.2"
 
     defaultConfig {
         applicationId "com.rnbase"
         minSdkVersion 16
-        targetSdkVersion 22
+        targetSdkVersion 23
         versionCode 1
         versionName "1.0"
         ndk {
@@ -122,6 +122,7 @@ android {
 dependencies {
     compile project(':react-native-i18n')
     compile project(':react-native-vector-icons')
+    compile project(':react-native-push-notification')
     compile fileTree(dir: "libs", include: ["*.jar"])
     compile "com.android.support:appcompat-v7:23.0.1"
     compile "com.facebook.react:react-native:+"  // From node_modules

--- a/ignite-base/android/app/src/main/AndroidManifest.xml
+++ b/ignite-base/android/app/src/main/AndroidManifest.xml
@@ -7,6 +7,7 @@
     <uses-permission android:name="${applicationId}.permission.C2D_MESSAGE" />
     <uses-permission android:name="android.permission.WAKE_LOCK" />
     <uses-permission android:name="android.permission.VIBRATE" />
+    <uses-permission android:name="android.permission.SYSTEM_ALERT_WINDOW"/>
     <uses-permission android:name="android.permission.INTERNET" />
 
     <application

--- a/ignite-base/android/app/src/main/AndroidManifest.xml
+++ b/ignite-base/android/app/src/main/AndroidManifest.xml
@@ -1,6 +1,12 @@
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
     package="com.rnbase">
 
+    <permission
+      android:name="${applicationId}.permission.C2D_MESSAGE"
+      android:protectionLevel="signature" />
+    <uses-permission android:name="${applicationId}.permission.C2D_MESSAGE" />
+    <uses-permission android:name="android.permission.WAKE_LOCK" />
+    <uses-permission android:name="android.permission.VIBRATE" />
     <uses-permission android:name="android.permission.INTERNET" />
 
     <application
@@ -8,6 +14,25 @@
       android:label="@string/app_name"
       android:icon="@mipmap/ic_launcher"
       android:theme="@style/AppTheme">
+      <receiver
+          android:name="com.google.android.gms.gcm.GcmReceiver"
+          android:exported="true"
+          android:permission="com.google.android.c2dm.permission.SEND" >
+          <intent-filter>
+              <action android:name="com.google.android.c2dm.intent.RECEIVE" />
+              <category android:name="${applicationId}" />
+          </intent-filter>
+      </receiver>
+
+      <service android:name="com.dieam.reactnativepushnotification.modules.RNPushNotificationRegistrationService"/>
+      <service
+          android:name="com.dieam.reactnativepushnotification.modules.RNPushNotificationListenerService"
+          android:exported="false" >
+          <intent-filter>
+              <action android:name="com.google.android.c2dm.intent.RECEIVE" />
+          </intent-filter>
+      </service>
+
       <activity
         android:name=".MainActivity"
         android:label="@string/app_name"

--- a/ignite-base/android/app/src/main/java/com/rnbase/MainActivity.java
+++ b/ignite-base/android/app/src/main/java/com/rnbase/MainActivity.java
@@ -1,5 +1,7 @@
 package com.rnbase;
 
+import android.content.Intent;
+import com.dieam.reactnativepushnotification.ReactNativePushNotificationPackage;
 import com.facebook.react.ReactActivity;
 import com.i18n.reactnativei18n.ReactNativeI18n;
 import com.oblador.vectoricons.VectorIconsPackage;
@@ -10,6 +12,8 @@ import java.util.Arrays;
 import java.util.List;
 
 public class MainActivity extends ReactActivity {
+
+    private ReactNativePushNotificationPackage mReactNativePushNotificationPackage;
 
     /**
      * Returns the name of the main component registered from JavaScript.
@@ -35,10 +39,21 @@ public class MainActivity extends ReactActivity {
      */
     @Override
     protected List<ReactPackage> getPackages() {
+        mReactNativePushNotificationPackage = new ReactNativePushNotificationPackage(this); // <------ Initialize the Package
         return Arrays.<ReactPackage>asList(
             new MainReactPackage(),
             new ReactNativeI18n(),
-            new VectorIconsPackage()
+            new VectorIconsPackage(),
+            mReactNativePushNotificationPackage
         );
     }
+
+    // Add onNewIntent
+    @Override
+    protected void onNewIntent (Intent intent) {
+      super.onNewIntent(intent);
+
+      mReactNativePushNotificationPackage.newIntent(intent);
+    }
+
 }

--- a/ignite-base/android/settings.gradle
+++ b/ignite-base/android/settings.gradle
@@ -5,3 +5,5 @@ include ':react-native-vector-icons'
 project(':react-native-vector-icons').projectDir = new File(rootProject.projectDir, '../node_modules/react-native-vector-icons/android')
 include ':react-native-i18n'
 project(':react-native-i18n').projectDir = new File(rootProject.projectDir, '../node_modules/react-native-i18n/android')
+include ':react-native-push-notification'
+project(':react-native-push-notification').projectDir = file('../node_modules/react-native-push-notification/RNPushNotificationAndroid')

--- a/ignite-base/ios/RNBase.xcodeproj/project.pbxproj
+++ b/ignite-base/ios/RNBase.xcodeproj/project.pbxproj
@@ -26,6 +26,7 @@
 		489B58760665471AA3E6EB2F /* Zocial.ttf in Resources */ = {isa = PBXBuildFile; fileRef = 4D56EC13585E48B18779678B /* Zocial.ttf */; };
 		5D577C7EB47145EAA2BEA1BA /* Entypo.ttf in Resources */ = {isa = PBXBuildFile; fileRef = 5B4FAE39577E4B4C87A827D3 /* Entypo.ttf */; };
 		60E66BE4D5434E7BA7EEA39E /* libRNVectorIcons.a in Frameworks */ = {isa = PBXBuildFile; fileRef = F745055AC6594FDE88A42390 /* libRNVectorIcons.a */; };
+		7B189D4E1CB7EE08004CCC54 /* libRCTPushNotification.a in Frameworks */ = {isa = PBXBuildFile; fileRef = 7B189D451CB7EDE6004CCC54 /* libRCTPushNotification.a */; };
 		832341BD1AAA6AB300B99B32 /* libRCTText.a in Frameworks */ = {isa = PBXBuildFile; fileRef = 832341B51AAA6A8300B99B32 /* libRCTText.a */; };
 		9099CF4E1CC543699546A3CE /* EvilIcons.ttf in Resources */ = {isa = PBXBuildFile; fileRef = 984D8FC5FFE34AA59402EEA6 /* EvilIcons.ttf */; };
 		9899EBC86C7D4D898D025410 /* Octicons.ttf in Resources */ = {isa = PBXBuildFile; fileRef = EE9C0949165E4E669FB7C472 /* Octicons.ttf */; };
@@ -126,6 +127,13 @@
 			remoteGlobalIDString = 134814201AA4EA6300B7C361;
 			remoteInfo = RCTLinking;
 		};
+		7B189D441CB7EDE6004CCC54 /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = 7B189D3B1CB7EDE6004CCC54 /* RCTPushNotification.xcodeproj */;
+			proxyType = 2;
+			remoteGlobalIDString = 134814201AA4EA6300B7C361;
+			remoteInfo = RCTPushNotification;
+		};
 		832341B41AAA6A8300B99B32 /* PBXContainerItemProxy */ = {
 			isa = PBXContainerItemProxy;
 			containerPortal = 832341B01AAA6A8300B99B32 /* RCTText.xcodeproj */;
@@ -163,6 +171,7 @@
 		6B7020FAD6C04DB88066FD95 /* libRNI18n.a */ = {isa = PBXFileReference; explicitFileType = undefined; fileEncoding = 9; includeInIndex = 0; lastKnownFileType = archive.ar; path = libRNI18n.a; sourceTree = "<group>"; };
 		78C398B01ACF4ADC00677621 /* RCTLinking.xcodeproj */ = {isa = PBXFileReference; lastKnownFileType = "wrapper.pb-project"; name = RCTLinking.xcodeproj; path = "../node_modules/react-native/Libraries/LinkingIOS/RCTLinking.xcodeproj"; sourceTree = "<group>"; };
 		7B119248E8874CC4991BEC78 /* Foundation.ttf */ = {isa = PBXFileReference; explicitFileType = undefined; fileEncoding = 9; includeInIndex = 0; lastKnownFileType = unknown; name = Foundation.ttf; path = "../node_modules/react-native-vector-icons/Fonts/Foundation.ttf"; sourceTree = "<group>"; };
+		7B189D3B1CB7EDE6004CCC54 /* RCTPushNotification.xcodeproj */ = {isa = PBXFileReference; lastKnownFileType = "wrapper.pb-project"; name = RCTPushNotification.xcodeproj; path = "../node_modules/react-native/Libraries/PushNotificationIOS/RCTPushNotification.xcodeproj"; sourceTree = "<group>"; };
 		832341B01AAA6A8300B99B32 /* RCTText.xcodeproj */ = {isa = PBXFileReference; lastKnownFileType = "wrapper.pb-project"; name = RCTText.xcodeproj; path = "../node_modules/react-native/Libraries/Text/RCTText.xcodeproj"; sourceTree = "<group>"; };
 		984D8FC5FFE34AA59402EEA6 /* EvilIcons.ttf */ = {isa = PBXFileReference; explicitFileType = undefined; fileEncoding = 9; includeInIndex = 0; lastKnownFileType = unknown; name = EvilIcons.ttf; path = "../node_modules/react-native-vector-icons/Fonts/EvilIcons.ttf"; sourceTree = "<group>"; };
 		B721D5FF6D414F8E8BA82A71 /* RNVectorIcons.xcodeproj */ = {isa = PBXFileReference; explicitFileType = undefined; fileEncoding = 9; includeInIndex = 0; lastKnownFileType = "wrapper.pb-project"; name = RNVectorIcons.xcodeproj; path = "../node_modules/react-native-vector-icons/RNVectorIcons.xcodeproj"; sourceTree = "<group>"; };
@@ -183,6 +192,7 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				7B189D4E1CB7EE08004CCC54 /* libRCTPushNotification.a in Frameworks */,
 				146834051AC3E58100842450 /* libReact.a in Frameworks */,
 				00C302E51ABCBA2D00DB3ED1 /* libRCTActionSheet.a in Frameworks */,
 				00C302E71ABCBA2D00DB3ED1 /* libRCTGeolocation.a in Frameworks */,
@@ -336,9 +346,18 @@
 			name = Products;
 			sourceTree = "<group>";
 		};
+		7B189D3C1CB7EDE6004CCC54 /* Products */ = {
+			isa = PBXGroup;
+			children = (
+				7B189D451CB7EDE6004CCC54 /* libRCTPushNotification.a */,
+			);
+			name = Products;
+			sourceTree = "<group>";
+		};
 		832341AE1AAA6A7D00B99B32 /* Libraries */ = {
 			isa = PBXGroup;
 			children = (
+				7B189D3B1CB7EDE6004CCC54 /* RCTPushNotification.xcodeproj */,
 				146833FF1AC3E56700842450 /* React.xcodeproj */,
 				00C302A71ABCB8CE00DB3ED1 /* RCTActionSheet.xcodeproj */,
 				00C302B51ABCB90400DB3ED1 /* RCTGeolocation.xcodeproj */,
@@ -472,6 +491,10 @@
 					ProjectRef = 00C302D31ABCB9D200DB3ED1 /* RCTNetwork.xcodeproj */;
 				},
 				{
+					ProductGroup = 7B189D3C1CB7EDE6004CCC54 /* Products */;
+					ProjectRef = 7B189D3B1CB7EDE6004CCC54 /* RCTPushNotification.xcodeproj */;
+				},
+				{
 					ProductGroup = 139105B71AF99BAD00B5F7CC /* Products */;
 					ProjectRef = 139105B61AF99BAD00B5F7CC /* RCTSettings.xcodeproj */;
 				},
@@ -591,6 +614,13 @@
 			fileType = archive.ar;
 			path = libRCTLinking.a;
 			remoteRef = 78C398B81ACF4ADC00677621 /* PBXContainerItemProxy */;
+			sourceTree = BUILT_PRODUCTS_DIR;
+		};
+		7B189D451CB7EDE6004CCC54 /* libRCTPushNotification.a */ = {
+			isa = PBXReferenceProxy;
+			fileType = archive.ar;
+			path = libRCTPushNotification.a;
+			remoteRef = 7B189D441CB7EDE6004CCC54 /* PBXContainerItemProxy */;
 			sourceTree = BUILT_PRODUCTS_DIR;
 		};
 		832341B51AAA6A8300B99B32 /* libRCTText.a */ = {
@@ -745,6 +775,7 @@
 					"$(SRCROOT)/../node_modules/react-native/React/**",
 					"$(SRCROOT)/../node_modules/react-native-vector-icons/RNVectorIconsManager",
 					"$(SRCROOT)/../node_modules/react-native-i18n/RNI18n",
+					"$(SRCROOT)/../node_modules/react-native/Libraries/PushNotificationIOS/**",
 				);
 				INFOPLIST_FILE = RNBase/Info.plist;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks";
@@ -763,6 +794,7 @@
 					"$(SRCROOT)/../node_modules/react-native/React/**",
 					"$(SRCROOT)/../node_modules/react-native-vector-icons/RNVectorIconsManager",
 					"$(SRCROOT)/../node_modules/react-native-i18n/RNI18n",
+					"$(SRCROOT)/../node_modules/react-native/Libraries/PushNotificationIOS/**",
 				);
 				INFOPLIST_FILE = RNBase/Info.plist;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks";

--- a/ignite-base/ios/RNBase/AppDelegate.m
+++ b/ignite-base/ios/RNBase/AppDelegate.m
@@ -10,6 +10,7 @@
 #import "AppDelegate.h"
 
 #import "RCTRootView.h"
+#import "RCTPushNotificationManager.h"
 
 @implementation AppDelegate
 
@@ -53,5 +54,30 @@
   [self.window makeKeyAndVisible];
   return YES;
 }
+
+// Required to register for notifications
+- (void)application:(UIApplication *)application didRegisterUserNotificationSettings:(UIUserNotificationSettings *)notificationSettings
+{
+  [RCTPushNotificationManager didRegisterUserNotificationSettings:notificationSettings];
+}
+
+// Required for the register event.
+- (void)application:(UIApplication *)application didRegisterForRemoteNotificationsWithDeviceToken:(NSData *)deviceToken
+{
+  [RCTPushNotificationManager didRegisterForRemoteNotificationsWithDeviceToken:deviceToken];
+}
+
+// Required for the notification event.
+- (void)application:(UIApplication *)application didReceiveRemoteNotification:(NSDictionary *)notification
+{
+  [RCTPushNotificationManager didReceiveRemoteNotification:notification];
+}
+
+// Required for the localNotification event.
+- (void)application:(UIApplication *)application didReceiveLocalNotification:(UILocalNotification *)notification
+{
+  [RCTPushNotificationManager didReceiveLocalNotification:notification];
+}
+
 
 @end

--- a/ignite-base/package.json
+++ b/ignite-base/package.json
@@ -18,6 +18,7 @@
     "react-native-animatable": "^0.5.2",
     "react-native-drawer": "^2.0.0",
     "react-native-i18n": "0.0.8",
+    "react-native-push-notification": "^1.0.3",
     "react-native-vector-icons": "^1.3.3",
     "react-redux": "^4.4.0",
     "redux": "^3.3.1",

--- a/ignite-base/package.json.template
+++ b/ignite-base/package.json.template
@@ -18,6 +18,7 @@
     "react-native-animatable": "^0.5.2",
     "react-native-drawer": "^2.0.0",
     "react-native-i18n": "0.0.8",
+    "react-native-push-notification": "^1.0.3",
     "react-native-vector-icons": "^1.3.3",
     "react-redux": "^4.4.0",
     "redux": "^3.3.1",


### PR DESCRIPTION
This PR adds the `react-native-push-notification` project and configures the android and ios builds for push notifications. It also adds a generic configuration to `Root.js` and has an example that requests permissions after the user has logged in on the all components screen.

![simulator screen shot apr 8 2016 10 01 37 am](https://cloud.githubusercontent.com/assets/139261/14387555/f9988a72-fd77-11e5-8c5a-9026fc9a179d.png)


### Pull-Request Checklist

- [x] Works on iOS/Android/XDE
- [x] Tests Pass (run: `npm run test && npm run test:client`)
- [x] Code is StandardJS compliant (run: `npm run lint`)
