### PR TITLE
Turns off a mystery PN setting which was breaking fresh apps.

### DIFF
--- a/ignite-base/App/Root.js
+++ b/ignite-base/App/Root.js
@@ -36,7 +36,7 @@ PushNotification.configure({
 
   // Should the initial notification be popped automatically
   // default: true
-  popInitialNotification: true,
+  popInitialNotification: false,
 
   /**
     * IOS ONLY: (optional) default: true


### PR DESCRIPTION
I actually don't know anything about this push notification component.

Seems like at startup, it's triggering a request to display a push notification.  This phantom notification is causing itself to trip up.

Setting this value to false seems to dodge that issue, but our app now runs.