### PR TITLE
Adds the missing validation.js to the packing list.

### DIFF
--- a/ignite-generator/package.json
+++ b/ignite-generator/package.json
@@ -6,7 +6,8 @@
     "app",
     "screen",
     "component",
-    "container"
+    "container",
+    "validation.js"
   ],
   "scripts": {
     "test": "echo \"Error: no test specified\" && exit 1",


### PR DESCRIPTION
Was just missing the `validation.js` from the generator's `package.json` `files` node.

Fixes #75 
Fixes #71 
