### PR TITLE
- [Base] - Make yellowbox obey DebugSettings boolean

### DIFF
--- a/ignite-base/App/Root.js
+++ b/ignite-base/App/Root.js
@@ -6,6 +6,7 @@ import { Provider } from 'react-redux'
 import Actions from './Actions/Creators'
 import Drawer from 'react-native-drawer'
 import PushNotification from 'react-native-push-notification'
+import DebugSettings from '../Config/DebugSettings'
 
 // Styles
 import styles from './Containers/Styles/RootStyle'
@@ -69,6 +70,7 @@ export default class RNBase extends React.Component {
   }
 
   renderApp () {
+    console.disableYellowBox = !DebugSettings.yellowBox
     return (
       <Provider store={store}>
         <View style={styles.applicationView}>


### PR DESCRIPTION
#### Ignite Base Change
- [x] Works on iOS/Android/XDE
- [x] Tests Pass (run: `npm run test`)
- [x] Code is StandardJS compliant (run: `npm run lint`)

YellowBox was not obeying the boolean in DebugSettings - fixed
