### PR TITLE
[Base] - Adding Android to FastLane

### DIFF
--- a/ignite-base/fastlane/Appfile
+++ b/ignite-base/fastlane/Appfile
@@ -1,7 +1,11 @@
+# iOS
 # app_identifier "com.infinitered.ignite" # The bundle identifier of your app
 # apple_id "thisIsMe@gmail.com" # Your Apple email address
+# team_id "3FTD6ME549"  # Developer Portal Team ID
 
-#  team_id "3FTD6ME549"  # Developer Portal Team ID
+# Android
+# json_key_file "./google-play-api-secret.json" # Path to the json secret file - Follow https://github.com/fastlane/supply#setup to get one
+# package_name "com.infinitered.myapp" # You Android app package
 
 # you can even provide different app identifiers, Apple IDs and team names per lane:
 # More information: https://github.com/fastlane/fastlane/blob/master/fastlane/docs/Appfile.md

--- a/ignite-base/fastlane/Fastfile
+++ b/ignite-base/fastlane/Fastfile
@@ -97,6 +97,59 @@ platform :ios do
   end
 end
 
+platform :android do
+  before_all do
+    # ENV["SLACK_URL"] = "https://hooks.slack.com/services/..."
+  end
+
+  desc "Tests Slack"
+  lane :test_slack do
+    # snapshot
+    slack(
+      message: "You can post to Slack!",
+      channel: "#p-projectname",  # Optional, by default will post to the default channel configured for the POST URL.
+      payload: {            # Optional, lets you specify any number of your own Slack attachments.
+        'Build Date' => Time.new.to_s
+      },
+      default_payloads: [:git_branch, :git_author], # Optional, lets you specify a whitelist of default payloads to include. Pass an empty array to suppress all the default payloads. Don't add this key, or pass nil, if you want all the default payloads. The available default payloads are: `lane`, `test_result`, `git_branch`, `git_author`, `last_git_commit`.
+    )
+  end
+
+  desc "Submit a new Alpha Build to Google Play Store"
+  lane :alpha do
+    # Build the release version of the Android App
+    gradle(
+      task: "assemble", 
+      build_type: "Release", 
+      project_dir: "android/"
+    )
+    
+    # Uploads generated apk to Google Play Store as an Alpha build
+    supply(
+      track: "alpha", 
+      apk: "android/app/build/outputs/apk/app-release.apk"
+    )
+
+  end
+
+  # You can define as many lanes as you want
+
+  after_all do |lane|
+    # This block is called, only if the executed lane was successful
+
+    slack(
+      message: "App successfully released",
+      channel: "#myAppChannel"
+    )
+  end
+
+  error do |lane, exception|
+    # slack(
+    #   message: exception.message,
+    #   success: false
+    # )
+  end
+end
 
 # More information about multiple platforms in fastlane: https://github.com/fastlane/fastlane/blob/master/docs/Platforms.md
 # All available actions: https://github.com/fastlane/fastlane/blob/master/fastlane/docs/Actions.md

--- a/ignite-base/package.json
+++ b/ignite-base/package.json
@@ -9,8 +9,6 @@
     "newclear": "rm -rf $TMPDIR/react-* && watchman watch-del-all && rm -rf ios/build/ModuleCache/* && rm -rf node_modules/ && npm cache clean && npm i",
     "test": "mocha --opts Tests/mocha.opts Tests/ --recursive",
     "tron": "node_modules/.bin/reactotron",
-    "deploy-android": "fastlane android alpha", 
-    "deploy-ios": "node node_modules/react-native/local-cli/cli.js bundle --entry-file ./index.ios.js --platform ios --bundle-output ios/main.jsbundle bundle && fastlane ios beta", 
     "android:build": "cd android && ./gradlew assembleRelease",
     "android:install": "cd android && ./gradlew assembleRelease && ./gradlew installRelease",
     "android:hockeyapp": "cd android && ./gradlew assembleRelease && puck -submit=auto app/build/outputs/apk/app-release.apk",

--- a/ignite-base/package.json
+++ b/ignite-base/package.json
@@ -9,6 +9,8 @@
     "newclear": "rm -rf $TMPDIR/react-* && watchman watch-del-all && rm -rf ios/build/ModuleCache/* && rm -rf node_modules/ && npm cache clean && npm i",
     "test": "mocha --opts Tests/mocha.opts Tests/ --recursive",
     "tron": "node_modules/.bin/reactotron",
+    "deploy-android": "fastlane android alpha", 
+    "deploy-ios": "node node_modules/react-native/local-cli/cli.js bundle --entry-file ./index.ios.js --platform ios --bundle-output ios/main.jsbundle bundle && fastlane ios beta", 
     "android:build": "cd android && ./gradlew assembleRelease",
     "android:install": "cd android && ./gradlew assembleRelease && ./gradlew installRelease",
     "android:hockeyapp": "cd android && ./gradlew assembleRelease && puck -submit=auto app/build/outputs/apk/app-release.apk",


### PR DESCRIPTION
#### Ignite Base Change
- [x] Works on iOS/Android/XDE
- [x] Tests Pass (run: `npm run test`)
- [x] Code is StandardJS compliant (run: `npm run lint`)

--

Don't know if you're interested, let me know.  
P.S.:  Interesting threads to keep an eye on:  
[Increment build and version numbers for Android apps using Gradle](https://github.com/fastlane/fastlane/issues/878)    
[Gradle upgrades](https://github.com/fastlane/fastlane/pull/1082)