### PR TITLE
[Generator] - properly import proptypes - closes #113

### DIFF
--- a/ignite-generator/container/templates/container.js.template
+++ b/ignite-generator/container/templates/container.js.template
@@ -1,12 +1,11 @@
-import React from 'react'
-import { ScrollView, Text, PropTypes } from 'react-native'
+import React, { PropTypes } from 'react'
+import { ScrollView, Text } from 'react-native'
 import { connect } from 'react-redux'
 import Actions from '../Actions/Creators'
 import Routes from '../Navigation/Routes'
 
 // Styles
 import styles from './Styles/<%= name %>Style'
-
 
 export default class <%= name %> extends React.Component {
 

--- a/ignite-generator/screen/templates/screen.js.template
+++ b/ignite-generator/screen/templates/screen.js.template
@@ -1,6 +1,6 @@
 // An All Components Screen is a great way to dev and quick-test components
-import React from 'react'
-import { View, ScrollView, Text, PropTypes, LayoutAnimation, DeviceEventEmitter } from 'react-native'
+import React, { PropTypes } from 'react'
+import { View, ScrollView, Text, LayoutAnimation, DeviceEventEmitter } from 'react-native'
 import { connect } from 'react-redux'
 import Actions from '../Actions/Creators'
 import Routes from '../Navigation/Routes'


### PR DESCRIPTION
#### Generator Change
- [x] package.json lists all generators under "files"
- [x] I have run and tested `npm compile` with latest src

Fixes proptypes issue.
