### PR TITLE
[Generator] - Fixes the generators by removing the verify check

### DIFF
--- a/ignite-generator/component/index.js
+++ b/ignite-generator/component/index.js
@@ -6,8 +6,6 @@ var _createClass = function () { function defineProperties(target, props) { for 
 
 var _yeomanGenerator = require('yeoman-generator');
 
-var _validation = require('../validation');
-
 function _classCallCheck(instance, Constructor) { if (!(instance instanceof Constructor)) { throw new TypeError("Cannot call a class as a function"); } }
 
 function _possibleConstructorReturn(self, call) { if (!self) { throw new ReferenceError("this hasn't been initialised - super() hasn't been called"); } return call && (typeof call === "object" || typeof call === "function") ? call : self; }
@@ -32,12 +30,6 @@ var ComponentGenerator = function (_NamedBase) {
   }
 
   _createClass(ComponentGenerator, [{
-    key: 'initializing',
-    value: function initializing() {
-      // Fail if tools are missing
-      (0, _validation.verifyTools)();
-    }
-  }, {
     key: 'generateApp',
     value: function generateApp() {
       // Copy over component files.

--- a/ignite-generator/container/index.js
+++ b/ignite-generator/container/index.js
@@ -6,8 +6,6 @@ var _createClass = function () { function defineProperties(target, props) { for 
 
 var _yeomanGenerator = require('yeoman-generator');
 
-var _validation = require('../validation');
-
 function _classCallCheck(instance, Constructor) { if (!(instance instanceof Constructor)) { throw new TypeError("Cannot call a class as a function"); } }
 
 function _possibleConstructorReturn(self, call) { if (!self) { throw new ReferenceError("this hasn't been initialised - super() hasn't been called"); } return call && (typeof call === "object" || typeof call === "function") ? call : self; }
@@ -32,12 +30,6 @@ var ContainerGenerator = function (_NamedBase) {
   }
 
   _createClass(ContainerGenerator, [{
-    key: 'initializing',
-    value: function initializing() {
-      // Fail if tools are missing
-      (0, _validation.verifyTools)();
-    }
-  }, {
     key: 'generateApp',
     value: function generateApp() {
       // Copy over component files.

--- a/ignite-generator/screen/index.js
+++ b/ignite-generator/screen/index.js
@@ -6,8 +6,6 @@ var _createClass = function () { function defineProperties(target, props) { for 
 
 var _yeomanGenerator = require('yeoman-generator');
 
-var _validation = require('../validation');
-
 var _utilities = require('../utilities');
 
 var Utilities = _interopRequireWildcard(_utilities);
@@ -43,12 +41,6 @@ var ScreenGenerator = function (_NamedBase) {
   }
 
   _createClass(ScreenGenerator, [{
-    key: 'initializing',
-    value: function initializing() {
-      // Fail if tools are missing
-      (0, _validation.verifyTools)();
-    }
-  }, {
     key: 'generateApp',
     value: function generateApp() {
       // Copy over component files.

--- a/ignite-generator/src/component/index.es
+++ b/ignite-generator/src/component/index.es
@@ -2,7 +2,6 @@
 'use strict'
 
 import { NamedBase } from 'yeoman-generator'
-import { verifyTools } from '../validation'
 
 const copyOverCompoment = (context) => {
   // copy component template
@@ -21,10 +20,6 @@ const copyOverCompoment = (context) => {
 }
 
 class ComponentGenerator extends NamedBase {
-  initializing () {
-    // Fail if tools are missing
-    verifyTools()
-  }
 
   generateApp () {
     // Copy over component files.

--- a/ignite-generator/src/container/index.es
+++ b/ignite-generator/src/container/index.es
@@ -2,7 +2,6 @@
 'use strict'
 
 import { NamedBase } from 'yeoman-generator'
-import { verifyTools } from '../validation'
 
 const copyOverContainer = (context) => {
   // copy container template
@@ -21,11 +20,6 @@ const copyOverContainer = (context) => {
 }
 
 class ContainerGenerator extends NamedBase {
-  initializing () {
-    // Fail if tools are missing
-    verifyTools()
-  }
-
   generateApp () {
     // Copy over component files.
     copyOverContainer(this)

--- a/ignite-generator/src/screen/index.es
+++ b/ignite-generator/src/screen/index.es
@@ -2,7 +2,6 @@
 'use strict'
 
 import { NamedBase } from 'yeoman-generator'
-import { verifyTools } from '../validation'
 import * as Utilities from '../utilities'
 
 const copyOverScreenContainer = (context) => {
@@ -34,11 +33,7 @@ const addToRoutes = (context) => {
 }
 
 class ScreenGenerator extends NamedBase {
-  initializing () {
-    // Fail if tools are missing
-    verifyTools()
-  }
-
+  
   generateApp () {
     // Copy over component files.
     copyOverScreenContainer(this)


### PR DESCRIPTION
Wouldn't mind your opinion on this @GantMan .

My vote is to remove the verification check for the generators that aren't 'app'.

Once your project has gotten started, I think it's safe to assume that `react-native` is installed.

There are other checks I'd like to perform though.  (like verifying the proper directory)