### PR TITLE
[CLI] Keeps the colours when running through the CLI.

### DIFF
--- a/ignite-cli/package.json
+++ b/ignite-cli/package.json
@@ -30,6 +30,7 @@
   "dependencies": {
     "colors": "^1.1.2",
     "commander": "^2.9.0",
+    "cross-spawn": "^4.0.0",
     "generator-react-native-ignite": "^0.3.1",
     "ramda": "^0.20.0",
     "shelljs": "^0.6.0",

--- a/ignite-cli/src/index.es
+++ b/ignite-cli/src/index.es
@@ -4,6 +4,7 @@ import Program from 'commander'
 import colors from 'colors/safe'
 import pjson from './package.json'
 import Shell from 'shelljs'
+import spawn from 'cross-spawn'
 
 const FIRE = colors.red('FIRE!')
 
@@ -27,7 +28,7 @@ Program
   .action((project) => {
     checkYo()
     console.log(`🔥 Setting ${project} on ${FIRE} 🔥`)
-    Shell.exec(`yo react-native-ignite ${project}`)
+    spawn('yo', ['react-native-ignite', project], { shell: true, stdio: 'inherit' })
   })
 
 // generate
@@ -38,7 +39,7 @@ Program
   .action((type, name) => {
     checkYo()
     console.log(`Generate a new ${type} named ${name}`)
-    Shell.exec(`yo react-native-ignite:${type} ${name}`)
+    spawn('yo', [`react-native-ignite:${type}`, name], { shell: true, stdio: 'inherit' })
   })
 
 // parse params


### PR DESCRIPTION
![image](https://cloud.githubusercontent.com/assets/68273/15630110/6673c742-24fb-11e6-9d86-75b63abcf518.png)

Apparently we want to spawn instead of exec.  Something about keeping the TTY and environment variables?  Oh Unix.  You so crazy.

