### PR TITLE
Updated react-native-drawer styles property

### DIFF
--- a/ignite-base/App/Root.js
+++ b/ignite-base/App/Root.js
@@ -46,7 +46,7 @@ export default class RNBase extends React.Component {
           <Drawer
             ref={(ref) => { this.drawer = ref }}
             content={this.renderDrawerContent()}
-            style={styles.drawer}
+            styles={styles.drawer}
             openDrawerOffset={100}
             type='static'
             tapToClose


### PR DESCRIPTION
- [Base] - Fixed bug in Drawer Styles

#### Ignite Base Change
- [x ] Works on iOS/Android/XDE
- [ x] Tests Pass (run: `npm run test`)
- [ x] Code is StandardJS compliant (run: `npm run lint`)

'react-native-drawer' calls it style property style**s**.
(see: https://github.com/root-two/react-native-drawer)