### PR TITLE
- [Base] - Adding Rehydration guard

### DIFF
--- a/ignite-base/App/Config/DebugSettings.js
+++ b/ignite-base/App/Config/DebugSettings.js
@@ -3,7 +3,6 @@ const SETTINGS = {
   ezLogin: false,
   yellowBox: __DEV__,
   reduxLogging: true,
-  reduxPersist: true,
   includeExamples: __DEV__
 }
 

--- a/ignite-base/App/Config/ReduxPersist.js
+++ b/ignite-base/App/Config/ReduxPersist.js
@@ -1,0 +1,15 @@
+import immutablePersistenceTransform from '../Store/ImmutablePersistenceTransform'
+import { persistentStoreBlacklist } from '../Reducers/'
+import { AsyncStorage } from 'react-native'
+
+const REDUX_PERSIST = {
+  active: true,
+  reducerVersion: '1',
+  storeConfig: {
+    storage: AsyncStorage,
+    blacklist: persistentStoreBlacklist,
+    transforms: [immutablePersistenceTransform]
+  }
+}
+
+export default REDUX_PERSIST

--- a/ignite-base/App/Services/RehydrationServices.js
+++ b/ignite-base/App/Services/RehydrationServices.js
@@ -1,0 +1,27 @@
+import ReduxPersist from '../Config/ReduxPersist'
+import { AsyncStorage } from 'react-native'
+import { persistStore } from 'redux-persist'
+
+const updateReducers = (store) => {
+  const reducerVersion = ReduxPersist.reducerVersion
+  const config = ReduxPersist.storeConfig
+
+  // Begin a fresh store
+  persistStore(store, config)
+
+  // Check to ensure latest reducer version
+  AsyncStorage.getItem('reducerVersion').then((localVersion) => {
+    if (localVersion !== reducerVersion) {
+      console.log('PURGING STORE', localVersion, 'vs.', reducerVersion)
+      // Purge store and refresh
+      persistStore(store, config, () => {
+        // Start a fresh store
+        persistStore(store, config)
+      }).purgeAll()
+      // Update reducer to current version number
+      AsyncStorage.setItem('reducerVersion', reducerVersion)
+    }
+  }).catch(() => AsyncStorage.setItem('reducerVersion', reducerVersion))
+}
+
+export default {updateReducers}

--- a/ignite-base/App/Store/Store.js
+++ b/ignite-base/App/Store/Store.js
@@ -1,14 +1,14 @@
 import { createStore, applyMiddleware, compose } from 'redux'
-import { persistStore, autoRehydrate } from 'redux-persist'
-import { AsyncStorage } from 'react-native'
+import { autoRehydrate } from 'redux-persist'
 import createLogger from 'redux-logger'
-import rootReducer, { persistentStoreBlacklist } from '../Reducers/'
+import rootReducer from '../Reducers/'
 import Config from '../Config/DebugSettings'
 import createSagaMiddleware from 'redux-saga'
 import sagas from '../Sagas/'
 import R from 'ramda'
-import immutablePersistenceTransform from './ImmutablePersistenceTransform'
 import Reactotron from 'reactotron'
+import RehydrationServices from '../Services/RehydrationServices'
+import ReduxPersist from '../Config/ReduxPersist'
 
 // the logger master switch
 const USE_LOGGING = Config.reduxLogging
@@ -32,8 +32,8 @@ if (__DEV__) {
 export default () => {
   let store = {}
 
-  // Add rehydrate enhancer if reduxPersist
-  if (Config.reduxPersist) {
+  // Add rehydrate enhancer if ReduxPersist is active
+  if (ReduxPersist.active) {
     const enhancers = compose(
       applyMiddleware(...middleware),
       Reactotron.storeEnhancer(),
@@ -45,12 +45,8 @@ export default () => {
       enhancers
     )
 
-    // configure persistStore
-    persistStore(store, {
-      storage: AsyncStorage,
-      blacklist: persistentStoreBlacklist,
-      transforms: [immutablePersistenceTransform]
-    })
+    // configure persistStore and check reducer version number
+    RehydrationServices.updateReducers(store)
   } else {
     const enhancers = compose(
       applyMiddleware(...middleware),


### PR DESCRIPTION
## Checklist
#### Ignite Base Change
- [x] Works on iOS/Android/XDE
- [x] Tests Pass (run: `npm run test`)
- [x] Code is StandardJS compliant (run: `npm run lint`)

Crashes and bugs can be caused when the app rehydrates the store after a reducer shape has changed.
The app has no way to know that the reducer shape has changed since the rehydrate feature will  resurrect the outdated reducers...until now...

* Here we move `reduxPersist` from `DebugSettings.js` to its own file (`ReduxPersist.js`) with its own set of properties.
* Additionally we will configure the store in `ReduxPersist.js` as well and make it a part of ReduxPersist since this store is what we are creating/persisting and it can be accessed by `RehydrationServices.js`
* Finally we will add a `reducerVersion` in `ReduxPersist.js` to track changes in reducer shape and notify `RehydrationServices` that a change has occurred. 

##### How it works
* When the app is loaded, it will check for an update with `RehydrationServices`
* If the version number in persisted storage is different that the one in `ReduxPersist`, then the app will purge the current store and rebuild a new one with the updated reducer(s) shape

#### Why do we need this?

Let's say you remove an element(s) from the reducer shape (we're going to remove `city` and `state` since we can get both from just the zip code)
```
export const INITIAL_STATE = Immutable({
  city: null,
  state: null,
  zipCode: null
})
```
goes to:
```
export const INITIAL_STATE = Immutable({
  zipCode: null
})
```
##### COOL 👍 

But now our app will rehydrate with the old reducer shape and expect `city` and `state` to exist!!!

### OH NOES!!!
### ...
#### RehydrationServices to the rescue!
Because we bumped our `reducerVersion`, RehydrationServices will know that we would rehydrate with an outdated reducer shape, so...


![alt tag](http://i.giphy.com/byrjZgFhTYQHm.gif)

#### FRESH START - FRESH STORE
##### RehydrationServices will purge the store and re-persist a fresh store with the updated reducer shape!! 
### YAY!!!

@GantMan This is a preventative feature that could be more fully explained and elaborated upon in a blog post 😉 

