### PR TITLE
- [Base] - Add ScrollView as parent to LoginScreen

### DIFF
--- a/ignite-base/App/Containers/LoginScreen.js
+++ b/ignite-base/App/Containers/LoginScreen.js
@@ -1,6 +1,7 @@
 import React, {PropTypes} from 'react'
 import {
   View,
+  ScrollView,
   Text,
   TextInput,
   TouchableOpacity,
@@ -109,7 +110,7 @@ class LoginScreen extends React.Component {
     const editable = !attempting
     const textInputStyle = editable ? Styles.textInput : Styles.textInputReadonly
     return (
-      <View style={[Styles.container, {height: this.state.visibleHeight}]}>
+      <ScrollView contentContainerStyle={{justifyContent: 'center'}} style={[Styles.container, {height: this.state.visibleHeight}]}>
         <Image source={Images.logo} style={[Styles.topLogo, this.state.topLogo]} />
         <View style={Styles.form}>
           <View style={Styles.row}>
@@ -155,7 +156,7 @@ class LoginScreen extends React.Component {
           </View>
         </View>
 
-      </View>
+      </ScrollView>
     )
   }
 

--- a/ignite-base/App/Containers/Styles/LoginScreenStyle.js
+++ b/ignite-base/App/Containers/Styles/LoginScreenStyle.js
@@ -3,7 +3,6 @@ import Colors from '../../Themes/Colors'
 
 export default StyleSheet.create({
   container: {
-    justifyContent: 'center',
     paddingTop: 70,
     backgroundColor: Colors.ember
   },


### PR DESCRIPTION
#### Ignite Base Change
- [x] Works on iOS/Android/XDE
- [x] Tests Pass (run: `npm run test`)
- [x] Code is StandardJS compliant (run: `npm run lint`)

I used the built-in LoginScreen for my project but my logo was a bit larger that the default logo. This pushed the buttons further down the screen so that they were unreachable without scroll.