### PR TITLE
- [Base] - Upgrade Left drawer

### DIFF
--- a/ignite-base/App/Components/DrawerButton.js
+++ b/ignite-base/App/Components/DrawerButton.js
@@ -1,0 +1,20 @@
+import React, { Component, PropTypes } from 'react'
+import { Text, TouchableOpacity } from 'react-native'
+import styles from './Styles/DrawerButtonStyles'
+
+class DrawerButton extends Component {
+  render () {
+    return (
+      <TouchableOpacity onPress={this.props.onPress}>
+        <Text style={styles.text}>{this.props.text}</Text>
+      </TouchableOpacity>
+    )
+  }
+}
+
+DrawerButton.propTypes = {
+  text: PropTypes.string.isRequired,
+  onPress: PropTypes.func.isRequired
+}
+
+export default DrawerButton

--- a/ignite-base/App/Components/DrawerContent.js
+++ b/ignite-base/App/Components/DrawerContent.js
@@ -10,7 +10,7 @@ class DrawerContent extends React.Component {
     super(props)
     this.handlePressComponent = props.onPushRoute.bind(this, Routes.AllComponentsScreen)
     this.handlePressUsage = props.onPushRoute.bind(this, Routes.UsageExamplesScreen)
-    this.handlePressApi = props.onPushRoute.bind(this, Routes.ApiTestingScreen)
+    this.handlePressApi = props.onPushRoute.bind(this, Routes.APITestingScreen)
     this.handlePressTheme = props.onPushRoute.bind(this, Routes.ThemeScreen)
     this.handlePressDeviceInfo = props.onPushRoute.bind(this, Routes.DeviceInfoScreen)
   }

--- a/ignite-base/App/Components/DrawerContent.js
+++ b/ignite-base/App/Components/DrawerContent.js
@@ -1,0 +1,36 @@
+import React, { PropTypes } from 'react'
+import { ScrollView, Image } from 'react-native'
+import { Images } from '../Themes'
+import DrawerButton from '../Components/DrawerButton'
+import styles from './Styles/DrawerContentStyle'
+import Routes from '../Navigation/Routes'
+
+class DrawerContent extends React.Component {
+  constructor (props) {
+    super(props)
+    this.handlePressComponent = props.onPushRoute.bind(this, Routes.AllComponentsScreen)
+    this.handlePressUsage = props.onPushRoute.bind(this, Routes.UsageExamplesScreen)
+    this.handlePressApi = props.onPushRoute.bind(this, Routes.ApiTestingScreen)
+    this.handlePressTheme = props.onPushRoute.bind(this, Routes.ThemeScreen)
+    this.handlePressDeviceInfo = props.onPushRoute.bind(this, Routes.DeviceInfoScreen)
+  }
+
+  render () {
+    return (
+      <ScrollView style={styles.container}>
+        <Image source={Images.logo} style={styles.logo} />
+        <DrawerButton text='Component Examples' onPress={this.handlePressComponent} />
+        <DrawerButton text='Usage Examples' onPress={this.handlePressUsage} />
+        <DrawerButton text='API Testing' onPress={this.handlePressApi} />
+        <DrawerButton text='Themes' onPress={this.handlePressTheme} />
+        <DrawerButton text='Device Info' onPress={this.handlePressDeviceInfo} />
+      </ScrollView>
+    )
+  }
+}
+
+DrawerContent.propTypes = {
+  onPushRoute: PropTypes.func.isRequired
+}
+
+export default DrawerContent

--- a/ignite-base/App/Components/Styles/DrawerButtonStyles.js
+++ b/ignite-base/App/Components/Styles/DrawerButtonStyles.js
@@ -1,0 +1,9 @@
+import { Metrics, Colors, Fonts } from '../../Themes'
+
+export default {
+  text: {
+    ...Fonts.style.h5,
+    color: Colors.snow,
+    marginVertical: Metrics.baseMargin
+  }
+}

--- a/ignite-base/App/Components/Styles/DrawerContentStyle.js
+++ b/ignite-base/App/Components/Styles/DrawerContentStyle.js
@@ -1,0 +1,9 @@
+export default {
+  container: {
+    flex: 1,
+    padding: 20
+  },
+  logo: {
+    alignSelf: 'center'
+  }
+}

--- a/ignite-base/App/Containers/Styles/DeviceInfoScreenStyle.js
+++ b/ignite-base/App/Containers/Styles/DeviceInfoScreenStyle.js
@@ -20,7 +20,6 @@ export default StyleSheet.create({
       height: 7,
       width: 7
     },
-    shadowOpacity: 0.25,
     shadowRadius: 2,
     paddingBottom: Metrics.baseMargin,
     margin: Metrics.baseMargin

--- a/ignite-base/App/Containers/Styles/RootStyle.js
+++ b/ignite-base/App/Containers/Styles/RootStyle.js
@@ -3,7 +3,9 @@ import {Fonts, Metrics, Colors} from '../../Themes/'
 
 // For some reason this doesn't want to be a stylesheet
 export const drawerStyles = {
-  drawer: {shadowColor: '#000000', shadowOpacity: 0.8, shadowRadius: 3, backgroundColor: Colors.background}
+  drawer: {
+    backgroundColor: Colors.drawer
+  }
 }
 
 const RootStyle = StyleSheet.create({
@@ -14,11 +16,6 @@ const RootStyle = StyleSheet.create({
     flex: 1,
     justifyContent: 'center',
     backgroundColor: Colors.background
-  },
-  drawer: {
-    shadowColor: '#000000',
-    shadowOpacity: 0.8,
-    shadowRadius: 3
   },
   welcome: {
     fontSize: 20,

--- a/ignite-base/App/Root.js
+++ b/ignite-base/App/Root.js
@@ -1,11 +1,12 @@
 import React from 'react'
-import { View, Text, Navigator, StatusBar } from 'react-native'
+import { View, Navigator, StatusBar } from 'react-native'
 import {Router, Routes, NavigationBar} from './Navigation/'
 import configureStore from './Store/Store'
 import { Provider } from 'react-redux'
 import Actions from './Actions/Creators'
 import Drawer from 'react-native-drawer'
 import DebugSettings from './Config/DebugSettings'
+import DrawerContent from './Components/DrawerContent'
 import './Config/PushConfig'
 
 // Styles
@@ -14,6 +15,11 @@ import styles, {drawerStyles} from './Containers/Styles/RootStyle'
 const store = configureStore()
 
 export default class RNBase extends React.Component {
+  constructor (props) {
+    super(props)
+    this.handlePushRoute = this.handlePushRoute.bind(this)
+    this.closeDrawer = this.closeDrawer.bind(this)
+  }
 
   componentWillMount () {
     const { dispatch } = store
@@ -21,17 +27,23 @@ export default class RNBase extends React.Component {
   }
 
   componentDidMount () {
-    this.navigator.drawer = this.drawer
+    this.refs.drawerContent.navigator = this.navigator
+    this.navigator.drawer = this.refs.drawer
+  }
+
+  handlePushRoute (route) {
+    this.navigator.push(route)
+    this.closeDrawer()
   }
 
   renderDrawerContent () {
     return (
-      <View style={{marginTop: 30, padding: 10}}>
-        <Text style={{color: 'white'}}>
-          Drawer Content Goes Here!
-        </Text>
-      </View>
+      <DrawerContent ref='drawerContent' onPushRoute={this.handlePushRoute} onClose={this.closeDrawer} />
     )
+  }
+
+  closeDrawer () {
+    this.refs.drawer.close()
   }
 
   renderApp () {
@@ -44,12 +56,14 @@ export default class RNBase extends React.Component {
           />
 
           <Drawer
-            ref={(ref) => { this.drawer = ref }}
+            ref='drawer'
             content={this.renderDrawerContent()}
             styles={drawerStyles}
             openDrawerOffset={100}
-            type='static'
+            type='overlay'
             tapToClose
+            panOpenMask={0.05}
+            panCloseMask={0.3}
           >
             <Navigator
               ref={(ref) => { this.navigator = ref }}

--- a/ignite-base/App/Themes/Colors.js
+++ b/ignite-base/App/Themes/Colors.js
@@ -17,7 +17,7 @@ const colors = {
   snow: 'white',
   ember: 'rgba(164, 0, 48, 0.5)',
   fire: '#e73536',
-  drawer: 'rgba(30, 30, 29, 0.85)'
+  drawer: 'rgba(30, 30, 29, 0.95)'
 }
 
 export default colors

--- a/ignite-base/App/Themes/Colors.js
+++ b/ignite-base/App/Themes/Colors.js
@@ -16,7 +16,8 @@ const colors = {
   bloodOrange: '#fb5f26',
   snow: 'white',
   ember: 'rgba(164, 0, 48, 0.5)',
-  fire: '#e73536'
+  fire: '#e73536',
+  drawer: 'rgba(30, 30, 29, 0.85)'
 }
 
 export default colors

--- a/ignite-base/App/Themes/Metrics.js
+++ b/ignite-base/App/Themes/Metrics.js
@@ -8,6 +8,7 @@ const metrics = {
   marginVertical: 10,
   section: 25,
   baseMargin: 10,
+  doubleBaseMargin: 20,
   smallMargin: 5,
   horizontalLineHeight: 1,
   screenWidth: width < height ? width : height,


### PR DESCRIPTION
#### Ignite Base Change
- [x] Works on iOS/Android/XDE
- [x] Tests Pass (run: `npm run test`)
- [x] Code is StandardJS compliant (run: `npm run lint`)

* First step in establishing a general best practice for a Menu Drawer that is responsible for ancillary navigation

Typically a Menu Drawer can be responsible for navigating to screens when deep into the navigation stack from the "Home Screen." Here we've set up a lean component that's business logic is handled at the highest level (`Root`) that is on par with the navigator - where it should be IMO. This allows the Drawer Content Component to be a "dumb" stand-alone component that functions without any knowledge of state, `navigator`, and `dispatch`. 

##### Since we wrap the `Navigator` with a `Drawer`

![screen shot 2016-06-23 at 11 37 22 am](https://cloud.githubusercontent.com/assets/10098988/16311614/dff8a584-3936-11e6-85be-0c487f5f7205.png)


**This upgrade method eliminates the pesky issue of passing around `navigator` and `dispatch` to the Menu Drawer, which are necessary when dealing with navigation, as well as consequential async problems that arise from `navigator` handling during the component and app lifecycle.**

![alt tag](http://i.giphy.com/PFoisOCLmGd0s.gif)
##### YAY!!


## How's it work?

#### DrawerContent

* Created a `DrawerContent` component that will live in the `Drawer` at `Root`
* `DrawerContent`'s parent is a `ScrollView` to allow for many items (buttons, etc.)
* Also created a default `DrawerButton` that has settable `text` and an `onPress` function
* Load up your `DrawerContent` `render` method with as many `DrawerButton`s as you like - even throw in your favorite logo 😉 

![screen shot 2016-06-23 at 11 11 31 am](https://cloud.githubusercontent.com/assets/10098988/16310716/4478cb6e-3933-11e6-85f5-794276c515ba.png)

* We're going to bind `onPress`s' called function inside a `constructor` method, because binding inside the `onPress` property creates a new function in the `render` method, which causes react to reset that property - performing “work” where none is needed. (Thanks @skellock !)

![screen shot 2016-06-23 at 11 23 34 am](https://cloud.githubusercontent.com/assets/10098988/16311134/f29401cc-3934-11e6-92f7-7a043b389750.png)

 * Our `DrawerComponent` is passed a required `onPushRoute` property from `Root`

![screen shot 2016-06-23 at 11 32 44 am](https://cloud.githubusercontent.com/assets/10098988/16311433/3cf5ebb2-3936-11e6-9438-0f6a30bbf121.png)

* By passing `DrawerContent` this function, we've allowed for `navigator` and `dispatch` to remain in `Root` and still be accessed by our `DrawerContent` component

#### Root

* Our `DrawerContent` component's `onPushRoute` property calls `handlePushRoute` (which is also bound in a `constructor` method in `Root`
* `handlePushRoute` pushes the route AND closes our Menu Drawer

![screen shot 2016-06-23 at 11 40 43 am](https://cloud.githubusercontent.com/assets/10098988/16311824/a6194b4c-3937-11e6-83e4-49db9ad11c3e.png)

# **Bing, Bang, ![alt tag](http://i.giphy.com/LrN9NbJNp9SWQ.gif)**





