### PR TITLE
Updates apisauce to use network error & timeout detection.

### DIFF
--- a/ignite-base/App/Services/Api.js
+++ b/ignite-base/App/Services/Api.js
@@ -18,9 +18,6 @@ const create = (baseURL = 'http://openweathermap.org/data/2.1') => {
       'Cache-Control': 'no-cache'
     },
     // 10 second timeout...
-    // ...however, it doesn't work on React Native because the `timeout`
-    // property of `XMLHttpRequest` hasn't been implemented.  It is
-    // arriving in RN 0.25 though!
     timeout: 10000
   })
 

--- a/ignite-base/package.json
+++ b/ignite-base/package.json
@@ -19,7 +19,7 @@
     "android:shake": "$ANDROID_HOME/platform-tools/adb devices | grep '\\t' | awk '{print $1}' | sed 's/\\s//g' | xargs -I {} $ANDROID_HOME/platform-tools/adb -s {} shell input keyevent 82"
   },
   "dependencies": {
-    "apisauce": "^0.1.5",
+    "apisauce": "^0.2.0",
     "format-json": "^1.0.3",
     "querystringify": "0.0.3",
     "ramda": "^0.21.0",

--- a/ignite-base/package.json.template
+++ b/ignite-base/package.json.template
@@ -19,7 +19,7 @@
     "android:shake": "$ANDROID_HOME/platform-tools/adb devices | grep '\\t' | awk '{print $1}' | sed 's/\\s//g' | xargs -I {} $ANDROID_HOME/platform-tools/adb -s {} shell input keyevent 82"
   },
   "dependencies": {
-    "apisauce": "^0.1.5",
+    "apisauce": "^0.2.0",
     "format-json": "^1.0.3",
     "querystringify": "0.0.3",
     "ramda": "^0.21.0",


### PR DESCRIPTION
Now with apisauce 0.2.0, axios 0.12 and react-native 0.25+, we have the ability to detect timeouts and network errors.  Hooray!