### PR TITLE
Quick fix for issue #233. Lock the current react-native version to 0.28

### DIFF
--- a/ignite-generator/src/app/index.es
+++ b/ignite-generator/src/app/index.es
@@ -202,7 +202,7 @@ export class AppGenerator extends Generators.Base {
     this.spinner.text = status
     const done = this.async()
     const command = 'react-native'
-    const commandOpts = ['init', this.name]
+    const commandOpts = ['init', this.name, '--version 0.28.0']
     this.spawnCommand(command, commandOpts, {stdio: 'ignore'})
       .on('close', () => {
         this.spinner.stop()

--- a/ignite-generator/src/app/index.es
+++ b/ignite-generator/src/app/index.es
@@ -9,6 +9,7 @@ import ora from 'ora'
 import semver from 'semver'
 
 const igniteBase = 'ignite-base'
+const lockedReactNativeVersion = '0.28.0'
 
 const emptyFolder = (folder) => {
   Shell.rm('-rf', folder)
@@ -202,7 +203,7 @@ export class AppGenerator extends Generators.Base {
     this.spinner.text = status
     const done = this.async()
     const command = 'react-native'
-    const commandOpts = ['init', this.name, '--version 0.28.0']
+    const commandOpts = ['init', this.name, '--version', lockedReactNativeVersion]
     this.spawnCommand(command, commandOpts, {stdio: 'ignore'})
       .on('close', () => {
         this.spinner.stop()


### PR DESCRIPTION
## Please verify the following:
- [X] Everything works on iOS/Android
- [X] `ignite-base` **ava** tests pass
- [X] `fireDrill.sh` passed

## Describe your PR

- Locks the react-native version used to init the base template to 0.28.0. Since the base directory assumes 0.28, I felt hard-coding the current version was appropriate.