### PR TITLE
Fix the react-native-cli version check

### DIFF
--- a/ignite-generator/src/app/index.es
+++ b/ignite-generator/src/app/index.es
@@ -133,14 +133,12 @@ export class AppGenerator extends Generators.Base {
     this.spinner.text = status
     this.spinner.start()
     if (!isCommandInstalled('react-native')) {
-      this.log(`${xmark} Missing react-native - 'npm install -g react-native-cli'`)
-      process.exit(1)
+      this._logAndExit(`${xmark} Missing react-native - 'npm install -g react-native-cli'`)
     }
 
     // verify 1.x or higher (we need react-native link)
     if (Shell.exec("react-native -v | grep 'react-native-cli: [1-9]\\d*\\.\\d\\.\\d'", {silent: true}).code > 0) {
-      this.log(`${xmark} Must have at least version 1.x - 'npm install -g react-native-cli'`)
-      process.exit(1)
+      this._logAndExit(`${xmark} Must have at least version 1.x - 'npm install -g react-native-cli'`)
     }
     this.spinner.stop()
     this.log(`${check} Found react-native`)
@@ -154,8 +152,7 @@ export class AppGenerator extends Generators.Base {
     this.spinner.text = status
     this.spinner.start()
     if (!isCommandInstalled('git')) {
-      this.log(`${xmark} Missing git`)
-      process.exit(1)
+      this._logAndExit(`${xmark} Missing git`)
     }
     this.spinner.stop()
     this.log(`${check} Found git`)
@@ -351,6 +348,15 @@ export class AppGenerator extends Generators.Base {
     emptyFolder(this.sourceRoot())
     this.spinner.stop()
     this.log(`${check} ${status}`)
+  }
+
+  /**
+   * Log an error and exit gracefully.
+   */
+  _logAndExit(finalMessage) {
+    this.spinner.stop()
+    this.log(finalMessage)
+    process.exit(1)
   }
 
   /**

--- a/ignite-generator/src/app/index.es
+++ b/ignite-generator/src/app/index.es
@@ -138,7 +138,7 @@ export class AppGenerator extends Generators.Base {
     }
 
     // verify 1.x or higher (we need react-native link)
-    if (!Shell.exec("react-native -v | grep 'react-native-cli: [1-9]\d*\.\d\.\d'")) {
+    if (Shell.exec("react-native -v | grep 'react-native-cli: [1-9]\\d*\\.\\d\\.\\d'", {silent: true}).code > 0) {
       this.log(`${xmark} Must have at least version 1.x - 'npm install -g react-native-cli'`)
       process.exit(1)
     }

--- a/ignite-generator/src/utilities.js
+++ b/ignite-generator/src/utilities.js
@@ -25,9 +25,9 @@ export const insertInFile = (theFile, theFind, theInsert, insertAfter = true) =>
   fs.writeFileSync(theFile, newContents, 'utf-8')
 }
 
-////////////////
+// --------------
 // UNTESTED
-////////////////
+// --------------
 export const replaceInFile = (theFile, theFind, theReplace) => {
   // read full file - Not a great idea if we ever touch large files
   let data = fs.readFileSync(theFile, 'utf-8')
@@ -48,7 +48,6 @@ export const replaceInFile = (theFile, theFind, theReplace) => {
 export const isInFile = (theFile, theFind) => {
   // read full file - Not a great idea if we ever touch large files
   let data = fs.readFileSync(theFile, 'utf-8')
-  let newContents = ''
   // get the full line of first occurance
   let finder = new RegExp(`.*${theFind}.*`, '')
   let matches = data.match(finder)


### PR DESCRIPTION
## Please verify the following:
- [x] Everything works on iOS/Android
- [x] `ignite-base` **ava** tests pass
- [x] `fireDrill.sh` passed

## Describe your PR
The react-native-cli version check would always fail for a few different reasons:
* `Shell.exec` returns the exit code in an object, not as the return value itself
* The grep regex needed to be escaped, otherwise javascript throws in control characters
* The silent option needed to be set so we don't get the version string dumped into the console

Also when some checks did fail, the error message would be displayed in a run-on line instead of its own.

This PR should resolve both these things and avoid more issues like #241