### PR TITLE
baked-in support for redux persist whitelist

### DIFF
--- a/ignite-base/App/Config/ReduxPersist.js
+++ b/ignite-base/App/Config/ReduxPersist.js
@@ -1,5 +1,5 @@
 import immutablePersistenceTransform from '../Store/ImmutablePersistenceTransform'
-import { persistentStoreBlacklist } from '../Reducers/'
+import { persistentStoreBlacklist, persistentStoreWhitelist } from '../Reducers/'
 import { AsyncStorage } from 'react-native'
 
 const REDUX_PERSIST = {
@@ -8,6 +8,7 @@ const REDUX_PERSIST = {
   storeConfig: {
     storage: AsyncStorage,
     blacklist: persistentStoreBlacklist,
+    whitelist: persistentStoreWhitelist,
     transforms: [immutablePersistenceTransform]
   }
 }

--- a/ignite-base/App/Reducers/index.js
+++ b/ignite-base/App/Reducers/index.js
@@ -10,3 +10,5 @@ export default combineReducers({
 
 // Put reducer keys that you do NOT want stored to persistence here
 export const persistentStoreBlacklist = ['login']
+// OR put reducer keys that you DO want stored to persistence here (overrides blacklist)
+// export const persistentStoreWhitelist = []


### PR DESCRIPTION
## Please verify the following:
- [x] Everything works on iOS/Android
- [x] `ignite-base` **ava** tests pass
- [x] `fireDrill.sh` passed

Redux-persist has built-in whitelist support, but we weren't exposing it.


