### PR TITLE
Change toggle drawer to open drawer.

### DIFF
--- a/ignite-base/App/Navigation/NavItems.js
+++ b/ignite-base/App/Navigation/NavItems.js
@@ -5,10 +5,10 @@ import { Actions as NavigationActions } from 'react-native-router-flux'
 import Icon from 'react-native-vector-icons/FontAwesome'
 import { Colors, Metrics } from '../Themes'
 
-const toggleDrawer = () => {
+const openDrawer = () => {
   NavigationActions.refresh({
     key: 'drawer',
-    open: value => !value
+    open: true
   })
 }
 
@@ -27,7 +27,7 @@ export default {
 
   hamburgerButton () {
     return (
-      <TouchableOpacity onPress={toggleDrawer}>
+      <TouchableOpacity onPress={openDrawer}>
         <Icon name='bars'
           size={Metrics.icons.medium}
           color={Colors.snow}


### PR DESCRIPTION
## Please verify the following:
- [x] Everything works on iOS/Android
- [x] `ignite-base` **ava** tests pass
- [x] `fireDrill.sh` passed

## Describe your PR

Make the hamburger just open the menu. Currently it's giving a function to `open` which it doesn't understand and just interpret as *truthy* anyway.

- Fixes propType validation error (`open` can't have value `function`)
- It is not possible to invoke the `onPress` of `hamburgerButton` while the menu is showing, so just having it open the menu seems sensible (in any case it's the same behaviour as currently)