### PR TITLE
standard --fix to fix code according to standardjs

### DIFF
--- a/ignite-base/App/Components/AlertMessageComponent.js
+++ b/ignite-base/App/Components/AlertMessageComponent.js
@@ -21,18 +21,6 @@ ExamplesRegistry.add('Alert Message', () =>
 )
 
 export default class AlertMessage extends React.Component {
-
-  static propTypes = {
-    style: React.PropTypes.object,
-    title: React.PropTypes.string.isRequired,
-    icon: React.PropTypes.string,
-    show: React.PropTypes.bool
-  }
-
-  static defaultProps = {
-    show: true
-  }
-
   render () {
     let messageComponent = null
     if (this.props.show) {
@@ -57,4 +45,15 @@ export default class AlertMessage extends React.Component {
 
     return messageComponent
   }
+}
+
+AlertMessage.propTypes = {
+  style: React.PropTypes.object,
+  title: React.PropTypes.string.isRequired,
+  icon: React.PropTypes.string,
+  show: React.PropTypes.bool
+}
+
+AlertMessage.defaultProps = {
+  show: true
 }

--- a/ignite-base/App/Components/FullButton.js
+++ b/ignite-base/App/Components/FullButton.js
@@ -12,13 +12,6 @@ ExamplesRegistry.add('Full Button', () =>
 )
 
 export default class FullButton extends React.Component {
-
-  static propTypes = {
-    text: React.PropTypes.string.isRequired,
-    onPress: React.PropTypes.func.isRequired,
-    styles: React.PropTypes.object
-  }
-
   render () {
     return (
       <TouchableOpacity style={[styles.button, this.props.styles]} onPress={this.props.onPress}>
@@ -26,4 +19,10 @@ export default class FullButton extends React.Component {
       </TouchableOpacity>
     )
   }
+}
+
+FullButton.propTypes = {
+  text: React.PropTypes.string.isRequired,
+  onPress: React.PropTypes.func.isRequired,
+  styles: React.PropTypes.object
 }

--- a/ignite-base/App/Components/MapCallout.js
+++ b/ignite-base/App/Components/MapCallout.js
@@ -4,11 +4,6 @@ import MapView from 'react-native-maps'
 import Styles from './Styles/MapCalloutStyle'
 
 export default class MapCallout extends React.Component {
-  static propTypes = {
-    location: PropTypes.object.isRequired,
-    onPress: PropTypes.func
-  }
-
   constructor (props) {
     super(props)
     this.onPress = this.props.onPress.bind(this, this.props.location)
@@ -28,4 +23,9 @@ export default class MapCallout extends React.Component {
       </MapView.Callout>
     )
   }
+}
+
+MapCallout.propTypes = {
+  location: PropTypes.object.isRequired,
+  onPress: PropTypes.func
 }

--- a/ignite-base/App/Components/ProgressiveImage.js
+++ b/ignite-base/App/Components/ProgressiveImage.js
@@ -22,12 +22,6 @@ export default class ProgressiveImage extends Component {
     }
   }
 
-  static propTypes = {
-    thumbnail: PropTypes.string,
-    source: PropTypes.string,
-    style: PropTypes.number
-  }
-
   mainImageLoad = () => {
     window.requestAnimationFrame((time) => {
       Animated.timing(this.state.thumbnailOpacity, {
@@ -78,4 +72,10 @@ export default class ProgressiveImage extends Component {
       </View>
     )
   }
+}
+
+ProgressiveImage.propTypes = {
+  thumbnail: PropTypes.string,
+  source: PropTypes.string,
+  style: PropTypes.number
 }

--- a/ignite-base/App/Components/RoundedButton.js
+++ b/ignite-base/App/Components/RoundedButton.js
@@ -13,13 +13,6 @@ ExamplesRegistry.add('Rounded Button', () =>
 
 export default class RoundedButton extends React.Component {
 
-  static propTypes = {
-    navigator: React.PropTypes.object,
-    text: React.PropTypes.string,
-    onPress: React.PropTypes.func.isRequired,
-    children: React.PropTypes.string
-  }
-
   getText () {
     const buttonText = this.props.text || this.props.children.toString()
     return buttonText.toUpperCase()
@@ -32,4 +25,11 @@ export default class RoundedButton extends React.Component {
       </TouchableOpacity>
     )
   }
+}
+
+RoundedButton.propTypes = {
+  navigator: React.PropTypes.object,
+  text: React.PropTypes.string,
+  onPress: React.PropTypes.func.isRequired,
+  children: React.PropTypes.string
 }

--- a/ignite-base/App/Containers/AllComponentsScreen.js
+++ b/ignite-base/App/Containers/AllComponentsScreen.js
@@ -15,10 +15,6 @@ import ExamplesRegistry from '../Services/ExamplesRegistry'
 
 class AllComponentsScreen extends React.Component {
 
-  static propTypes = {
-    dispatch: PropTypes.func
-  }
-
   render () {
     return (
       <View style={styles.mainContainer}>
@@ -41,6 +37,10 @@ class AllComponentsScreen extends React.Component {
       </View>
     )
   }
+}
+
+AllComponentsScreen.propTypes = {
+  dispatch: PropTypes.func
 }
 
 export default connect()(AllComponentsScreen)

--- a/ignite-base/App/Containers/DeviceInfoScreen.js
+++ b/ignite-base/App/Containers/DeviceInfoScreen.js
@@ -32,9 +32,6 @@ const APP_DATA = [
 ]
 
 export default class DeviceInfoScreen extends React.Component {
-  static propTypes = {
-  }
-
   constructor (props) {
     super(props)
 

--- a/ignite-base/App/Containers/PresentationScreen.js
+++ b/ignite-base/App/Containers/PresentationScreen.js
@@ -9,15 +9,6 @@ import { Actions as NavigationActions } from 'react-native-router-flux'
 import styles from './Styles/PresentationScreenStyle'
 
 class PresentationScreen extends React.Component {
-
-  static propTypes = {
-    componentExamples: PropTypes.func,
-    usageExamples: PropTypes.func,
-    apiTesting: PropTypes.func,
-    theme: PropTypes.func,
-    deviceInfo: PropTypes.func
-  }
-
   render () {
     return (
       <View style={styles.mainContainer}>
@@ -62,6 +53,14 @@ class PresentationScreen extends React.Component {
       </View>
     )
   }
+}
+
+PresentationScreen.propTypes = {
+  componentExamples: PropTypes.func,
+  usageExamples: PropTypes.func,
+  apiTesting: PropTypes.func,
+  theme: PropTypes.func,
+  deviceInfo: PropTypes.func
 }
 
 const mapStateToProps = (state) => {

--- a/ignite-base/App/Containers/ThemeScreen.js
+++ b/ignite-base/App/Containers/ThemeScreen.js
@@ -20,9 +20,6 @@ export default class UsageExamplesScreen extends React.Component {
     this.state = {}
   }
 
-  static propTypes = {
-  }
-
   renderColor (color) {
     return (
       <View style={styles.colorContainer} key={`${color}Container`}>

--- a/ignite-base/App/Containers/UsageExamplesScreen.js
+++ b/ignite-base/App/Containers/UsageExamplesScreen.js
@@ -22,19 +22,6 @@ class UsageExamplesScreen extends React.Component {
     this.state = {}
   }
 
-  static propTypes = {
-    loggedIn: PropTypes.bool,
-    dispatch: PropTypes.func,
-    temperature: PropTypes.number,
-    city: PropTypes.string,
-    login: PropTypes.func,
-    logout: PropTypes.func,
-    requestTemperature: PropTypes.func,
-    listviewExample: PropTypes.func,
-    listviewGridExample: PropTypes.func,
-    mapviewExample: PropTypes.func
-  }
-
   componentWillReceiveProps (nextProps) {
     // Request push premissions only if the user has logged in.
     const { loggedIn } = nextProps
@@ -155,6 +142,19 @@ class UsageExamplesScreen extends React.Component {
       </View>
     )
   }
+}
+
+UsageExamplesScreen.propTypes = {
+  loggedIn: PropTypes.bool,
+  dispatch: PropTypes.func,
+  temperature: PropTypes.number,
+  city: PropTypes.string,
+  login: PropTypes.func,
+  logout: PropTypes.func,
+  requestTemperature: PropTypes.func,
+  listviewExample: PropTypes.func,
+  listviewGridExample: PropTypes.func,
+  mapviewExample: PropTypes.func
 }
 
 const mapStateToProps = (state) => {

--- a/ignite-base/App/Navigation/NavigationDrawer.js
+++ b/ignite-base/App/Navigation/NavigationDrawer.js
@@ -15,10 +15,6 @@ class NavigationDrawer extends Component {
     this.props.navigationState.open = false
   }
 
-  static propTypes = {
-    navigationState: PropTypes.object
-  }
-
   render () {
     const state = this.props.navigationState
     const children = state.children
@@ -43,6 +39,10 @@ class NavigationDrawer extends Component {
       </Drawer>
     )
   }
+}
+
+NavigationDrawer.propTypes = {
+  navigationState: PropTypes.object
 }
 
 const mapStateToProps = (state) => {

--- a/ignite-base/App/Root.js
+++ b/ignite-base/App/Root.js
@@ -10,10 +10,6 @@ import NavigationRouter from './Navigation/NavigationRouter'
 import styles from './Containers/Styles/RootStyle'
 
 export default class Root extends React.Component {
-  static propTypes = {
-    store: PropTypes.object.isRequired
-  }
-
   componentWillMount () {
     const { dispatch } = this.props.store
     dispatch(Actions.startup())
@@ -36,6 +32,10 @@ export default class Root extends React.Component {
   render () {
     return this.renderApp()
   }
+}
+
+Root.propTypes = {
+  store: PropTypes.object.isRequired
 }
 
 require('./I18n/I18n.js')

--- a/ignite-base/package.json
+++ b/ignite-base/package.json
@@ -5,6 +5,7 @@
   "scripts": {
     "start": "node node_modules/react-native/local-cli/cli.js start",
     "lint": "standard --verbose | snazzy",
+    "fixcode": "standard --fix",
     "lintdiff": "git diff --name-only --cached --relative | grep '\\.js$' | xargs standard | snazzy",
     "clean": "rm -rf $TMPDIR/react-* && watchman watch-del-all && npm cache clean",
     "newclear": "rm -rf $TMPDIR/react-* && watchman watch-del-all && rm -rf ios/build/ModuleCache/* && rm -rf node_modules/ && npm cache clean && npm i",

--- a/ignite-base/package.json
+++ b/ignite-base/package.json
@@ -5,8 +5,8 @@
   "scripts": {
     "start": "node node_modules/react-native/local-cli/cli.js start",
     "lint": "standard --verbose | snazzy",
-    "fixcode": "standard --fix",
     "lintdiff": "git diff --name-only --cached --relative | grep '\\.js$' | xargs standard | snazzy",
+    "fixcode": "standard --fix",
     "clean": "rm -rf $TMPDIR/react-* && watchman watch-del-all && npm cache clean",
     "newclear": "rm -rf $TMPDIR/react-* && watchman watch-del-all && rm -rf ios/build/ModuleCache/* && rm -rf node_modules/ && npm cache clean && npm i",
     "test": "ava",

--- a/ignite-base/package.json
+++ b/ignite-base/package.json
@@ -55,7 +55,7 @@
     "react-native-mock": "^0.2.3",
     "reactotron": "^0.8.0",
     "snazzy": "^4.0.0",
-    "standard": "^7.1.2"
+    "standard": "^8.0.0"
   },
   "ava": {
     "files": [

--- a/ignite-base/package.json.template
+++ b/ignite-base/package.json.template
@@ -6,6 +6,7 @@
     "start": "node node_modules/react-native/local-cli/cli.js start",
     "lint": "standard --verbose | snazzy",
     "lintdiff": "git diff --name-only --cached --relative | grep '\\.js$' | xargs standard | snazzy",
+    "fixcode": "standard --fix",
     "clean": "rm -rf $TMPDIR/react-* && watchman watch-del-all && npm cache clean",
     "newclear": "rm -rf $TMPDIR/react-* && watchman watch-del-all && rm -rf ios/build/ModuleCache/* && rm -rf node_modules/ && npm cache clean && npm i",
     "test": "ava",

--- a/ignite-base/package.json.template
+++ b/ignite-base/package.json.template
@@ -55,7 +55,7 @@
     "react-native-mock": "^0.2.3",
     "reactotron": "^0.8.0",
     "snazzy": "^4.0.0",
-    "standard": "^7.1.2"
+    "standard": "^8.0.0"
   },
   "ava": {
     "files": [

--- a/ignite-generator/Generator.js
+++ b/ignite-generator/Generator.js
@@ -1,75 +1,104 @@
-'use strict';
+'use strict'
 
-Object.defineProperty(exports, "__esModule", {
+Object.defineProperty(exports, '__esModule', {
   value: true
-});
-exports.hydrateComponent = exports.fileSign = undefined;
+})
+exports.hydrateComponent = exports.fileSign = undefined
 
-var _safe = require('colors/safe');
+var _safe = require('colors/safe')
 
-var _safe2 = _interopRequireDefault(_safe);
+var _safe2 = _interopRequireDefault(_safe)
 
-var _fs = require('fs');
+var _fs = require('fs')
 
-var _fs2 = _interopRequireDefault(_fs);
+var _fs2 = _interopRequireDefault(_fs)
 
-var _ramda = require('ramda');
+var _ramda = require('ramda')
 
-var _ramda2 = _interopRequireDefault(_ramda);
+var _ramda2 = _interopRequireDefault(_ramda)
 
-var _mkdirp = require('mkdirp');
+var _mkdirp = require('mkdirp')
 
-var _mkdirp2 = _interopRequireDefault(_mkdirp);
+var _mkdirp2 = _interopRequireDefault(_mkdirp)
 
-function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { default: obj }; }
+function _interopRequireDefault (obj) { return obj && obj.__esModule ? obj : { default: obj } }
 
 var baseName = _ramda2.default.when(function (x) {
-  return _ramda2.default.eqBy(_ramda2.default.toLower, _ramda2.default.takeLast(3, x), '.js');
+  return _ramda2.default.eqBy(_ramda2.default.toLower, _ramda2.default.takeLast(3, x), '.js')
 }, function (y) {
-  return _ramda2.default.take(_ramda2.default.length(y) - 3, y);
-});
-var folderError = "\n Are you sure you're in an IR project?";
+  return _ramda2.default.take(_ramda2.default.length(y) - 3, y)
+})
+var folderError = "\n Are you sure you're in an IR project?"
 
-var baseComponentContent = function baseComponentContent(name) {
-  return '\'use strict\'\n\nimport React, { ScrollView, View, Text } from \'react-native\'\nvar styles = require(\'../Styles/' + name + 'Style\')\n\nexport default class ' + name + ' extends React.Component {\n\n  static propTypes = {\n    navigator: React.PropTypes.object\n  }\n\n  render () {\n    return (\n      <ScrollView style={styles.container}>\n        <Text>Some Component</Text>\n      </ScrollView>\n    )\n  }\n}\n';
-};
+var baseComponentContent = function baseComponentContent (name) {
+  return `'use strict'
 
-var baseComponentStyle = function baseComponentStyle(name) {
-  return '\'use strict\'\n\nimport { StyleSheet } from \'react-native\'\nimport { Fonts, Colors, Metrics } from \'../Themes/\'\n\nexport default StyleSheet.create({\n  container: {\n    flex: 1,\n    paddingTop: Metrics.titlePadding\n  }\n})\n';
-};
+import React, { ScrollView, View, Text } from 'react-native'
+var styles = require('../Styles/${name}Style')
 
-var createFile = function createFile(path, contents) {
+export default class ${name} extends React.Component {
+  render () {
+    return (
+      <ScrollView style={styles.container}>
+        <Text>Some Component</Text>
+      </ScrollView>
+    )
+  }
+}
+
+${name}.propTypes = {
+  navigator: React.PropTypes.object
+}
+`
+}
+
+var baseComponentStyle = function baseComponentStyle (name) {
+  return `'use strict'
+
+import { StyleSheet } from 'react-native'
+import { Fonts, Colors, Metrics } from '../Themes/'
+
+export default StyleSheet.create({
+  container: {
+    flex: 1,
+    paddingTop: Metrics.titlePadding
+  }
+})
+`
+}
+
+var createFile = function createFile (path, contents) {
   _fs2.default.writeFile(path, contents, function (err) {
     if (err) {
-      return console.log(err);
+      return console.log(err)
     }
-    fileSign(path);
-  });
-};
+    fileSign(path)
+  })
+}
 
-var fileSign = exports.fileSign = function fileSign(path) {
-  var separator = _safe2.default.rainbow('!-=-=-=-=-=-=-!');
-  console.log(separator + _safe2.default.yellow(' "') + _safe2.default.underline(path) + _safe2.default.yellow('" was saved ') + separator);
-};
+var fileSign = exports.fileSign = function fileSign (path) {
+  var separator = _safe2.default.rainbow('!-=-=-=-=-=-=-!')
+  console.log(separator + _safe2.default.yellow(' "') + _safe2.default.underline(path) + _safe2.default.yellow('" was saved ') + separator)
+}
 
-var hydrateComponent = exports.hydrateComponent = function hydrateComponent(folder, fileName) {
+var hydrateComponent = exports.hydrateComponent = function hydrateComponent (folder, fileName) {
   // Folders first
   (0, _mkdirp2.default)('./App/' + folder, function (err) {
-    if (err) console.log(err + folderError);else console.log('Assured Folder ./App/' + folder);
+    if (err) console.log(err + folderError); else console.log('Assured Folder ./App/' + folder)
   });
   (0, _mkdirp2.default)('./App/' + folder + '/Styles', function (err) {
-    if (err) console.log(err + folderError);else console.log('Assured Folder ./App/' + folder + '/Styles');
-  });
+    if (err) console.log(err + folderError); else console.log('Assured Folder ./App/' + folder + '/Styles')
+  })
 
-  var baseFileName = baseName(fileName);
-  var fullFile = './App/' + folder + '/' + baseFileName + '.js';
-  var fullStyleFile = './App/' + folder + '/Styles/' + baseFileName + 'Style.js';
+  var baseFileName = baseName(fileName)
+  var fullFile = './App/' + folder + '/' + baseFileName + '.js'
+  var fullStyleFile = './App/' + folder + '/Styles/' + baseFileName + 'Style.js'
 
-  createFile(fullFile, baseComponentContent(fileName));
-  createFile(fullStyleFile, baseComponentStyle(fileName));
-};
+  createFile(fullFile, baseComponentContent(fileName))
+  createFile(fullStyleFile, baseComponentStyle(fileName))
+}
 
 exports.default = {
   fileSign: fileSign,
   hydrateComponent: hydrateComponent
-};
+}

--- a/ignite-generator/component/templates/component.js.template
+++ b/ignite-generator/component/templates/component.js.template
@@ -4,16 +4,6 @@ import styles from './Styles/<%= name %>Style'
 
 export default class <%= name %> extends React.Component {
 
-  // // Prop type warnings
-  // static propTypes = {
-  //   someProperty: React.PropTypes.object,
-  //   someSetting: React.PropTypes.bool.isRequired
-  // }
-  //
-  // // Defaults for props
-  // static defaultProps = {
-  //   someSetting: false
-  // }
 
   render () {
     return (
@@ -23,3 +13,14 @@ export default class <%= name %> extends React.Component {
     )
   }
 }
+
+// // Prop type warnings
+// <%= name %>.propTypes = {
+//   someProperty: React.PropTypes.object,
+//   someSetting: React.PropTypes.bool.isRequired
+// }
+//
+// // Defaults for props
+// <%= name %>.defaultProps = {
+//   someSetting: false
+// }

--- a/ignite-generator/mapview/templates/mapcallout.js.template
+++ b/ignite-generator/mapview/templates/mapcallout.js.template
@@ -4,11 +4,6 @@ import MapView from 'react-native-maps'
 import Styles from './Styles/MapCalloutStyle'
 
 export default class MapCallout extends React.Component {
-  static propTypes = {
-    location: PropTypes.object.isRequired,
-    onPress: PropTypes.func
-  }
-
   constructor (props) {
     super(props)
     this.onPress = this.props.onPress.bind(this, this.props.location)
@@ -28,4 +23,9 @@ export default class MapCallout extends React.Component {
       </MapView.Callout>
     )
   }
+}
+
+MapCallout.propTypes = {
+  location: PropTypes.object.isRequired,
+  onPress: PropTypes.func
 }


### PR DESCRIPTION
## Please verify the following:
- [X] Everything works on iOS/Android
- [X] `ignite-base` **ava** tests pass
- [X] `fireDrill.sh` passed

## Describe your PR
To format the code correctly according to standardjs, one can use the `standard --fix file` CLI. But the quirk there is that it doesn't like the `static propTypes = {` line within the class. So instead, using `ClassName.propTypes = {` will allow the CLI to work properly. 

I personally also thinks it makes the code cleaner to seperate out the propType from the class. 

ps: If you look at Generator.js in this PR, you can see `standard --fix` at work.

ps: I have `standard --fix` running each time I save js files on my editor, that's why I know it wasn't working. 
