### PR TITLE
Updates Reactotron to 1.1.0 and adds some in-app samples.

### DIFF
--- a/ignite-base/App/Config/ReactotronConfig.js
+++ b/ignite-base/App/Config/ReactotronConfig.js
@@ -1,14 +1,37 @@
-import Reactotron from 'reactotron'
-import {Platform} from 'react-native'
-
-Reactotron.connect({
-  enabled: __DEV__,
-  name: 'ignite App',
-  userAgent: Platform.OS
-})
+const Reactotron = require('reactotron-react-native').default
+const errorPlugin = require('reactotron-react-native').trackGlobalErrors
+const apisaucePlugin = require('reactotron-apisauce')
 
 if (__DEV__) {
+  Reactotron
+    .configure({
+      // host: '10.0.3.2' // default is localhost (on android don't forget to `adb reverse tcp:9090 tcp:9090`)
+      name: 'Ignite App' // would you like to see your app's name?
+    })
+
+    // forward all errors to Reactotron
+    .use(errorPlugin({
+      // ignore all error frames from react-native (for example)
+      veto: (frame) =>
+        frame.fileName.indexOf('/node_modules/react-native/') >= 0
+    }))
+
+    // register apisauce so we can install a monitor later
+    .use(apisaucePlugin())
+
+    // let's connect!
+    .connect()
+
+  // Totally hacky, but this allows you to not both importing reactotron-react-native
+  // on every file.  This is just DEV mode, so no big deal.
   console.tron = Reactotron
 } else {
-  console.tron = () => false
+  // a mock version should you decide to leave console.tron in your codebase
+  console.tron = {
+    log: () => false,
+    warn: () => false,
+    error: () => false,
+    display: () => false,
+    image: () => false
+  }
 }

--- a/ignite-base/App/Containers/DeviceInfoScreen.js
+++ b/ignite-base/App/Containers/DeviceInfoScreen.js
@@ -3,7 +3,7 @@ import React from 'react'
 import { View, ScrollView, Text, Image, NetInfo } from 'react-native'
 import DeviceInfo from 'react-native-device-info'
 import { Metrics, Images } from '../Themes'
-
+import { map, fromPairs } from 'ramda'
 import styles from './Styles/DeviceInfoScreenStyle'
 
 const HARDWARE_DATA = [
@@ -52,6 +52,17 @@ export default class DeviceInfoScreen extends React.Component {
     NetInfo.addEventListener('change', this.setConnectionInfo)
     NetInfo.fetch().done(this.setConnectionInfo)
     NetInfo.addEventListener('change', this.updateConnectionInfoHistory)
+
+    // an example of how to display a custom Reactotron message
+    console.tron.display({
+      name: 'SPECS',
+      value: {
+        hardware: fromPairs(map((o) => [o.title, o.info], HARDWARE_DATA)),
+        os: fromPairs(map((o) => [o.title, o.info], OS_DATA)),
+        app: fromPairs(map((o) => [o.title, o.info], APP_DATA))
+      },
+      preview: 'About this device...'
+    })
   }
 
   componentWillUnmount () {

--- a/ignite-base/App/Services/Api.js
+++ b/ignite-base/App/Services/Api.js
@@ -1,6 +1,5 @@
 // a library to wrap and simplify api calls
 import apisauce from 'apisauce'
-import Reactotron from 'reactotron'
 
 // our "constructor"
 const create = (baseURL = 'http://openweathermap.org/data/2.1') => {
@@ -22,11 +21,12 @@ const create = (baseURL = 'http://openweathermap.org/data/2.1') => {
   })
 
   // Wrap api's addMonitor to allow the calling code to attach
-  // additional monitors in the future.
-  const addMonitor = api.addMonitor((response) => {
-    // Monitors are called passively after every request.
-    Reactotron.apiLog(response)
-  })
+  // additional monitors in the future.  But only in __DEV__ and only
+  // if we've attached Reactotron to console (it isn't during unit tests).
+  if (__DEV__ && console.tron) {
+    console.tron.log('Hello, I\'m an example of how to log via Reactotron.')
+    api.addMonitor(console.tron.apisauce)
+  }
 
   // ------
   // STEP 2
@@ -58,9 +58,7 @@ const create = (baseURL = 'http://openweathermap.org/data/2.1') => {
   //
   return {
     // a list of the API functions from step 2
-    getCity,
-    // additional utilities
-    addMonitor
+    getCity
   }
 }
 

--- a/ignite-base/Tests/Setup.js
+++ b/ignite-base/Tests/Setup.js
@@ -14,7 +14,9 @@ mockery.warnOnUnregistered(false)
 
 // Mock any libs that get called in here
 // I'm looking at you react-native-router-flux, reactotron etc!
-mockery.registerMock('reactotron', {})
+mockery.registerMock('reactotron-react-native', {})
+mockery.registerMock('reactotron-redux', {})
+mockery.registerMock('reactotron-apisauce', {})
 
 // Mock all images for React Native
 const originalLoader = m._load

--- a/ignite-base/index.android.js
+++ b/ignite-base/index.android.js
@@ -1,7 +1,7 @@
+import './App/Config/ReactotronConfig'
 import React from 'react'
 import { AppRegistry } from 'react-native'
 import Root from './App/Root'
-import './App/Config/ReactotronConfig'
 import configureStore from './App/Store/Store'
 
 // Handling store here to avoid hot-reloading issues

--- a/ignite-base/index.ios.js
+++ b/ignite-base/index.ios.js
@@ -1,7 +1,7 @@
+import './App/Config/ReactotronConfig'
 import React from 'react'
 import { AppRegistry } from 'react-native'
 import Root from './App/Root'
-import './App/Config/ReactotronConfig'
 import configureStore from './App/Store/Store'
 
 // Handling store here to avoid hot-reloading issues

--- a/ignite-base/index.js.template
+++ b/ignite-base/index.js.template
@@ -1,7 +1,7 @@
+import './App/Config/ReactotronConfig'
 import React from 'react'
 import { AppRegistry } from 'react-native'
 import Root from './App/Root'
-import './App/Config/ReactotronConfig'
 import configureStore from './App/Store/Store'
 
 // Handling store here to avoid hot-reloading issues

--- a/ignite-base/package.json
+++ b/ignite-base/package.json
@@ -53,7 +53,9 @@
     "react-addons-test-utils": "^15.3.1",
     "react-dom": "^15.3.1",
     "react-native-mock": "^0.2.6",
-    "reactotron": "^0.8.0",
+    "reactotron-apisauce": "^1.1.0",
+    "reactotron-react-native": "^1.1.0",
+    "reactotron-redux": "^1.1.0",
     "snazzy": "^4.0.1",
     "standard": "^8.0.0"
   },

--- a/ignite-base/package.json.template
+++ b/ignite-base/package.json.template
@@ -53,7 +53,9 @@
     "react-addons-test-utils": "^15.3.1",
     "react-dom": "^15.3.1",
     "react-native-mock": "^0.2.6",
-    "reactotron": "^0.8.0",
+    "reactotron-apisauce": "^1.1.0",
+    "reactotron-react-native": "^1.1.0",
+    "reactotron-redux": "^1.1.0",
     "snazzy": "^4.0.1",
     "standard": "^8.0.0"
   },


### PR DESCRIPTION
![image](https://cloud.githubusercontent.com/assets/68273/18030066/f2d5a5de-6c77-11e6-936c-54e7284e85ca.png)

![image](https://cloud.githubusercontent.com/assets/68273/18030083/7bc06a0a-6c78-11e6-81eb-35289becc8fc.png)

Heads up, there's a warning about peer dependency of React Native with `reactotron-react-native`.  I'm going to loosen up the requirement on my end from `^0.31.0` to `>=0.31.0`.  

But it's harmless.  You're welcome to hold off on this merge, but it might not be for a few days before I can get to that task.

https://github.com/reactotron/reactotron/issues/186


