### PR TITLE
we're not really supporting exponent anymore

### DIFF
--- a/ignite-base/index.js
+++ b/ignite-base/index.js
@@ -1,8 +1,0 @@
-// This file is here if you'd like to use Exponent XDE
-// Swap out the RN dependency for the latest from Exponent.
-// E.G. "react-native": "github:exponentjs/react-native#2016-01-02"
-
-import { AppRegistry } from 'react-native'
-import Root from './App/Root'
-
-AppRegistry.registerComponent('main', () => Root)


### PR DESCRIPTION
## Please verify the following:
- [x] Everything works on iOS/Android
- [x] `ignite-base` **ava** tests pass
- [x] `fireDrill.sh` passed

## Describe your PR
We stopped updating the index.js for exponent builds.  Might as well officially remove it.

