### PR TITLE
Fixes problem with chicken-and-env for react-native-config.

### DIFF
--- a/ignite-base/android/app/build.gradle
+++ b/ignite-base/android/app/build.gradle
@@ -1,4 +1,5 @@
 apply plugin: "com.android.application"
+apply from: project(':react-native-config').projectDir.getPath() + "/dotenv.gradle"
 
 import com.android.build.OutputFile
 
@@ -141,4 +142,3 @@ task copyDownloadableDepsToLibs(type: Copy) {
   from configurations.compile
   into 'libs'
 }
-

--- a/ignite-base/android/app/src/main/java/com/rnbase/MainApplication.java
+++ b/ignite-base/android/app/src/main/java/com/rnbase/MainApplication.java
@@ -32,7 +32,7 @@ public class MainApplication extends Application implements ReactApplication {
 
       return Arrays.<ReactPackage>asList(
           new MainReactPackage(),
-            new ReactNativeConfigPackage(),
+          new ReactNativeConfigPackage(),
           // new MapsPackage(),
           new RNDeviceInfo(),
           new ReactNativeI18n(),

--- a/ignite-base/package.json
+++ b/ignite-base/package.json
@@ -28,7 +28,7 @@
     "react": "~15.3.0",
     "react-native": "^0.32.0",
     "react-native-animatable": "^0.6.0",
-    "react-native-config": "0.0.8",
+    "react-native-config": "github:skellock/react-native-config#fix-missing-env",
     "react-native-device-info": "^0.9.4",
     "react-native-drawer": "^2.3.0",
     "react-native-i18n": "0.0.8",

--- a/ignite-base/package.json.template
+++ b/ignite-base/package.json.template
@@ -28,7 +28,7 @@
     "react": "~15.3.0",
     "react-native": "^0.32.0",
     "react-native-animatable": "^0.6.0",
-    "react-native-config": "0.0.8",
+    "react-native-config": "github:skellock/react-native-config#fix-missing-env",
     "react-native-device-info": "^0.9.4",
     "react-native-drawer": "^2.3.0",
     "react-native-i18n": "0.0.8",


### PR DESCRIPTION
Finishes hooking up `react-native-config` to Android and temporarily switch to a branch which doesn't die when building projects missing an `.env` file.

https://github.com/luggit/react-native-config/pull/31
