### PR TITLE
Bumps Reactotron due to version warning inside that dependency.

### DIFF
--- a/ignite-base/package.json
+++ b/ignite-base/package.json
@@ -53,9 +53,9 @@
     "react-addons-test-utils": "^15.3.1",
     "react-dom": "^15.3.1",
     "react-native-mock": "^0.2.6",
-    "reactotron-apisauce": "^1.1.0",
-    "reactotron-react-native": "^1.1.0",
-    "reactotron-redux": "^1.1.0",
+    "reactotron-apisauce": "^1.1.2",
+    "reactotron-react-native": "^1.1.2",
+    "reactotron-redux": "^1.1.2",
     "snazzy": "^4.0.1",
     "standard": "^8.0.0"
   },

--- a/ignite-base/package.json.template
+++ b/ignite-base/package.json.template
@@ -53,9 +53,9 @@
     "react-addons-test-utils": "^15.3.1",
     "react-dom": "^15.3.1",
     "react-native-mock": "^0.2.6",
-    "reactotron-apisauce": "^1.1.0",
-    "reactotron-react-native": "^1.1.0",
-    "reactotron-redux": "^1.1.0",
+    "reactotron-apisauce": "^1.1.2",
+    "reactotron-react-native": "^1.1.2",
+    "reactotron-redux": "^1.1.2",
     "snazzy": "^4.0.1",
     "standard": "^8.0.0"
   },


### PR DESCRIPTION
Switched Reactotron's React Native dependency from `~0.31.0` to `>=0.31.0` because it was throwing warnings.  Sorry about that.