### PR TITLE
Early exit (with a nice message!) when project folder exists.

### DIFF
--- a/ignite-cli/src/index.es
+++ b/ignite-cli/src/index.es
@@ -7,6 +7,7 @@ import Shell from 'shelljs'
 import spawn from 'cross-spawn'
 import R from 'ramda'
 import updateNotifier from 'update-notifier'
+import * as fs from 'fs'
 
 const FIRE = colors.red('FIRE!')
 
@@ -22,6 +23,14 @@ const checkName = (project) => {
   // Only alphanumeric project names
   if (/[^a-z0-9]+/i.test(project)) {
     console.log(`"${project}" is not a valid name for a project. Please use a valid identifier name (alphanumeric).`)
+    Shell.exit(1)
+  }
+}
+
+// Early exit if the project name already exists (#349)
+const checkDir = (project) => {
+  if (fs.existsSync(process.cwd() + '/' + project.toString())) {
+    console.log(`Sorry, I couldn\'t create the directory for "${project}" - it already exists. :(`)
     Shell.exit(1)
   }
 }
@@ -52,6 +61,7 @@ Program
   .action((project, options) => {
     checkYo()
     checkName(project)
+    checkDir(project)
     checkReactNative()
     console.log(`🔥 Setting ${project} on ${FIRE} 🔥`)
     // the array of options fed into spawn


### PR DESCRIPTION
## Please verify the following:
- [X] Everything works on iOS/Android (update for the cli)
- [X] `ignite-base` **ava** tests pass
- [X] `fireDrill.sh` passed

## Describe your PR
Added an early exit with a nice message when the project folder already exists in the target directory.

Since there were no tests (understandably) I've done some manual before and after testing below to verify results:

![screen shot 2016-09-05 at 1 36 14 pm](https://cloud.githubusercontent.com/assets/7445602/18235683/1a52f5b6-7372-11e6-8e99-d9e5a25c57de.png)

![screen shot 2016-09-05 at 1 42 15 pm](https://cloud.githubusercontent.com/assets/7445602/18235690/2c331356-7372-11e6-9642-71420b3be2c3.png)

If there's anything that needs changing, let me know. (I'm a first time node-r but long time code-r)

And thanks for a great starter package! 😄 