### PR TITLE
gradlew clean android now

### DIFF
--- a/ignite-generator/src/app/index.es
+++ b/ignite-generator/src/app/index.es
@@ -16,6 +16,14 @@ const emptyFolder = (folder) => {
   Shell.mkdir(folder)
 }
 
+// This step needed as of Ignite 1.7.0 and RN 0.33.0
+// This wasn't necessary before, might need to be removed at some point
+const cleanAndroid = (projectFolder) => {
+  Shell.cd(`${projectFolder}/android`)
+  Shell.exec('./gradlew clean')
+  Shell.cd('../..')
+}
+
 /**
  * Doctors the AndroidManifest.xml to put in the stuff we need.
  */
@@ -351,6 +359,7 @@ export class AppGenerator extends Generators.Base {
     this.spinner.text = status
     this.spinner.start()
     emptyFolder(this.sourceRoot())
+    cleanAndroid(this.name)
     this.spinner.stop()
     this.log(`${check} ${status}`)
   }


### PR DESCRIPTION
## Please verify the following:
- [x] Everything works on iOS/Android
- [x] `ignite-base` **ava** tests pass
- [x] `fireDrill.sh` passed

## Describe your PR
As of #361 we started getting a strange error on Android.  As reported here in #362 

This PR now automatically does some buttwiping for React Native Android so the dex files don't complain.  Not sure if this symptom should be be further investigated, but this fixes it for now.   Someone like @darinwilson  or @skellock might know why this was needed?

If not, the screw it, this PR does all the fixing necessary.

