### PR TITLE
Added early exit if generators are being run in an ignite directory.

### DIFF
--- a/ignite-cli/src/index.es
+++ b/ignite-cli/src/index.es
@@ -32,6 +32,19 @@ const checkDir = (project) => {
   if (fs.existsSync(process.cwd() + '/' + project.toString())) {
     console.log(`Sorry, I couldn\'t create the directory for "${project}" - it already exists. :(`)
     Shell.exit(1)
+  };
+
+  if (fs.existsSync(process.cwd() + '/App')) {
+    console.log(`Sorry, I couldn\'t create a new app here, I\'m being run in an Ignite directory.`)
+    Shell.exit(1)
+  }
+}
+
+// Ensure generators are in the correct directory (#129)
+const checkIgniteDir = (type, name) => {
+  if (!fs.existsSync(process.cwd() + '/App')) {
+    console.log(`Sorry, I couldn\'t make your ${type} named ${name} - I\'m not being run from an Ignite directory. :(`)
+    Shell.exit(1)
   }
 }
 
@@ -90,6 +103,7 @@ Program
   .alias('g')
   .action((type, name) => {
     checkYo()
+    checkIgniteDir(type, name)
     console.log(`Generate a new ${type} named ${name}`)
     spawn('yo', [`react-native-ignite:${type}`, name], { shell: true, stdio: 'inherit' })
   })


### PR DESCRIPTION
## Please verify the following:
- [X] Everything works on iOS/Android (update to cli)
- [X] `ignite-base` **ava** tests pass
- [X] `fireDrill.sh` passed

## Describe your PR
* Early exit when generators are not being run in an ignite directory
* Also added an early exit if the new command is being run in an ignite directory.

Verification Tests:

![screen shot 2016-09-13 at 12 46 44 pm](https://cloud.githubusercontent.com/assets/7445602/18457901/a105d814-79b0-11e6-9e73-964fa4810861.png)

Let me know if there's anything else :)