### PR TITLE
fix html coverage report opening on Linux

### DIFF
--- a/ignite-base/package.json
+++ b/ignite-base/package.json
@@ -11,7 +11,7 @@
     "newclear": "rm -rf $TMPDIR/react-* && watchman watch-del-all && rm -rf ios/build/ModuleCache/* && rm -rf node_modules/ && npm cache clean && npm i",
     "test": "NODE_ENV=production ava",
     "test:watch": "ava --watch",
-    "coverage": "nyc ava && nyc report --reporter=html && open coverage/index.html",
+    "coverage": "nyc ava && nyc report --reporter=html && open coverage/index.html || xdg-open coverage/index.html",
     "tron": "node_modules/.bin/reactotron",
     "android:build": "cd android && ./gradlew assembleRelease",
     "android:install": "cd android && ./gradlew assembleRelease && ./gradlew installRelease",

--- a/ignite-base/package.json.template
+++ b/ignite-base/package.json.template
@@ -11,7 +11,7 @@
     "newclear": "rm -rf $TMPDIR/react-* && watchman watch-del-all && rm -rf ios/build/ModuleCache/* && rm -rf node_modules/ && npm cache clean && npm i",
     "test": "NODE_ENV=production ava",
     "test:watch": "ava --watch",
-    "coverage": "nyc ava && nyc report --reporter=html && open coverage/index.html",
+    "coverage": "nyc ava && nyc report --reporter=html && open coverage/index.html || xdg-open coverage/index.html",
     "tron": "node_modules/.bin/reactotron",
     "android:build": "cd android && ./gradlew assembleRelease",
     "android:install": "cd android && ./gradlew assembleRelease && ./gradlew installRelease",


### PR DESCRIPTION
## Please verify the following:
- [X] Everything works on iOS/Android
- [X] `ignite-base` **ava** tests pass
- [X] `fireDrill.sh` passed

## Describe your PR
Currently the HTML coverage reports don't open on Linux because there is no `open` executable. This PR fixes that by falling back to use `xdg-open` if the `open` command fails. 
