### PR TITLE
Fix warning of duplicate key for MapCallout

### DIFF
--- a/ignite-base/App/Components/MapCallout.js
+++ b/ignite-base/App/Components/MapCallout.js
@@ -5,7 +5,7 @@ import Styles from './Styles/MapCalloutStyle'
 import ExamplesRegistry from '../Services/ExamplesRegistry'
 
 // Example
-ExamplesRegistry.add('Full Button', () =>
+ExamplesRegistry.add('Map Callout', () =>
   <MapCallout
     location={{
       title: 'Callout Example'


### PR DESCRIPTION
Fixes warning in simulator for "child keys must be unique".


