### PR TITLE
feat: Add yarn to install packages

### DIFF
--- a/ignite-generator/src/app/index.es
+++ b/ignite-generator/src/app/index.es
@@ -428,8 +428,22 @@ export class AppGenerator extends Generators.Base {
 
     const done = this.async()
     const dir = `${Shell.pwd()}/${this.name}`
+    let command = ''
+    let commandOpts = []
+
+    // Use Yarn if it is installed
+    if (!Shell.which('yarn')) {
+      command = 'npm'
+      commandOpts.push('install')
+      this.log(`\n➟ Package manager:\t[${check}]︎ npm  |  [ ]︎ yarn`)
+    } else {
+      command = 'yarn'
+      commandOpts.push('install')
+      this.log(`\n➟ Package manager:\t[ ]︎ npm  |  [${check}]︎ yarn`)
+    }
+
     // run the npm command
-    this.spawnCommand('npm', ['install'], {cwd: dir, stdio: 'ignore'})
+    this.spawnCommand(command, commandOpts, {cwd: dir, stdio: 'ignore'})
       .on('close', (retCode) => {
         animation.finish(retCode)
 

--- a/ignite-generator/src/app/index.es
+++ b/ignite-generator/src/app/index.es
@@ -442,7 +442,7 @@ export class AppGenerator extends Generators.Base {
       this.log(`\n➟ Package manager:\t[ ]︎ npm  |  [${check}]︎ yarn`)
     }
 
-    // run the npm command
+    // Install node modules
     this.spawnCommand(command, commandOpts, {cwd: dir, stdio: 'ignore'})
       .on('close', (retCode) => {
         animation.finish(retCode)


### PR DESCRIPTION
## Please verify the following:
- [ ] Everything works on iOS/Android
- [x] `ignite-base` **ava** tests pass
- [ ] `fireDrill.sh` passed

## Describe your PR


Check if yarn is installed and use it instead of npm to install packages
in ignite-generator.

## Everything works on iOS/Android
Only checked the iOS app and everything works.

## fireDrill.sh output
```
standard: Use JavaScript Standard Style (http://standardjs.com)
  /.../ignite/ignite-cli/src/index.es:39:32: Unnecessary escape character: \'.
  /.../ignite/ignite-cli/src/index.es:44:32: Unnecessary escape character: \'.
  /.../ignite/ignite-cli/src/index.es:44:60: Unnecessary escape character: \'.
  /.../ignite/ignite-cli/src/index.es:52:32: Unnecessary escape character: \'.
  /.../ignite/ignite-cli/src/index.es:52:71: Unnecessary escape character: \'.
standard: Use JavaScript Standard Style (http://standardjs.com)
standard: Run `standard --fix` to automatically fix some problems.
  /.../ignite/ignite-generator/src/utilities.js:14:1: More than 1 blank line not allowed.
```