### PR TITLE
Updated docs to add yarn install note

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,6 +66,8 @@ or
 
 `yarn global add react-native-ignite`
 
+NOTE: If you seem to not have `ignite` available on your path, check that your correct yarn bin directory is on your path by checking that the output of `yarn global bin` is listed as a directory in `$PATH` environment variable.
+
 For those of you unfamiliar with the new package manager Yarn, it's basically a 1 for 1 replacement for npm, but with a significant speed boost. Check out this [yarn cheatsheet](https://shift.infinite.red/npm-vs-yarn-cheat-sheet-8755b092e5cc#.1ckrhd77a) for more info.
 
 **Step 2: Use**


### PR DESCRIPTION
## What is the context of this PR?

When trying to install the cli for the first time on mac os using the new Facebook backed Yarn packaging system, a non-obvious issue occurs where a binary application is not available in your path despite you following the detailed and correct install notes.

## What does this change?

This PR updates the documentation to cover a bug in how yarn install notes explain how to set your path and how globally installed binaries are added to a system. Hopefully in the future the getting started notes will explain that if you install binaries globally on a system you need to add that global path to your environment path.

This should be reviewed in the future to check if required given Yarn's fast development.

This PR fixes #477 

## Who can review

Anyone but @dhilton