### PR TITLE
fix ThemeScreen name

### DIFF
--- a/ignite-base/App/Containers/ThemeScreen.js
+++ b/ignite-base/App/Containers/ThemeScreen.js
@@ -15,7 +15,7 @@ const types = R.keys(Fonts.type)
 // Font Styles
 const fontStyles = R.keys(Fonts.style)
 
-export default class UsageExamplesScreen extends React.Component {
+export default class ThemeScreen extends React.Component {
 
   renderColor (color: string) {
     return (


### PR DESCRIPTION
## Please verify the following:
- [x] Everything works on iOS/Android
- [x] `ignite-base` **ava** tests pass
- [x] `fireDrill.sh` passed

I couldn't get fireDrill.sh to run at first, confusing error: `Wrong version of Flow. The config specifies version ^0.33.0 but this is version 0.34.0`. I added flow-bin@0.33.0 in fireDrill.sh and it worked

## Describe your PR
Very small change, the name of the class in `ThemeScreen.js` class was 'UsageExamplesScreen'

Loving Ignite so far, thanks!