### PR TITLE
Add .gitattributes file, treat .pbxproj as binary

### DIFF
--- a/ignite-base/.gitattributes
+++ b/ignite-base/.gitattributes
@@ -1,0 +1,1 @@
+*.pbxproj binary


### PR DESCRIPTION
## Please verify the following:
- [x] Everything works on iOS/Android
- [x] `ignite-base` **ava** tests pass
- [x] `fireDrill.sh` passed

## Describe your PR
By default, the `.pbxproj` file generated by Ignite should be treated as binary data to prevent Git from possibly automatically converting or fixing CRLF issues with this file, which would break it. 

See https://git-scm.com/book/en/v2/Customizing-Git-Git-Attributes#identifying-binary-files-znTLIVhvhG (where it specifically mentions `.pbxproj` files) for more information.
