### PR TITLE
Reactotron 1.5 - Sagas, Timeline Filter + More 💃

### DIFF
--- a/ignite-base/App/Config/ReactotronConfig.js
+++ b/ignite-base/App/Config/ReactotronConfig.js
@@ -4,6 +4,7 @@ const Reactotron = require('reactotron-react-native').default
 const errorPlugin = require('reactotron-react-native').trackGlobalErrors
 const apisaucePlugin = require('reactotron-apisauce')
 const { reactotronRedux } = require('reactotron-redux')
+const sagaPlugin = require('reactotron-redux-saga')
 
 if (__DEV__) {
   Reactotron
@@ -34,6 +35,9 @@ if (__DEV__) {
       // immutable with `seamless-immutable`, we ensure we convert to that format.
       onRestore: state => Immutable(state)
     }))
+
+    // register the redux-saga plugin so we can use the monitor in CreateStore.js
+    .use(sagaPlugin())
 
     // let's connect!
     .connect()

--- a/ignite-base/App/Redux/CreateStore.js
+++ b/ignite-base/App/Redux/CreateStore.js
@@ -16,7 +16,8 @@ export default (rootReducer, rootSaga) => {
 
   /* ------------- Saga Middleware ------------- */
 
-  const sagaMiddleware = createSagaMiddleware()
+  const sagaMonitor = __DEV__ ? console.tron.createSagaMonitor() : null
+  const sagaMiddleware = createSagaMiddleware({ sagaMonitor })
   middleware.push(sagaMiddleware)
 
   /* ------------- Logger Middleware ------------- */

--- a/ignite-base/App/Sagas/StartupSagas.js
+++ b/ignite-base/App/Sagas/StartupSagas.js
@@ -7,7 +7,7 @@ export const selectTemperature = (state) => state.temperature.temperature
 
 // process STARTUP actions
 export function * startup (action) {
-  if (__DEV__) {
+  if (__DEV__ && console.tron) {
     // straight-up string logging
     console.tron.log('Hello, I\'m an example of how to log via Reactotron.')
 

--- a/ignite-base/App/Sagas/StartupSagas.js
+++ b/ignite-base/App/Sagas/StartupSagas.js
@@ -7,6 +7,31 @@ export const selectTemperature = (state) => state.temperature.temperature
 
 // process STARTUP actions
 export function * startup (action) {
+  if (__DEV__) {
+    // straight-up string logging
+    console.tron.log('Hello, I\'m an example of how to log via Reactotron.')
+
+    // logging an object for better clarity
+    console.tron.log({
+      message: 'pass objects for better logging',
+      someGeneratorFunction: selectTemperature
+    })
+
+    // fully customized!
+    const subObject = { a: 1, b: [1, 2, 3], c: true }
+    subObject.circularDependency = subObject // osnap!
+    console.tron.display({
+      name: '🔥 IGNITE 🔥',
+      preview: 'You should totally expand this',
+      value: {
+        '💃': 'Welcome to the future!',
+        subObject,
+        someInlineFunction: () => true,
+        someGeneratorFunction: startup,
+        someNormalFunction: selectTemperature
+      }
+    })
+  }
   const temp = yield select(selectTemperature)
   // only fetch new temps when we don't have one yet
   if (!is(Number, temp)) {

--- a/ignite-base/App/Services/Api.js
+++ b/ignite-base/App/Services/Api.js
@@ -29,7 +29,6 @@ const create = (baseURL = 'http://api.openweathermap.org/data/2.5/') => {
   // additional monitors in the future.  But only in __DEV__ and only
   // if we've attached Reactotron to console (it isn't during unit tests).
   if (__DEV__ && console.tron) {
-    console.tron.log('Hello, I\'m an example of how to log via Reactotron.')
     api.addMonitor(console.tron.apisauce)
   }
 

--- a/ignite-base/package.json
+++ b/ignite-base/package.json
@@ -40,7 +40,7 @@
     "redux": "^3.6.0",
     "redux-logger": "^2.4.0",
     "redux-persist": "^3.5.0",
-    "redux-saga": "^0.11.1",
+    "redux-saga": "^0.12.1",
     "reduxsauce": "0.2.0",
     "seamless-immutable": "^6.1.0"
   },
@@ -58,7 +58,8 @@
     "react-native-mock": "^0.2.7",
     "reactotron-apisauce": "^1.3.0",
     "reactotron-react-native": "^1.3.0",
-    "reactotron-redux": "^1.3.1",
+    "reactotron-redux": "^1.4.0",
+    "reactotron-redux-saga": "^1.4.0",
     "snazzy": "^5.0.0",
     "standard-flow": "^1.0.0"
   },

--- a/ignite-base/package.json
+++ b/ignite-base/package.json
@@ -40,7 +40,7 @@
     "redux": "^3.6.0",
     "redux-logger": "^2.4.0",
     "redux-persist": "^3.5.0",
-    "redux-saga": "^0.12.1",
+    "redux-saga": "^0.13.0",
     "reduxsauce": "0.2.0",
     "seamless-immutable": "^6.1.0"
   },
@@ -56,10 +56,10 @@
     "react-addons-test-utils": "^15.3.2",
     "react-dom": "^15.3.2",
     "react-native-mock": "^0.2.7",
-    "reactotron-apisauce": "^1.3.0",
-    "reactotron-react-native": "^1.3.0",
-    "reactotron-redux": "^1.4.0",
-    "reactotron-redux-saga": "^1.4.0",
+    "reactotron-apisauce": "^1.5.2",
+    "reactotron-react-native": "^1.5.2",
+    "reactotron-redux": "^1.5.2",
+    "reactotron-redux-saga": "^1.5.2",
     "snazzy": "^5.0.0",
     "standard-flow": "^1.0.0"
   },

--- a/ignite-base/package.json.template
+++ b/ignite-base/package.json.template
@@ -40,7 +40,7 @@
     "redux": "^3.6.0",
     "redux-logger": "^2.4.0",
     "redux-persist": "^3.5.0",
-    "redux-saga": "^0.11.1",
+    "redux-saga": "^0.12.1",
     "reduxsauce": "0.2.0",
     "seamless-immutable": "^6.1.0"
   },
@@ -58,7 +58,8 @@
     "react-native-mock": "^0.2.7",
     "reactotron-apisauce": "^1.3.0",
     "reactotron-react-native": "^1.3.0",
-    "reactotron-redux": "^1.3.1",
+    "reactotron-redux": "^1.4.0",
+    "reactotron-redux-saga": "^1.4.0",
     "snazzy": "^5.0.0",
     "standard-flow": "^1.0.0"
   },

--- a/ignite-base/package.json.template
+++ b/ignite-base/package.json.template
@@ -40,7 +40,7 @@
     "redux": "^3.6.0",
     "redux-logger": "^2.4.0",
     "redux-persist": "^3.5.0",
-    "redux-saga": "^0.12.1",
+    "redux-saga": "^0.13.0",
     "reduxsauce": "0.2.0",
     "seamless-immutable": "^6.1.0"
   },
@@ -56,10 +56,10 @@
     "react-addons-test-utils": "^15.3.2",
     "react-dom": "^15.3.2",
     "react-native-mock": "^0.2.7",
-    "reactotron-apisauce": "^1.3.0",
-    "reactotron-react-native": "^1.3.0",
-    "reactotron-redux": "^1.4.0",
-    "reactotron-redux-saga": "^1.4.0",
+    "reactotron-apisauce": "^1.5.2",
+    "reactotron-react-native": "^1.5.2",
+    "reactotron-redux": "^1.5.2",
+    "reactotron-redux-saga": "^1.5.2",
     "snazzy": "^5.0.0",
     "standard-flow": "^1.0.0"
   },

--- a/ignite-base/yarn.lock
+++ b/ignite-base/yarn.lock
@@ -5515,9 +5515,19 @@ reactotron-react-native@^1.3.0:
     socket.io "^1.4.8"
     socket.io-client "^1.4.8"
 
-reactotron-redux@^1.3.1:
-  version "1.3.1"
-  resolved "https://registry.yarnpkg.com/reactotron-redux/-/reactotron-redux-1.3.1.tgz#4426226ef977165985610d457d1d422f854c1d0d"
+reactotron-redux-saga@^1.4.0:
+  version "1.4.0"
+  resolved "https://registry.yarnpkg.com/reactotron-redux-saga/-/reactotron-redux-saga-1.4.0.tgz#21df159b4183df78c14291575eb0a4ceb7bd86c8"
+  dependencies:
+    ramda "^0.22.1"
+    ramdasauce "^1.1.1"
+    reactotron-core-client "^1.3.0"
+    redux "^3.6.0"
+    redux-saga "^0.12.1"
+
+reactotron-redux@^1.4.0:
+  version "1.4.0"
+  resolved "https://registry.yarnpkg.com/reactotron-redux/-/reactotron-redux-1.4.0.tgz#9fb61f64e3a13a3266fe8e353b43c99d7d3ded8f"
   dependencies:
     ramda "^0.22.1"
     ramdasauce "^1.1.1"
@@ -5650,9 +5660,9 @@ redux-persist@^3.5.0:
     json-stringify-safe "^5.0.1"
     lodash "^4.11.1"
 
-redux-saga@^0.11.1:
-  version "0.11.1"
-  resolved "https://registry.yarnpkg.com/redux-saga/-/redux-saga-0.11.1.tgz#dc2023d059af0b91c0b1b4febce21194b67d5a58"
+redux-saga@^0.12.1:
+  version "0.12.1"
+  resolved "https://registry.yarnpkg.com/redux-saga/-/redux-saga-0.12.1.tgz#79c9263d67486fd26a7a3d3b9df8ed65057a9fc6"
 
 redux@^3.6.0:
   version "3.6.0"


### PR DESCRIPTION
For people with existing Ignited apps:

* upgrade existing reactotron dependencies in your `package.json` to `1.5.2`
* `npm i --save-dev reactotron-redux-saga`
* register `reactotron-redux-saga` plugin within `ReactotronConfig.js`
* configure `createSagaMiddleware()` to use a custom `sagaMonitor` in your `CreateStore.js`

And now you get this:

![image](https://cloud.githubusercontent.com/assets/68273/20225273/7f5fd820-a810-11e6-82f4-3d5da7753c06.png)

You can download the Reactotron app with Homebrew on macOS:

```sh
brew update && brew cask install reactotron
```

To upgrade from an old version:

```sh
brew update && brew cask upgrade reactotron
```

To just [download the binaries like a savage](https://github.com/reactotron/reactotron/releases/tag/v1.5.0).

