### PR TITLE
Missing dev dependency on 'standard' command

### DIFF
--- a/ignite-base/package.json
+++ b/ignite-base/package.json
@@ -62,7 +62,8 @@
     "reactotron-redux": "^1.5.2",
     "reactotron-redux-saga": "^1.5.2",
     "snazzy": "^5.0.0",
-    "standard-flow": "^1.0.0"
+    "standard-flow": "^1.0.0",
+    "standard": "8.6.0"
   },
   "ava": {
     "files": [

--- a/ignite-base/package.json.template
+++ b/ignite-base/package.json.template
@@ -62,7 +62,8 @@
     "reactotron-redux": "^1.5.2",
     "reactotron-redux-saga": "^1.5.2",
     "snazzy": "^5.0.0",
-    "standard-flow": "^1.0.0"
+    "standard-flow": "^1.0.0",
+    "standard": "8.6.0"
   },
   "ava": {
     "files": [


### PR DESCRIPTION
## Please verify the following:
- [ x] Everything works on iOS/Android
- [ ] `ignite-base` **ava** tests pass
- [ ] `fireDrill.sh` passed

## Describe your PR
Git commits would fail with no standard command as it wasn't getting installed on project init.