### PR TITLE
Move Reactotron switch to DebugSettings.js

### DIFF
--- a/ignite-base/App/Config/DebugSettings.js
+++ b/ignite-base/App/Config/DebugSettings.js
@@ -4,7 +4,7 @@ const SETTINGS = {
   yellowBox: __DEV__,
   reduxLogging: __DEV__,
   includeExamples: __DEV__,
-  reactotron: __DEV__
+  useReactotron: __DEV__
 }
 
 export default SETTINGS

--- a/ignite-base/App/Config/DebugSettings.js
+++ b/ignite-base/App/Config/DebugSettings.js
@@ -3,7 +3,8 @@ const SETTINGS = {
   ezLogin: false,
   yellowBox: __DEV__,
   reduxLogging: __DEV__,
-  includeExamples: __DEV__
+  includeExamples: __DEV__,
+  reactotron: __DEV__
 }
 
 export default SETTINGS

--- a/ignite-base/App/Config/ReactotronConfig.js
+++ b/ignite-base/App/Config/ReactotronConfig.js
@@ -1,12 +1,14 @@
 import { StartupTypes } from '../Redux/StartupRedux'
+import Config from '../Config/DebugSettings'
 import Immutable from 'seamless-immutable'
 const Reactotron = require('reactotron-react-native').default
 const errorPlugin = require('reactotron-react-native').trackGlobalErrors
 const apisaucePlugin = require('reactotron-apisauce')
 const { reactotronRedux } = require('reactotron-redux')
 const sagaPlugin = require('reactotron-redux-saga')
+const USE_REACTOTRON = Config.reactotron
 
-if (__DEV__) {
+if (USE_REACTOTRON) {
   Reactotron
     .configure({
       // host: '10.0.3.2' // default is localhost (on android don't forget to `adb reverse tcp:9090 tcp:9090`)

--- a/ignite-base/App/Config/ReactotronConfig.js
+++ b/ignite-base/App/Config/ReactotronConfig.js
@@ -6,9 +6,8 @@ const errorPlugin = require('reactotron-react-native').trackGlobalErrors
 const apisaucePlugin = require('reactotron-apisauce')
 const { reactotronRedux } = require('reactotron-redux')
 const sagaPlugin = require('reactotron-redux-saga')
-const USE_REACTOTRON = Config.reactotron
 
-if (USE_REACTOTRON) {
+if (Config.useReactotron) {
   Reactotron
     .configure({
       // host: '10.0.3.2' // default is localhost (on android don't forget to `adb reverse tcp:9090 tcp:9090`)

--- a/ignite-base/App/Redux/CreateStore.js
+++ b/ignite-base/App/Redux/CreateStore.js
@@ -45,8 +45,9 @@ export default (rootReducer, rootSaga) => {
     enhancers.push(autoRehydrate())
   }
 
-  // in dev mode, we'll create the store through Reactotron
-  const createAppropriateStore = __DEV__ ? console.tron.createStore : createStore
+  // if reactotron es enabled (default for __DEV__), we'll create the store through Reactotron
+  const USE_REACTOTRON = Config.reactotron
+  const createAppropriateStore = USE_REACTOTRON ? console.tron.createStore : createStore
   const store = createAppropriateStore(rootReducer, compose(...enhancers))
 
   // configure persistStore and check reducer version number

--- a/ignite-base/App/Redux/CreateStore.js
+++ b/ignite-base/App/Redux/CreateStore.js
@@ -45,7 +45,7 @@ export default (rootReducer, rootSaga) => {
     enhancers.push(autoRehydrate())
   }
 
-  // if reactotron es enabled (default for __DEV__), we'll create the store through Reactotron
+  // if Reactotron is enabled (default for __DEV__), we'll create the store through Reactotron
   const USE_REACTOTRON = Config.reactotron
   const createAppropriateStore = USE_REACTOTRON ? console.tron.createStore : createStore
   const store = createAppropriateStore(rootReducer, compose(...enhancers))

--- a/ignite-base/App/Redux/CreateStore.js
+++ b/ignite-base/App/Redux/CreateStore.js
@@ -46,8 +46,7 @@ export default (rootReducer, rootSaga) => {
   }
 
   // if Reactotron is enabled (default for __DEV__), we'll create the store through Reactotron
-  const USE_REACTOTRON = Config.reactotron
-  const createAppropriateStore = USE_REACTOTRON ? console.tron.createStore : createStore
+  const createAppropriateStore = Config.useReactotron ? console.tron.createStore : createStore
   const store = createAppropriateStore(rootReducer, compose(...enhancers))
 
   // configure persistStore and check reducer version number


### PR DESCRIPTION
While Reactotron is very helpful, it often affects the performance of the app in DEV mode to a point where it gets frustrating (mainly on navigation animations).

These changes allows to quickly disable Reactotron in DEV mode by just editting `DebugSettings.js` in the same fashion that we can disable Redux logging.