### PR TITLE
Add I18N support for Ava tests

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 # OSX
 #
 .DS_Store
+npm-debug.log

--- a/ignite-base/Tests/Sagas/TemperatureSagaTest.js
+++ b/ignite-base/Tests/Sagas/TemperatureSagaTest.js
@@ -3,6 +3,8 @@ import FixtureAPI from '../../App/Services/FixtureApi'
 import { put, call } from 'redux-saga/effects'
 import { getTemperature } from '../../App/Sagas/TemperatureSagas'
 import TemperatureActions from '../../App/Redux/TemperatureRedux'
+import convertFromKelvin from '../../App/Transforms/ConvertFromKelvin'
+import { path } from 'ramda'
 
 const stepper = (fn) => (mock) => fn.next(mock).value
 
@@ -18,7 +20,11 @@ test('success path', (t) => {
   // first step API
   step()
   // Second step successful return and temperature
-  t.deepEqual(step(response), put(TemperatureActions.temperatureSuccess(21, 'bonus')))
+  const stepResponse = step(response)
+  // Get the calculated temperature value from the fixture-based response
+  const kelvin = path(['data', 'main', 'temp_max'], response)
+  const temperature = convertFromKelvin(kelvin)
+  t.deepEqual(stepResponse, put(TemperatureActions.temperatureSuccess(temperature, 'bonus')))
 })
 
 test('failure path', (t) => {

--- a/ignite-base/Tests/Setup.js
+++ b/ignite-base/Tests/Setup.js
@@ -1,5 +1,7 @@
 import mockery from 'mockery'
 import m from 'module'
+import english from '../App/I18n/english.json'
+import {keys, replace, forEach} from 'ramda'
 
 // inject __DEV__ as it is not available when running through the tests
 global.__DEV__ = true
@@ -20,9 +22,22 @@ mockery.registerMock('reactotron-apisauce', {})
 mockery.registerMock('react-native-animatable', {View: 'Animatable.View'})
 mockery.registerMock('react-native-vector-icons/Ionicons', {})
 
-// mock i18n as it uses react native stufff
+// Mock i18n as it uses react native stuff
+// This mock returns the interpolated text from the english.json file in App/I18n
+// If you are not using '../App/I18n/english.json' for your I18n values, simply replace import english
+// with the import at the top of this file from '../App/I18n/english.json' with the I18n json file you
+// want to use, such as "import french from '../App/I18n/fr.json'" and set 'let value = french[key]' line 31`
 mockery.registerMock('react-native-i18n', {
-  t: (key) => key
+  t: (key, replacements) => {
+    let value = english[key]
+    if (!value) return key
+    if (!replacements) return value
+
+    forEach((r) => {
+      value = replace(`{{${r}}}`, replacements[r], value)
+    }, keys(replacements))
+    return value
+  }
 })
 
 // Mock all images for React Native

--- a/ignite-base/Tests/Setup.js
+++ b/ignite-base/Tests/Setup.js
@@ -26,7 +26,7 @@ mockery.registerMock('react-native-vector-icons/Ionicons', {})
 // This mock returns the interpolated text from the english.json file in App/I18n
 // If you are not using '../App/I18n/english.json' for your I18n values, simply replace import english
 // with the import at the top of this file from '../App/I18n/english.json' with the I18n json file you
-// want to use, such as "import french from '../App/I18n/fr.json'" and set 'let value = french[key]' line 31`
+// want to use, such as "import french from '../App/I18n/fr.json'" and set 'let value = french[key]`
 mockery.registerMock('react-native-i18n', {
   t: (key, replacements) => {
     let value = english[key]


### PR DESCRIPTION
## Please verify the following:
- [x] Everything works on iOS/Android
- [x] `ignite-base` **ava** tests pass
- [x] `fireDrill.sh` passed

## Describe your PR

Updates Setup for Ava tests to add support for I18n interpolated strings
