### PR TITLE
Add OPEN_SCREEN action and saga

### DIFF
--- a/ignite-base/App/Redux/OpenScreenRedux.js
+++ b/ignite-base/App/Redux/OpenScreenRedux.js
@@ -1,0 +1,10 @@
+import { createActions } from 'reduxsauce'
+
+/* ------------- Types and Action Creators ------------- */
+
+const { Types, Creators } = createActions({
+  openScreen: ['screen', 'options']
+})
+
+export const OpenScreenTypes = Types
+export default Creators

--- a/ignite-base/App/Sagas/OpenScreenSagas.js
+++ b/ignite-base/App/Sagas/OpenScreenSagas.js
@@ -1,0 +1,12 @@
+import { call } from 'redux-saga/effects'
+import { Actions as NavigationActions, ActionConst } from 'react-native-router-flux'
+import { merge } from 'ramda'
+
+// Process OPEN_SCREEN actions, intended for use with Reactotron to open a screen via a direct dispatch
+export function * openScreen (action) {
+  const {screen, options} = action
+  // Always reset the nav stack when opening a screen via Reactotron
+  // You can override the RESET type in the options passed to the OPEN_SCREEN dispatch
+  const mergedOptions = merge({type: ActionConst.RESET}, options)
+  yield call(NavigationActions[screen], mergedOptions)
+}

--- a/ignite-base/App/Sagas/OpenScreenSagas.js
+++ b/ignite-base/App/Sagas/OpenScreenSagas.js
@@ -2,10 +2,10 @@ import { call } from 'redux-saga/effects'
 import { Actions as NavigationActions, ActionConst } from 'react-native-router-flux'
 import { merge } from 'ramda'
 
-// Process OPEN_SCREEN actions, intended for use with Reactotron to open a screen via a direct dispatch
+// Process OPEN_SCREEN actions
 export function * openScreen (action) {
   const {screen, options} = action
-  // Always reset the nav stack when opening a screen via Reactotron
+  // Always reset the nav stack when opening a screen by default
   // You can override the RESET type in the options passed to the OPEN_SCREEN dispatch
   const mergedOptions = merge({type: ActionConst.RESET}, options)
   yield call(NavigationActions[screen], mergedOptions)

--- a/ignite-base/App/Sagas/OpenScreenSagas.js
+++ b/ignite-base/App/Sagas/OpenScreenSagas.js
@@ -1,12 +1,11 @@
 import { call } from 'redux-saga/effects'
 import { Actions as NavigationActions, ActionConst } from 'react-native-router-flux'
-import { merge } from 'ramda'
 
 // Process OPEN_SCREEN actions
 export function * openScreen (action) {
-  const {screen, options} = action
+  const {screen, options = {}} = action
   // Always reset the nav stack when opening a screen by default
   // You can override the RESET type in the options passed to the OPEN_SCREEN dispatch
-  const mergedOptions = merge({type: ActionConst.RESET}, options)
+  const mergedOptions = {type: ActionConst.RESET, ...options}
   yield call(NavigationActions[screen], mergedOptions)
 }

--- a/ignite-base/App/Sagas/index.js
+++ b/ignite-base/App/Sagas/index.js
@@ -8,12 +8,14 @@ import DebugSettings from '../Config/DebugSettings'
 import { StartupTypes } from '../Redux/StartupRedux'
 import { TemperatureTypes } from '../Redux/TemperatureRedux'
 import { LoginTypes } from '../Redux/LoginRedux'
+import { OpenScreenTypes } from '../Redux/OpenScreenRedux'
 
 /* ------------- Sagas ------------- */
 
 import { startup } from './StartupSagas'
 import { login } from './LoginSagas'
 import { getTemperature } from './TemperatureSagas'
+import { openScreen } from './OpenScreenSagas'
 
 /* ------------- API ------------- */
 
@@ -28,6 +30,7 @@ export default function * root () {
     // some sagas only receive an action
     takeLatest(StartupTypes.STARTUP, startup),
     takeLatest(LoginTypes.LOGIN_REQUEST, login),
+    takeLatest(OpenScreenTypes.OPEN_SCREEN, openScreen),
 
     // some sagas receive extra parameters in addition to an action
     takeLatest(TemperatureTypes.TEMPERATURE_REQUEST, getTemperature, api)

--- a/ignite-base/Tests/Sagas/OpenScreenSagaTest.js
+++ b/ignite-base/Tests/Sagas/OpenScreenSagaTest.js
@@ -1,0 +1,21 @@
+import test from 'ava'
+import { call } from 'redux-saga/effects'
+import { openScreen } from '../../App/Sagas/OpenScreenSagas'
+import { Actions as NavigationActions, ActionConst } from 'react-native-router-flux'
+
+const stepper = (fn) => (mock) => fn.next(mock).value
+
+// Using 'myScreen' in the mocks of the arguments passed to the action for these tests is important.
+// The react-native-router-flux component is mocked in App/Tests/Setup.js to use 'myScreen'
+
+test('the right default options are passed to the navigation action', (t) => {
+  const mock = {screen: 'myScreen'}
+  const step = stepper(openScreen(mock))
+  t.deepEqual(step(), call(NavigationActions['myScreen'], {type: ActionConst.RESET}))
+})
+
+test('the right merged options are passed to the navigation action', (t) => {
+  const mock = {screen: 'myScreen', options: {type: 'replace', foo: 'bar'}}
+  const step = stepper(openScreen(mock))
+  t.deepEqual(step(), call(NavigationActions['myScreen'], {type: 'replace', foo: 'bar'}))
+})

--- a/ignite-base/Tests/Setup.js
+++ b/ignite-base/Tests/Setup.js
@@ -21,6 +21,7 @@ mockery.registerMock('reactotron-redux', {})
 mockery.registerMock('reactotron-apisauce', {})
 mockery.registerMock('react-native-animatable', {View: 'Animatable.View'})
 mockery.registerMock('react-native-vector-icons/Ionicons', {})
+mockery.registerMock('react-native-router-flux', {Actions: {'myScreen': () => {}}, ActionConst: {RESET: 'reset'}})
 
 // Mock i18n as it uses react native stuff
 // This mock returns the interpolated text from the english.json file in App/I18n


### PR DESCRIPTION
## Please verify the following:
- [x] Everything works on iOS/Android
- [x] `ignite-base` **ava** tests pass
- [x] `fireDrill.sh` passed

## Describe your PR

This adds an action ('OPEN_SCREEN') & saga to enable users to dispatch a command to open any screen. 

For Reactotron users, when generating a new app via Ignite, users can retain the useful screens generated by ignite-base, such as 'componentExamples', even if their new app bypasses any Ignite-generated screens on startup, simply by dispatching to Reactotron, like this:

```{type: 'OPEN_SCREEN', screen: 'componentExamples'}```

In addition, 'OPEN_SCREEN' is helpful while developing screens for an app that have not been set up with any nav links in the app. The developer can work on the new screen and test it via a direct dispatch from Reactotron.

The saga sets the react-native-router-flux option param to type: ActionConst.RESET by default, but users can easily override this by passing in different options. The unit test for the saga demonstrates this.


