### PR TITLE
Bug fix: redux template

### DIFF
--- a/ignite-generator/redux/templates/redux.js.template
+++ b/ignite-generator/redux/templates/redux.js.template
@@ -40,7 +40,7 @@ export const failure = state =>
 /* ------------- Hookup Reducers To Types ------------- */
 
 export const reducer = createReducer(INITIAL_STATE, {
-  [Types.<%= name.toUpperCase() %>_REQUEST]: request,
-  [Types.<%= name.toUpperCase() %>_SUCCESS]: success,
-  [Types.<%= name.toUpperCase() %>_FAILURE]: failure
+  [Types.<%= name.split(/(?=[A-Z])/).join('_') %>_REQUEST]: request,
+  [Types.<%= name.split(/(?=[A-Z])/).join('_') %>_SUCCESS]: success,
+  [Types.<%= name.split(/(?=[A-Z])/).join('_') %>_FAILURE]: failure
 })


### PR DESCRIPTION
## Please verify the following:
- [x] Everything works on iOS/Android
- [x] `ignite-base` **ava** tests pass
- [x] `fireDrill.sh` passed

## Describe your PR


The documentation for reduxsauce states that it converts the key names into
"SCREAMING_SNAKE_CASE".  The existing code didn't account for file names
with more than one word or upper case letter.  For instance, the command: ignite g redux
"CorrectHorseBatteryStaple" would have resulted in template naming the
request key "CORRECTHORSEBATTERYSTAPLE_REQUEST".  My fix splits the string
at the uppercase letters, using regex, and joins the resulting array using
"_" as the delimiter.  In the above use case the resulting request key
would now be "CORRECT_HORSE_BATTERY_STAPLE_REQUEST".

Signed-off-by: Keith Center <keith.center@excella.com>