### PR TITLE
Adds a script debugging command.

### DIFF
--- a/packages/ignite/package.json
+++ b/packages/ignite/package.json
@@ -26,7 +26,9 @@
   ],
   "license": "MIT",
   "dependencies": {
-    "gluegun": "0.3.0"
+    "gluegun": "0.4.0",
+    "minimist": "^1.2.0",
+    "ramda": "^0.22.1"
   },
   "devDependencies": {
     "ava": "^0.17.0",

--- a/packages/ignite/src/cli/cli.js
+++ b/packages/ignite/src/cli/cli.js
@@ -1,4 +1,5 @@
-const { build, printCommands } = require('gluegun')
+const minimist = require('minimist')
+const { build, printCommands, printWtf } = require('gluegun')
 const header = require('../brand/header')
 const { isNil } = require('ramda')
 
@@ -9,6 +10,9 @@ const { isNil } = require('ramda')
  * @return {RunContext}      The gluegun RunContext
  */
 module.exports = async function run (argv) {
+  // parse the cmd line
+  const cmd = minimist(argv.slice(2))
+
   // create a runtime
   const runtime = build()
     .brand('ignite')
@@ -17,6 +21,12 @@ module.exports = async function run (argv) {
     .token('commandDescription', 'cliDescription')
     .token('extensionName', 'contextExtension')
     .createRuntime()
+
+  // wtf mode shows problems with plugins, commands, and extensions
+  if (cmd.wtf) {
+    printWtf(runtime)
+    process.exit(0)
+  }
 
   // run the command
   const context = await runtime.run()


### PR DESCRIPTION
This will help debug issues loading plugins, commands, and extensions.

```
❯ bin/ignite --wtf

---------------------------------------------------------------
plugin generate
  src/cli/../plugins/generate

command container -- Problem parsing file
  Generates a redux smart component.
  src/cli/../plugins/generate/commands/container.js

{ Error: Cannot find module '../shared/generate-utils'
    at Function.Module._resolveFilename (module.js:470:15)
    at Function.Module._load (module.js:418:25)
    at require (internal/module.js:20:19)
    at Object.<anonymous> (/Users/steve/src/ir/ignite/packages/ignite/src/plugins/generate/commands/container.js:3:18)
    at Module._compile (module.js:571:32)
    at Object.Module._extensions..js (module.js:580:10)
    at Module.load (module.js:488:32)
    at tryModuleLoad (module.js:447:12)
    at Function.Module._load (module.js:439:3)
    at require (internal/module.js:20:19) code: 'MODULE_NOT_FOUND' }
```

