### PR TITLE
Upgrades to gluegun 0.5.0.

### DIFF
--- a/packages/ignite/package.json
+++ b/packages/ignite/package.json
@@ -26,7 +26,7 @@
   ],
   "license": "MIT",
   "dependencies": {
-    "gluegun": "0.4.0",
+    "gluegun": "0.5.0",
     "minimist": "^1.2.0",
     "ramda": "^0.22.1"
   },


### PR DESCRIPTION
This gets us the fixed default plugin and a better printCommands.