### PR TITLE
exclude .env from generated gitignore

### DIFF
--- a/ignite-generator/.gitignore
+++ b/ignite-generator/.gitignore
@@ -47,3 +47,7 @@ redux/index.js
 saga/index.js
 screen/index.js
 testing/index.js
+
+# Secrets
+#
+.env


### PR DESCRIPTION
## Please verify the following:
- [x] Everything works on iOS/Android
- [x] `ignite-base` **ava** tests pass
- [x] `fireDrill.sh` passed

## Describe your PR
Not really changing much here (I think) but when I went to update an environment variable, I noticed that the file was tracked by git. This should keep your secrets safe and sound.