### PR TITLE
fix flash of pink when opening screen

### DIFF
--- a/ignite-base/App/Navigation/Styles/NavigationDrawerStyle.js
+++ b/ignite-base/App/Navigation/Styles/NavigationDrawerStyle.js
@@ -7,6 +7,6 @@ export default {
     backgroundColor: Colors.background
   },
   main: {
-    backgroundColor: Colors.ember
+    backgroundColor: Colors.clear
   }
 }


### PR DESCRIPTION
## Please verify the following:
- [x ] Everything works on iOS/Android
- [x] `ignite-base` **ava** tests pass
- [ x] `fireDrill.sh` passed

## Describe your PR

Fixes a flash of pink in a screen from an Ignited project when the project uses the default NavigationRouter (with the drawer!) by setting the backgroundColor of main in NavigationDrawerStyle.js from Color.ember to Color.clear. Word on the street is that this has been an issue for other ignited projects, and this proposed fix should solve it. It fixed the pink flash issue for my current ignited project

Note: fireDrill.sh passed, unit tests pass, lint passes, tested in iOS and it passes, but could not test in Android.