### PR TITLE
Decouple Ignite themes from ignited app

### DIFF
--- a/ignite-base/App/Components/Styles/CustomNavBarStyle.js
+++ b/ignite-base/App/Components/Styles/CustomNavBarStyle.js
@@ -8,7 +8,7 @@ export default {
     right: 0,
     height: Metrics.navBarHeight,
     paddingHorizontal: Metrics.baseMargin,
-    backgroundColor: Colors.background,
+    backgroundColor: Colors.igniteBackground,
     flexDirection: 'row',
     alignItems: 'center',
     justifyContent: 'space-between'

--- a/ignite-base/App/Containers/Styles/ListviewExampleStyle.js
+++ b/ignite-base/App/Containers/Styles/ListviewExampleStyle.js
@@ -8,7 +8,7 @@ export default StyleSheet.create({
   container: {
     flex: 1,
     marginTop: Metrics.navBarHeight,
-    backgroundColor: Colors.background
+    backgroundColor: Colors.igniteBackground
   },
   row: {
     flex: 1,

--- a/ignite-base/App/Containers/Styles/ListviewGridExampleStyle.js
+++ b/ignite-base/App/Containers/Styles/ListviewGridExampleStyle.js
@@ -8,7 +8,7 @@ export default StyleSheet.create({
   container: {
     flex: 1,
     marginTop: Metrics.navBarHeight,
-    backgroundColor: Colors.background
+    backgroundColor: Colors.igniteBackground
   },
   row: {
     width: 100,

--- a/ignite-base/App/Containers/Styles/LoginScreenStyle.js
+++ b/ignite-base/App/Containers/Styles/LoginScreenStyle.js
@@ -6,7 +6,7 @@ import { Colors, Metrics } from '../../Themes'
 export default StyleSheet.create({
   container: {
     paddingTop: 70,
-    backgroundColor: Colors.background
+    backgroundColor: Colors.igniteBackground
   },
   form: {
     backgroundColor: Colors.snow,

--- a/ignite-base/App/Containers/Styles/RootContainerStyle.js
+++ b/ignite-base/App/Containers/Styles/RootContainerStyle.js
@@ -10,7 +10,7 @@ export default StyleSheet.create({
   container: {
     flex: 1,
     justifyContent: 'center',
-    backgroundColor: Colors.background
+    backgroundColor: Colors.igniteBackground
   },
   welcome: {
     fontSize: 20,

--- a/ignite-base/App/Navigation/Styles/CustomNavBarStyle.js
+++ b/ignite-base/App/Navigation/Styles/CustomNavBarStyle.js
@@ -9,7 +9,7 @@ export default {
     height: Metrics.navBarHeight,
     paddingTop: Metrics.smallMargin,
     paddingHorizontal: 5,
-    backgroundColor: Colors.background,
+    backgroundColor: Colors.igniteBackground,
     flexDirection: 'row',
     justifyContent: 'space-between'
   },

--- a/ignite-base/App/Navigation/Styles/NavigationContainerStyle.js
+++ b/ignite-base/App/Navigation/Styles/NavigationContainerStyle.js
@@ -7,7 +7,7 @@ export default {
     flex: 1
   },
   navBar: {
-    backgroundColor: Colors.background
+    backgroundColor: Colors.igniteBackground
   },
   title: {
     color: Colors.snow

--- a/ignite-base/App/Navigation/Styles/NavigationDrawerStyle.js
+++ b/ignite-base/App/Navigation/Styles/NavigationDrawerStyle.js
@@ -4,7 +4,7 @@ import {Colors} from '../../Themes/'
 
 export default {
   drawer: {
-    backgroundColor: Colors.background
+    backgroundColor: Colors.igniteBackground
   },
   main: {
     backgroundColor: Colors.clear

--- a/ignite-base/App/Themes/Colors.js
+++ b/ignite-base/App/Themes/Colors.js
@@ -1,7 +1,9 @@
 // @flow
 
-const colors = {
-  background: '#1F0808',
+import { merge } from 'ramda'
+
+const igniteColors = {
+  igniteBackground: '#1F0808',
   clear: 'rgba(0,0,0,0)',
   facebook: '#3b5998',
   transparent: 'rgba(0,0,0,0)',
@@ -21,5 +23,9 @@ const colors = {
   fire: '#e73536',
   drawer: 'rgba(30, 30, 29, 0.95)'
 }
+
+const colors = merge(igniteColors, {
+  // add colors for your Ignited app here
+})
 
 export default colors

--- a/ignite-base/App/Themes/Colors.js
+++ b/ignite-base/App/Themes/Colors.js
@@ -1,7 +1,5 @@
 // @flow
 
-import { merge } from 'ramda'
-
 const igniteColors = {
   igniteBackground: '#1F0808',
   clear: 'rgba(0,0,0,0)',
@@ -24,8 +22,9 @@ const igniteColors = {
   drawer: 'rgba(30, 30, 29, 0.95)'
 }
 
-const colors = merge(igniteColors, {
+const colors = {
+  ...igniteColors
   // add colors for your Ignited app here
-})
+}
 
 export default colors

--- a/ignite-base/App/Themes/Fonts.js
+++ b/ignite-base/App/Themes/Fonts.js
@@ -1,12 +1,18 @@
 // @flow
 
-const type = {
+import { merge } from 'ramda'
+
+const igniteType = {
   base: 'HelveticaNeue',
   bold: 'HelveticaNeue-Bold',
   emphasis: 'HelveticaNeue-Italic'
 }
 
-const size = {
+const type = merge(igniteType, {
+  // Add font types for your Ignited app here
+})
+
+const igniteSize = {
   h1: 38,
   h2: 34,
   h3: 30,
@@ -20,7 +26,11 @@ const size = {
   tiny: 8.5
 }
 
-const style = {
+const size = merge(igniteSize, {
+  // Add font sizes for your Ignited app here
+})
+
+const igniteStyle = {
   h1: {
     fontFamily: type.base,
     fontSize: size.h1
@@ -54,6 +64,10 @@ const style = {
     fontSize: size.medium
   }
 }
+
+const style = merge(igniteStyle, {
+  // Add font styles for your Ignited app here
+})
 
 export default {
   type,

--- a/ignite-base/App/Themes/Fonts.js
+++ b/ignite-base/App/Themes/Fonts.js
@@ -1,16 +1,15 @@
 // @flow
 
-import { merge } from 'ramda'
-
 const igniteType = {
   base: 'HelveticaNeue',
   bold: 'HelveticaNeue-Bold',
   emphasis: 'HelveticaNeue-Italic'
 }
 
-const type = merge(igniteType, {
+const type = {
+  ...igniteType
   // Add font types for your Ignited app here
-})
+}
 
 const igniteSize = {
   h1: 38,
@@ -26,9 +25,10 @@ const igniteSize = {
   tiny: 8.5
 }
 
-const size = merge(igniteSize, {
+const size = {
+  ...igniteSize
   // Add font sizes for your Ignited app here
-})
+}
 
 const igniteStyle = {
   h1: {
@@ -65,9 +65,10 @@ const igniteStyle = {
   }
 }
 
-const style = merge(igniteStyle, {
+const style = {
+  ...igniteStyle
   // Add font styles for your Ignited app here
-})
+}
 
 export default {
   type,

--- a/ignite-base/App/Themes/Images.js
+++ b/ignite-base/App/Themes/Images.js
@@ -1,7 +1,5 @@
 // @flow
 
-import { merge } from 'ramda'
-
 // leave off @2x/@3x
 const igniteImages = {
   logo: require('../Images/ir.png'),
@@ -11,8 +9,9 @@ const igniteImages = {
   background: require('../Images/BG.png')
 }
 
-const images = merge(igniteImages, {
+const images = {
+  ...igniteImages
   // Add images for your Ignited app here
-})
+}
 
 export default images

--- a/ignite-base/App/Themes/Images.js
+++ b/ignite-base/App/Themes/Images.js
@@ -1,12 +1,18 @@
 // @flow
 
+import { merge } from 'ramda'
+
 // leave off @2x/@3x
-const images = {
+const igniteImages = {
   logo: require('../Images/ir.png'),
   clearLogo: require('../Images/top_logo.png'),
   ignite: require('../Images/ignite_logo.png'),
   tileBg: require('../Images/tile_bg.png'),
   background: require('../Images/BG.png')
 }
+
+const images = merge(igniteImages, {
+  // Add images for your Ignited app here
+})
 
 export default images

--- a/ignite-generator/container/templates/container-style.js.template
+++ b/ignite-generator/container/templates/container-style.js.template
@@ -7,6 +7,6 @@ export default StyleSheet.create({
   container: {
     flex: 1,
     marginTop: Metrics.navBarHeight,
-    backgroundColor: Colors.background
+    backgroundColor: Colors.igniteBackground
   }
 })

--- a/ignite-generator/listview/templates/gridlistview-style.js.template
+++ b/ignite-generator/listview/templates/gridlistview-style.js.template
@@ -8,7 +8,7 @@ export default StyleSheet.create({
   container: {
     flex: 1,
     marginTop: Metrics.navBarHeight,
-    backgroundColor: Colors.background
+    backgroundColor: Colors.igniteBackground
   },
   row: {
     width: 100,

--- a/ignite-generator/listview/templates/listview-style.js.template
+++ b/ignite-generator/listview/templates/listview-style.js.template
@@ -8,7 +8,7 @@ export default StyleSheet.create({
   container: {
     flex: 1,
     marginTop: Metrics.navBarHeight,
-    backgroundColor: Colors.background
+    backgroundColor: Colors.igniteBackground
   },
   row: {
     flex: 1,


### PR DESCRIPTION
## Please verify the following:
- [x] Everything works on iOS/Android
- [x] `ignite-base` **ava** tests pass
- [x] `fireDrill.sh` passed

## Describe your PR
This PR decouples default themes (Colors, Fonts, Images) generated by ignite-base from themes that developers need to create for their Ignited apps. Each of these theme files now provide an empty object with a comment that tells the developer to add values for their own Ignited app.
