### PR TITLE
Added multiDex support

### DIFF
--- a/ignite-base/android/app/build.gradle
+++ b/ignite-base/android/app/build.gradle
@@ -93,6 +93,7 @@ android {
         targetSdkVersion 22
         versionCode 1
         versionName "1.0"
+        multiDexEnabled true
         ndk {
             abiFilters "armeabi-v7a", "x86"
         }


### PR DESCRIPTION
> "Android application (APK) files contain executable bytecode files in the form of Dalvik Executable (DEX) files, which contain the compiled code used to run your app. The Dalvik Executable specification limits the total number of methods that can be referenced within a single DEX file to 65,536, including Android framework methods, library methods, and methods in your own code. Getting past this limit requires that you configure your app build process to generate more than one DEX file, known as a multidex configuration."

Preventing `Execution failed for task ':app:dexDebug'` error `finished with non-zero exit value 2` by modifying the `build.gradle` file.
