### PR TITLE
Adjust the README in usage section

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,14 +79,15 @@ For those of you unfamiliar with the new package manager Yarn, it's basically a 
 ## :arrow_forward: How to Run Generated App
 
 1. cd to the repo
-2. Run Build for either OS
+2. `npm install` or `yarn install`
+3. Run Build for either OS
   * for iOS
     * run the command `react-native run-ios`
   * for Android
     * Run Genymotion
     * run the command `react-native run-android`
-3. If the packager does not automatically start, run `npm start` or `yarn start`
-4. _**Enjoy!**_
+4. If the packager does not automatically start, run `npm start` or `yarn start`
+5. _**Enjoy!**_
 
 ![install](_art/screens.gif)
 


### PR DESCRIPTION
Add an additional step to the usage section. The app does not run before using yarn install or npm install

## Please verify the following:
- [x ] Everything works on iOS/Android
- [x ] `ignite-base` **ava** tests pass
- [x ] `fireDrill.sh` passed

## Describe your PR

While testing ignite and following the instructions the app does not start after generation. So i test yarn install to fix the issue and it worked out. Therefore i think the step is still missing in the documentation ;)