### PR TITLE
Hides user-defined plugins from the CLI.

### DIFF
--- a/packages/ignite/package.json
+++ b/packages/ignite/package.json
@@ -26,7 +26,7 @@
   ],
   "license": "MIT",
   "dependencies": {
-    "gluegun": "0.7.3",
+    "gluegun": "0.8.0",
     "gluegun-patching": "^0.3.0",
     "json2toml": "^1.0.6",
     "minimist": "^1.2.0",

--- a/packages/ignite/src/cli/cli.js
+++ b/packages/ignite/src/cli/cli.js
@@ -18,7 +18,7 @@ module.exports = async function run (argv) {
     .brand('ignite')
     .configFile('ignite.toml')
     .loadDefault(`${__dirname}/../plugins/default`)
-    .loadAll(`${process.cwd()}/node_modules`, 'ignite-*')
+    .loadAll(`${process.cwd()}/node_modules`, { matching: 'ignite-*', hidden: true })
     .token('commandName', 'cliCommand')
     .token('commandDescription', 'cliDescription')
     .token('extensionName', 'contextExtension')


### PR DESCRIPTION
All plugins living in `node_modules/ignite-*` will now be hidden from the command line.