### PR TITLE
Ensures uppercase when creating reducers with the redux generator.

### DIFF
--- a/ignite-generator/redux/templates/redux.js.template
+++ b/ignite-generator/redux/templates/redux.js.template
@@ -40,7 +40,7 @@ export const failure = state =>
 /* ------------- Hookup Reducers To Types ------------- */
 
 export const reducer = createReducer(INITIAL_STATE, {
-  [Types.<%= name.split(/(?=[A-Z])/).join('_') %>_REQUEST]: request,
-  [Types.<%= name.split(/(?=[A-Z])/).join('_') %>_SUCCESS]: success,
-  [Types.<%= name.split(/(?=[A-Z])/).join('_') %>_FAILURE]: failure
+  [Types.<%= name.split(/(?=[A-Z])/).join('_').toUpperCase() %>_REQUEST]: request,
+  [Types.<%= name.split(/(?=[A-Z])/).join('_').toUpperCase() %>_SUCCESS]: success,
+  [Types.<%= name.split(/(?=[A-Z])/).join('_').toUpperCase() %>_FAILURE]: failure
 })


### PR DESCRIPTION
This is a fix for #578.

The redux generator now will uppercase the `createReducer()` keys.