### PR TITLE
Adds ignite plugin path and improves ignite add support.

### DIFF
--- a/packages/ignite-empty-playground/ignite.toml
+++ b/packages/ignite-empty-playground/ignite.toml
@@ -1,2 +1,3 @@
 [ignite]
 createdWith = "2.0pre"
+examples = "classic"

--- a/packages/ignite-empty-playground/package.json
+++ b/packages/ignite-empty-playground/package.json
@@ -12,5 +12,8 @@
     "ignite-vector-icons": "^0.1.0",
     "react-native-vector-icons": "^3.0.0"
   },
-  "dependencies": {}
+  "dependencies": {
+    "ignite-vector-icons": "^0.1.0",
+    "react-native-vector-icons": "^3.0.0"
+  }
 }

--- a/packages/ignite-empty-playground/package.json
+++ b/packages/ignite-empty-playground/package.json
@@ -8,12 +8,8 @@
   "devDependencies": {
     "ignite": "2.0.0",
     "ignite-basic-generators": "0.2.0",
-    "ignite-basic-structure": "0.0.1",
-    "ignite-vector-icons": "^0.1.0",
-    "react-native-vector-icons": "^3.0.0"
+    "ignite-basic-structure": "0.0.1"
   },
   "dependencies": {
-    "ignite-vector-icons": "^0.1.0",
-    "react-native-vector-icons": "^3.0.0"
   }
 }

--- a/packages/ignite-vector-icons/index.js
+++ b/packages/ignite-vector-icons/index.js
@@ -1,19 +1,33 @@
-const sourceFolder = `${process.cwd()}/node_modules/ignite-vector-icons/templates/`
-const fileName = 'vectorExample.js'
+const NPM_MODULE_NAME = 'react-native-vector-icons'
+const EXAMPLE_FILE = 'vectorExample.js'
 
+/**
+ * Add ourself to the project.
+ */
 const add = async function (context) {
   const { ignite } = context
-  // knows to add via npm/yarn with visual
-  ignite.addModule('react-native-vector-icons')
-  // copy examples - if examples are live
-  ignite.addComponentExample(sourceFolder, fileName)
+
+  // install a npm module
+  await ignite.addModule(NPM_MODULE_NAME, { link: true })
+
+  // copy the example file (if examples are turned on)
+  await ignite.addComponentExample(EXAMPLE_FILE, { title: 'Vector Icons' })
 }
 
+/**
+ * Remove ourself from the project.
+ */
 const remove = async function (context) {
-  const { print, ignite } = context
-  ignite.removeModule('react-native-vector-icons')
-  // remove examples
-  ignite.removeComponentExample(vectorComponentExample)
+  const { ignite } = context
+
+  // remove the npm module
+  await ignite.removeModule(NPM_MODULE_NAME, { link: true })
+
+  // remove the component example
+  await ignite.removeComponentExample(EXAMPLE_FILE)
 }
 
+/**
+ * Expose an ignite plugin interface.
+ */
 module.exports = { add, remove }

--- a/packages/ignite-vector-icons/templates/vectorExample.js.ejs
+++ b/packages/ignite-vector-icons/templates/vectorExample.js.ejs
@@ -5,7 +5,7 @@ import { View, TouchableOpacity } from 'react-native'
 import ExamplesRegistry from '../Services/ExamplesRegistry'
 
 // Example
-ExamplesRegistry.add('Alert Message', () =>
+ExamplesRegistry.add('<%= props.title %>', () =>
   <View style={styles.groupContainer}>
     <TouchableOpacity onPress={this.handlePressRocket}>
       <Icon name='rocket' size={Metrics.icons.medium} color={Colors.ember} />


### PR DESCRIPTION
This PR adds a round of fun to the `ignite add` command.

* Gluegun now supports configurable template directories, so here's support for that + 1 example (vector-icons). Basic structure is next, but not part of this PR because I want to do something awesome with bulk template generation in gluegun.

* Switched `Shell.exec` to `context.system.run`.

* Added a switch called `--npm` to `ignite add` because `yarn` insists on validating existing modules against npm.  Since ignite 2.0 isn't shipped, this blows up `yarn`.  But not `npm`.

* Adds better code docs inside the `ignite` gluegun plugin.

* Adds support for ignite 3rd party folk to opt-in to `react-native link` and installing modules as dev dependencies.

* Added some try/catches in order to centralize error messages.
