### PR TITLE
during startup, we now have a check if everything is loaded already from storage.

### DIFF
--- a/ignite-base/App/Containers/PresentationScreen.js
+++ b/ignite-base/App/Containers/PresentationScreen.js
@@ -1,7 +1,9 @@
 // @flow
 
-import React from 'react'
+import React, { PropTypes } from 'react'
 import { ScrollView, Text, Image, View } from 'react-native'
+import { connect } from 'react-redux'
+import { isLoadedFromStorage } from '../Redux/StartupRedux'
 import { Images } from '../Themes'
 import RoundedButton from '../Components/RoundedButton'
 import { Actions as NavigationActions } from 'react-native-router-flux'
@@ -9,8 +11,9 @@ import { Actions as NavigationActions } from 'react-native-router-flux'
 // Styles
 import styles from './Styles/PresentationScreenStyle'
 
-export default class PresentationScreen extends React.Component {
+class PresentationScreen extends React.Component {
   render () {
+    const { loadedFromStorage } = this.props
     return (
       <View style={styles.mainContainer}>
         <Image source={Images.background} style={styles.backgroundImage} resizeMode='stretch' />
@@ -25,6 +28,10 @@ export default class PresentationScreen extends React.Component {
               are available below.
             </Text>
           </View>
+
+          <Text style={styles.sectionText} >
+            {loadedFromStorage ? 'Storage loaded' : 'Loading from storage..'}
+          </Text>
 
           <RoundedButton onPress={NavigationActions.componentExamples}>
             Component Examples Screen
@@ -55,3 +62,15 @@ export default class PresentationScreen extends React.Component {
     )
   }
 }
+
+PresentationScreen.propTypes = {
+  loadedFromStorage: PropTypes.bool
+}
+
+const mapStateToProps = (state) => {
+  return {
+    loadedFromStorage: isLoadedFromStorage(state.startup)
+  }
+}
+
+export default connect(mapStateToProps, null)(PresentationScreen)

--- a/ignite-base/App/Redux/StartupRedux.js
+++ b/ignite-base/App/Redux/StartupRedux.js
@@ -1,6 +1,7 @@
 // @flow
 
-import { createActions } from 'reduxsauce'
+import { createReducer, createActions } from 'reduxsauce'
+import Immutable from 'seamless-immutable'
 
 /* ------------- Types and Action Creators ------------- */
 
@@ -10,3 +11,25 @@ const { Types, Creators } = createActions({
 
 export const StartupTypes = Types
 export default Creators
+
+/* ------------- Initial State ------------- */
+
+export const INITIAL_STATE = Immutable({
+  loadedFromStorage: false
+})
+
+/* ------------- Reducers ------------- */
+
+// we just loaded from storage
+export const startup = (state: Object) => state.merge({ loadedFromStorage: true })
+
+/* ------------- Hookup Reducers To Types ------------- */
+
+export const reducer = createReducer(INITIAL_STATE, {
+  [Types.STARTUP]: startup
+})
+
+/* ------------- Selectors ------------- */
+
+// Is storage loaded already?
+export const isLoadedFromStorage = (startupState: Object) => startupState.loadedFromStorage

--- a/ignite-base/App/Redux/index.js
+++ b/ignite-base/App/Redux/index.js
@@ -7,6 +7,7 @@ import rootSaga from '../Sagas/'
 export default () => {
   /* ------------- Assemble The Reducers ------------- */
   const rootReducer = combineReducers({
+    startup: require('./StartupRedux').reducer,
     temperature: require('./TemperatureRedux').reducer,
     login: require('./LoginRedux').reducer,
     search: require('./SearchRedux').reducer


### PR DESCRIPTION

## Please verify the following:
- [X] Everything works on iOS/Android
- [X] `ignite-base` **ava** tests pass
- [X] `fireDrill.sh` passed

## Describe your PR
for example, before, if a user was logged in, the log in button would show up for a split second while the async storage loaded, and when it was finally loaded, it would swap for a log out button. now, we can have a check if the storage is loaded, so we can display an animation or a spinner, and then immediately show the log out button. no more flashing from log in -> log out.
