### PR TITLE
Adds Ignite 2.0 Plugin Developer Quality of Life

### DIFF
--- a/packages/ignite-basic-generators/index.js
+++ b/packages/ignite-basic-generators/index.js
@@ -1,9 +1,7 @@
 const add = async function (context) {
-  console.log('Adding Ignite Basic Generators')
 }
 
 const remove = async function (context) {
-  console.log('Removing Ignite Basic Generators')
 }
 
 module.exports = { add, remove }

--- a/packages/ignite-basic-generators/package.json
+++ b/packages/ignite-basic-generators/package.json
@@ -4,8 +4,5 @@
   "devEngines": {
     "node": ">=7.x",
     "npm": ">=4.x"
-  },
-  "dependencies": {
-    "ignite": "2.0.0"
   }
 }

--- a/packages/ignite-basic-structure/index.js
+++ b/packages/ignite-basic-structure/index.js
@@ -3,7 +3,6 @@ const generate = require('./shared/generate-utils')
 
 const add = async function (context) {
   const { filesystem, parameters } = context
-  console.log('Adding Ignite Basic Structure')
 
   const copyJobs = [
     // {

--- a/packages/ignite-basic-structure/package.json
+++ b/packages/ignite-basic-structure/package.json
@@ -4,8 +4,5 @@
   "devEngines": {
     "node": ">=7.x",
     "npm": ">=4.x"
-  },
-  "dependencies": {
-    "ignite": "2.0.0"
   }
 }

--- a/packages/ignite-vector-icons/package.json
+++ b/packages/ignite-vector-icons/package.json
@@ -5,7 +5,9 @@
     "node": ">=7.x",
     "npm": ">=4.x"
   },
-  "dependencies": {
-    "ignite": "2.0.0"
-  }
+  "files": [
+    "ignite.toml",
+    "index.js",
+    "templates"
+  ]
 }

--- a/packages/ignite/package.json
+++ b/packages/ignite/package.json
@@ -30,7 +30,6 @@
     "gluegun-patching": "^0.3.0",
     "json2toml": "^1.0.6",
     "minimist": "^1.2.0",
-    "npm-exists": "^0.1.0",
     "ramda": "^0.22.1",
     "ramdasauce": "^1.1.1",
     "shelljs": "^0.7.5",

--- a/packages/ignite/package.json
+++ b/packages/ignite/package.json
@@ -32,6 +32,7 @@
     "minimist": "^1.2.0",
     "npm-exists": "^0.1.0",
     "ramda": "^0.22.1",
+    "ramdasauce": "^1.1.1",
     "shelljs": "^0.7.5",
     "toml": "^2.3.1"
   },

--- a/packages/ignite/src/lib/detectedChanges.js
+++ b/packages/ignite/src/lib/detectedChanges.js
@@ -1,0 +1,16 @@
+const { keys, intersection, reduce, concat } = require('ramda')
+
+// used for changes warnings
+const detectedChanges = (oldObject, newObject) => {
+  let oldKeys = keys(oldObject)
+  let newKeys = keys(newObject)
+  const inter = intersection(oldKeys, newKeys)
+  return reduce((acc, k) => {
+    if (oldObject[k] !== newObject[k]) {
+      return concat([`'${k}'`], acc)
+    }
+    return acc
+  }, [], inter)
+}
+
+module.exports = detectedChanges

--- a/packages/ignite/src/lib/exitCodes.js
+++ b/packages/ignite/src/lib/exitCodes.js
@@ -1,0 +1,25 @@
+/**
+ * Exit codes used to off the app.
+ */
+module.exports = {
+  /**
+   * A peaceful & expected death.
+   */
+  OK: 0,
+
+  /**
+   * A generic and unexpected ending for our hero.
+   */
+  GENERIC: 1,
+
+  /**
+   * This is not a normal ignite plugin.
+   */
+  PLUGIN_INVALID: 2,
+
+  /**
+   * An ignite plugin bombed while installing.
+   */
+  PLUGIN_INSTALL: 3
+
+}

--- a/packages/ignite/src/plugins/default/commands/add.js
+++ b/packages/ignite/src/plugins/default/commands/add.js
@@ -1,8 +1,7 @@
 // @cliDescription  Add a new thingy
 // ----------------------------------------------------------------------------
-// const Exists = require('npm-exists')
+
 const Toml = require('toml')
-// Yeah, why would toml include this? :(
 const json2toml = require('json2toml')
 const R = require('ramda')
 const { dotPath } = require('ramdasauce')

--- a/packages/ignite/src/plugins/default/commands/add.js
+++ b/packages/ignite/src/plugins/default/commands/add.js
@@ -7,6 +7,7 @@ const R = require('ramda')
 const { dotPath } = require('ramdasauce')
 const detectedChanges = require('../../../lib/detectedChanges')
 const detectInstall = require('./add/detectInstall')
+const exitCodes = require('../../../lib/exitCodes')
 
 /**
  * Removes the ignite plugin.
@@ -62,7 +63,7 @@ Examples:
   ignite add gantman/ignite-react-native-config
   ignite add /path/to/plugin/you/are/building`
     info(instructions)
-    return
+    process.exit(exitCodes.OK)
   }
 
   // find out the type of install
@@ -75,7 +76,7 @@ Examples:
     await importPlugin(context, specs)
   } else {
     error(`💩  invalid ignite plugin`)
-    return
+    process.exit(exitCodes.PLUGIN_INVALID)
   }
 
   // the full path to the module installed within node_modules
@@ -87,7 +88,7 @@ Examples:
   if (!filesystem.exists(tomlFilePath)) {
     error('💩  no `ignite.toml` file found in this node module, are you sure it is an Ignite plugin?')
     await removeIgnitePlugin(moduleName, context)
-    return
+    process.exit(exitCodes.PLUGIN_INVALID)
   }
   const newConfig = Toml.parse(filesystem.read(tomlFilePath))
 
@@ -105,29 +106,42 @@ Examples:
       // if they refuse, then npm/yarn uninstall
     if (!ok) {
       await removeIgnitePlugin(moduleName, context)
-      return
+      process.exit(exitCodes.OK)
     }
   }
 
-  const combinedGenerators = Object.assign({}, currentGenerators, proposedGenerators)
-  const updatedConfig = R.assocPath(['ignite', 'generators'], combinedGenerators, context.config)
-
-  // We write the toml changes
-  const localToml = `${process.cwd()}/ignite.toml`
-  filesystem.write(localToml, json2toml(updatedConfig))
-
-  // bring the ignite plugin to life
-  const pluginModule = require(modulePath)
-
-  // set the path to the current running ignite plugin
-  ignite.setIgnitePluginPath(modulePath)
-
+  // ok, are we ready?
   try {
-    // and then call the add function
-    await pluginModule.add(context)
-    success('🍽  time to get cooking!')
+    // bring the ignite plugin to life
+    const pluginModule = require(modulePath)
+
+    // set the path to the current running ignite plugin
+    ignite.setIgnitePluginPath(modulePath)
+
+    // now let's try to run it
+    try {
+      await pluginModule.add(context)
+
+      // We write the toml changes
+      const combinedGenerators = Object.assign({}, currentGenerators, proposedGenerators)
+      const updatedConfig = R.assocPath(['ignite', 'generators'], combinedGenerators, context.config)
+      const localToml = `${process.cwd()}/ignite.toml`
+      filesystem.write(localToml, json2toml(updatedConfig))
+
+      // Sweet! We did it!
+      success('🍽  time to get cooking!')
+      process.exit(exitCodes.OK)
+    } catch (err) {
+      // it's up to the throwers of this error to ensure the error message is human friendly.
+      // to do this, we need to ensure all our core features like `addModule`, `addComponentExample`, etc
+      // all play along nicely.
+      error(err.message)
+      process.exit(exitCodes.PLUGIN_INSTALL)
+    }
   } catch (err) {
-      // write the error message out
-    error(err.message)
+    // we couldn't require the plugin, it probably has some nasty js!
+    error('💩  problem loading the plugin JS')
+    await removeIgnitePlugin(moduleName, context)
+    process.exit(exitCodes.PLUGIN_INVALID)
   }
 }

--- a/packages/ignite/src/plugins/default/commands/add.js
+++ b/packages/ignite/src/plugins/default/commands/add.js
@@ -1,23 +1,13 @@
 // @cliDescription  Add a new thingy
 // ----------------------------------------------------------------------------
-const Exists = require('npm-exists')
+// const Exists = require('npm-exists')
 const Toml = require('toml')
 // Yeah, why would toml include this? :(
 const json2toml = require('json2toml')
 const R = require('ramda')
-
-// used for changes warnings
-const detectedChanges = (oldObject, newObject) => {
-  let oldKeys = R.keys(oldObject)
-  let newKeys = R.keys(newObject)
-  const inter = R.intersection(oldKeys, newKeys)
-  return R.reduce((acc, k) => {
-    if (oldObject[k] !== newObject[k]) {
-      return R.concat([`'${k}'`], acc)
-    }
-    return acc
-  }, [], inter)
-}
+const { dotPath } = require('ramdasauce')
+const detectedChanges = require('../../../lib/detectedChanges')
+const detectInstall = require('./add/detectInstall')
 
 /**
  * Removes the ignite plugin.
@@ -37,81 +27,108 @@ const removeIgnitePlugin = async (moduleName, context) => {
   }
 }
 
+/**
+ * Install this module.
+ *
+ * @param {Object} context         The gluegun context
+ * @param {Object} opts            The options used to install
+ * @param {string} opts.moduleName The module to install
+ */
+async function importPlugin (context, opts) {
+  const { moduleName, type, directory } = opts
+  const { system, ignite } = context
+  const target = type === 'directory' ? directory : moduleName
+
+  if (ignite.useYarn) {
+    await system.run(`yarn add ${target} --dev`)
+  } else {
+    await system.run(`npm i ${target} --save-dev`)
+  }
+}
+
 module.exports = async function (context) {
     // grab a fist-full of features...
-  const { print, filesystem, parameters, prompt, ignite, system } = context
-  const { info, warning, success, checkmark, error } = print
+  const { print, filesystem, prompt, ignite, parameters, strings } = context
+  const { info, warning, success, error } = print
+  const currentGenerators = dotPath('config.ignite.generators', context) || {}
 
-  // take the last parameter (because of https://github.com/infinitered/gluegun/issues/123)
-  // prepend `ignite` as convention
-  const moduleName = `ignite-${parameters.array.pop()}`
-  info(`🔎    Finding ${moduleName} on npmjs.com`)
-  const moduleExists = await Exists(moduleName)
-  // it exists?  Let's install it else warn
-  if (moduleExists) {
-    info(`${checkmark}    Installing npm module`)
+  // the thing we're trying to install
+  if (strings.isBlank(parameters.second)) {
+    const instructions = `An ignite plugin is required.
 
-    // Let's install the `ignite-*` plugin.  These are dev dependencies.
-    if (ignite.useYarn) {
-      system.run(`yarn add ${moduleName} --dev`)
-    } else {
-      system.run(`npm i ${moduleName} --save-dev`)
-    }
+Examples:
+  ignite add ignite-basic-structure
+  ignite add ignite-basic-generators
+  ignite add vector-icons
+  ignite add gantman/ignite-react-native-config
+  ignite add /path/to/plugin/you/are/building`
+    info(instructions)
+    return
+  }
 
-    // the full path to the module installed within node_modules
-    const modulePath = `${process.cwd()}/node_modules/${moduleName}`
+  // find out the type of install
+  const specs = detectInstall(context)
+  const { moduleName } = specs
 
-    // once installed, let's check on its toml
-    const tomlFilePath = `${modulePath}/ignite.toml`
-    if (!filesystem.exists(tomlFilePath)) {
-      error('No `ignite.toml` file found in this node module, are you sure it is an Ignite plugin?')
+  // import the ignite plugin node module
+  info(`🔥  installing ${print.colors.cyan(moduleName)}`)
+  if (specs.type) {
+    await importPlugin(context, specs)
+  } else {
+    error(`💩  invalid ignite plugin`)
+    return
+  }
+
+  // the full path to the module installed within node_modules
+  const modulePath = `${process.cwd()}/node_modules/${moduleName}`
+
+  // once installed, let's check on its toml
+  const tomlFilePath = `${modulePath}/ignite.toml`
+
+  if (!filesystem.exists(tomlFilePath)) {
+    error('💩  no `ignite.toml` file found in this node module, are you sure it is an Ignite plugin?')
+    await removeIgnitePlugin(moduleName, context)
+    return
+  }
+  const newConfig = Toml.parse(filesystem.read(tomlFilePath))
+
+  const proposedGenerators = R.reduce((acc, k) => {
+    acc[k] = moduleName
+    return acc
+  }, {}, newConfig.ignite.generators || [])
+
+  // we compare the toml changes against ours
+  const changes = detectedChanges(currentGenerators, proposedGenerators)
+  if (changes.length > 0) {
+      // we warn the user on changes
+    warning(`🔥  The following generators would be changed: ${R.join(', ', changes)}`)
+    const ok = await prompt.confirm('You ok with that?')
+      // if they refuse, then npm/yarn uninstall
+    if (!ok) {
       await removeIgnitePlugin(moduleName, context)
       return
     }
-    const newConfig = Toml.parse(filesystem.read(tomlFilePath))
+  }
 
-    const proposedGenerators = R.reduce((acc, k) => {
-      acc[k] = moduleName
-      return acc
-    }, {}, newConfig.ignite.generators || [])
+  const combinedGenerators = Object.assign({}, currentGenerators, proposedGenerators)
+  const updatedConfig = R.assocPath(['ignite', 'generators'], combinedGenerators, context.config)
 
-    // we compare the toml changes against ours
-    const changes = detectedChanges(context.config.ignite.generators, proposedGenerators)
-    if (changes.length > 0) {
-      // we warn the user on changes
-      warning(`The following generators would be changed: ${R.join(', ', changes)}`)
-      const ok = await prompt.confirm('You ok with that?')
-      // if they refuse, then npm/yarn uninstall
-      if (!ok) {
-        await removeIgnitePlugin(moduleName, context)
-        return
-      }
-    }
+  // We write the toml changes
+  const localToml = `${process.cwd()}/ignite.toml`
+  filesystem.write(localToml, json2toml(updatedConfig))
 
-    const combinedGenerators = Object.assign({}, context.config.ignite.generators, proposedGenerators)
-    const updatedConfig = R.assocPath(['ignite', 'generators'], combinedGenerators, context.config)
+  // bring the ignite plugin to life
+  const pluginModule = require(modulePath)
 
-    // We write the toml changes
-    const localToml = `${process.cwd()}/ignite.toml`
-    filesystem.write(localToml, json2toml(updatedConfig))
+  // set the path to the current running ignite plugin
+  ignite.setIgnitePluginPath(modulePath)
 
-    // bring the ignite plugin to life
-    const pluginModule = require(modulePath)
-
-    // set the path to the current running ignite plugin
-    ignite.setIgnitePluginPath(modulePath)
-
-    try {
-      // and then call the add function
-      await pluginModule.add(context)
-      success('Time to get cooking! 🍽 ')
-    } catch (err) {
+  try {
+    // and then call the add function
+    await pluginModule.add(context)
+    success('🍽  time to get cooking!')
+  } catch (err) {
       // write the error message out
-      error(err.message)
-    }
-  } else {
-    error("We couldn't find that ignite plugin")
-    warning(`Please make sure ${moduleName} exists on the npmjs.com`)
-    process.exit(1)
+    error(err.message)
   }
 }

--- a/packages/ignite/src/plugins/default/commands/add/detectInstall.js
+++ b/packages/ignite/src/plugins/default/commands/add/detectInstall.js
@@ -1,0 +1,57 @@
+const { startsWith } = require('ramdasauce')
+const { unless, concat } = require('ramda')
+
+/**
+ * Ensures the given string starts with 'ignite-'.
+ *
+ * @param {string} value The string to check.
+ * @returns {string} The same string, but better.
+ */
+const alwaysStartWithIgnite = function (value) {
+  return unless(
+    startsWith('ignite-'),
+    concat('ignite-')
+  )(value)
+}
+
+/**
+ * Detects the type of install the user is requesting for this plugin.
+ *
+ * @param {object} context - A gluegun context
+ * @returns {object} specs about the type of install
+ */
+function detectInstall (context) {
+  // grab some gluegun goodies
+  const { filesystem, parameters } = context
+
+  /**
+   * Is this a valid ignite plugin?
+   *
+   * @param {string} candidate The potential directory to check.
+   * @returns {boolean} True if this is valid; otherwise false.
+   */
+  const isValidIgnitePluginDirectory = candidate =>
+    filesystem.exists(candidate) === 'dir' &&
+    filesystem.exists(`${candidate}/package.json`) === 'file'
+
+  // the thing we're trying to install
+  const thing = parameters.second
+
+  // is this a directory?
+  if (isValidIgnitePluginDirectory(thing)) {
+    const json = filesystem.read(`${thing}/package.json`, 'json') || {}
+    return {
+      directory: thing,
+      moduleName: json.name,
+      type: 'directory'
+    }
+  }
+
+  // this is a npmjs module
+  return {
+    moduleName: alwaysStartWithIgnite(thing),
+    type: 'npm'
+  }
+}
+
+module.exports = detectInstall


### PR DESCRIPTION
This gives us the ability to add plugins from our file system.

First, this is working really well for me:

```sh
cd packages
export IGNITE_STUFF=$(pwd)
cd ignite
npm link
```

Create a brand new React Native project (`ignite new` will handle this in the near future)

```sh
mkdir -p ~/tmp/ignite
cd ~/tmp/ignite
react-native init Fun
cd Fun
```

Then play around!

```sh
ignite add $IGNITE_STUFF/ignite-basic-structure --unholy
ignite add $IGNITE_STUFF/ignite-basic-generators
ignite generate screen GreatOdinsBeardThisIsActuallyWorking
ignite add $IGNITE_STUFF/ignite-vector-icons
```

A few other notable changes:

* temporarily turned off `yarn` support
* mucking about with console logging
* i took out `Exists` checking as not all npm modules live on npmjs.com

Things to chat about tomorrow.

* I'd like to simplify the interface of `ignite.toml` inside plugins for generators.  I'm thinking for consistency, let's move these to functions you register inside `add`.
* You might notice dependencies have been removed in the `ignite-*` modules.  They shouldn't be `dependencies` anymore.  I'd concede to `peerDependencies`, but I'd prefer them gone baby gone.  There are other options too, but it'll involve a little more work.
* Check out `package.json` in `ignite-vector-icons`.  See the new `files`?  Our modules are growing up so fast.  😿 
* We can chat more about dropping `Exists` and how we could bring it back if you need it.


