### PR TITLE
Remove ezLoging flag

### DIFF
--- a/ignite-base/App/Config/DebugSettings.js
+++ b/ignite-base/App/Config/DebugSettings.js
@@ -1,6 +1,5 @@
 const SETTINGS = {
   useFixtures: false,
-  ezLogin: false,
   yellowBox: __DEV__,
   reduxLogging: __DEV__,
   includeExamples: __DEV__,


### PR DESCRIPTION
## Please verify the following:
- [x] Everything works on iOS/Android
- [x] `ignite-base` **ava** tests pass
- [x] `fireDrill.sh` passed

## Describe your PR

The ezLogin flag wasn't used anywhere, I think it was a leftover from the initial commits.
