### PR TITLE
Fix MapView Generator Crash

### DIFF
--- a/ignite-generator/src/mapview/index.es
+++ b/ignite-generator/src/mapview/index.es
@@ -79,6 +79,7 @@ class MapviewGenerator extends Generators.Base {
    * Let's hand tweak the the android manifest because rnpm doesn't support that just yet.
    */
   updateAndroidManifest () {
+    this.spinner = ora('starting')
     const status = 'Updating android manifest file'
     this.spinner.start()
     this.spinner.text = status


### PR DESCRIPTION
MapView Generator is crashing without this fix.

## Please verify the following:
- [x ] Everything works on iOS/Android
- [ x] `ignite-base` **ava** tests pass
- [ x] `fireDrill.sh` passed

## Describe your PR
Fixes crashing of generator because spinner the doesn't exist.
