### PR TITLE
Updated auto-install packages for Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,14 +8,12 @@ install:
   - sudo apt-get install lib32stdc++6 lib32z1
   - wget http://dl.google.com/android/android-sdk_r24.4-linux.tgz
   - tar -xvf android-sdk_r24.4-linux.tgz
-  - cd android-sdk-linux/tools
   # list possible installs
-  - ./android list sdk --all
-  # -u means no ui / -a means all / -t means filter to specifc SDK items
-  # echo y to automatically accept android licenses
-  # Libs selected: SDK Build Tools 23.0.3 and 23.0.1, SDK Platform 23, Google APIs 23, Support Repo, Google Repo
-  - ( while [ 1 ]; do sleep 5; echo y; done ) | ./android update sdk -u -a -t 8,10,33,129,163,171
-  - cd ../../
+  # - ./android-sdk-linux/tools/android list sdk --all --extended
+  # -u means no ui / -a means all / -t means filter to specifc SDK items / -a means 
+  # pipe echo y to automatically accept android licenses
+  # Libs selected: SDK Build Tools 23.0.3, .2, and .1, SDK Platform 23, Google APIs 23, Support Repo, Google Repo
+  - echo y | ./android-sdk-linux/tools/android update sdk -u -a -t android-23,build-tools-23.0.3,build-tools-23.0.2,build-tools-23.0.1,addon-google_apis-google-23,extra-android-m2repository,extra-google-m2repository
 env:
   - ANDROID_HOME=~/build/infinitered/ignite/android-sdk-linux
 script:


### PR DESCRIPTION
Updates the `android update sdk` command on Travis to be less brittle by referring to packages by their names, not index numbers.

If Semaphore passes, we're good to go.

