### PR TITLE
Add flex sizes to cancelButton and searchIcon

### DIFF
--- a/ignite-base/App/Components/Styles/SearchBarStyle.js
+++ b/ignite-base/App/Components/Styles/SearchBarStyle.js
@@ -25,12 +25,14 @@ export default StyleSheet.create({
     flexDirection: 'row'
   },
   searchIcon: {
+    flex: 1,
     left: Metrics.doubleBaseMargin,
     alignSelf: 'center',
     color: Colors.snow,
     backgroundColor: Colors.transparent
   },
   cancelButton: {
+    flex: 1,
     alignItems: 'center',
     justifyContent: 'center',
     marginHorizontal: Metrics.baseMargin


### PR DESCRIPTION
When I tried this on an iPad Mini4 physical device, the search bar didn't show a useful area. Worked fine on the simulator, but not on the device. This seems to fix it.

## Please verify the following:
- [ ] Everything works on iOS/Android
- [ ] `ignite-base` **ava** tests pass
- [ ] `fireDrill.sh` passed

## Describe your PR

