### PR TITLE
Update android shake command to not fail

### DIFF
--- a/ignite-base/package.json
+++ b/ignite-base/package.json
@@ -19,7 +19,7 @@
     "android:hockeyapp": "cd android && ./gradlew assembleRelease && puck -submit=auto app/build/outputs/apk/app-release.apk",
     "android:devices": "$ANDROID_HOME/platform-tools/adb devices",
     "android:logcat": "$ANDROID_HOME/platform-tools/adb logcat *:S ReactNative:V ReactNativeJS:V",
-    "android:shake": "$ANDROID_HOME/platform-tools/adb devices | grep '\\t' | awk '{print $1}' | sed 's/\\s//g' | xargs -I {} $ANDROID_HOME/platform-tools/adb -s {} shell input keyevent 82",
+    "android:shake": "$ANDROID_HOME/platform-tools/adb devices | grep '\t' | awk '{print $1}' | sed 's/\\s//g' | xargs -I {} $ANDROID_HOME/platform-tools/adb -s {} shell input keyevent 82",
     "flow": "flow --show-all-errors"
   },
   "dependencies": {

--- a/ignite-base/package.json.template
+++ b/ignite-base/package.json.template
@@ -19,7 +19,7 @@
     "android:hockeyapp": "cd android && ./gradlew assembleRelease && puck -submit=auto app/build/outputs/apk/app-release.apk",
     "android:devices": "$ANDROID_HOME/platform-tools/adb devices",
     "android:logcat": "$ANDROID_HOME/platform-tools/adb logcat *:S ReactNative:V ReactNativeJS:V",
-    "android:shake": "$ANDROID_HOME/platform-tools/adb devices | grep '\\t' | awk '{print $1}' | sed 's/\\s//g' | xargs -I {} $ANDROID_HOME/platform-tools/adb -s {} shell input keyevent 82",
+    "android:shake": "$ANDROID_HOME/platform-tools/adb devices | grep '\t' | awk '{print $1}' | sed 's/\\s//g' | xargs -I {} $ANDROID_HOME/platform-tools/adb -s {} shell input keyevent 82",
     "flow": "flow --show-all-errors"
   },
   "dependencies": {


### PR DESCRIPTION
## Please verify the following:
- [x ] Everything works on iOS/Android - Nothing changed in that regard
- [x ] `ignite-base` **ava** tests pass
- [x ] `fireDrill.sh` passed

## Describe your PR

Android shake command fails for me as the previous command greps "List" out of the result and adb fails with unknown device "List"

This change greps all devices out of the device List and then omits the line containing "List".
