### PR TITLE
Next prompt

### DIFF
--- a/packages/ignite-basic-structure/templates/Unholy/Components/SearchBar.js
+++ b/packages/ignite-basic-structure/templates/Unholy/Components/SearchBar.js
@@ -1,7 +1,6 @@
 import React from 'react'
 import { Text, TextInput, TouchableOpacity } from 'react-native'
 import styles from './Styles/SearchBarStyle'
-import I18n from 'react-native-i18n'
 import { Colors, Metrics } from '../Themes/'
 import * as Animatable from 'react-native-animatable'
 import Icon from 'react-native-vector-icons/FontAwesome'
@@ -23,7 +22,7 @@ export default class SearchBar extends React.Component {
         <TextInput
           ref='searchText'
           autoFocus
-          placeholder={I18n.t('search')}
+          placeholder='Search'
           placeholderTextColor={Colors.snow}
           underlineColorAndroid='transparent'
           style={styles.searchInput}
@@ -36,7 +35,7 @@ export default class SearchBar extends React.Component {
           selectionColor={Colors.snow}
         />
         <TouchableOpacity onPress={onCancel} style={styles.cancelButton}>
-          <Text style={styles.buttonLabel}>{I18n.t('cancel')}</Text>
+          <Text style={styles.buttonLabel}>Cancel</Text>
         </TouchableOpacity>
       </Animatable.View>
     )

--- a/packages/ignite-basic-structure/templates/Unholy/Containers/DrawerContent.js
+++ b/packages/ignite-basic-structure/templates/Unholy/Containers/DrawerContent.js
@@ -4,8 +4,6 @@ import React, { Component } from 'react'
 import { ScrollView, Image, BackAndroid } from 'react-native'
 import styles from './Styles/DrawerContentStyle'
 import { Images } from '../Themes'
-import DrawerButton from '../Components/DrawerButton'
-import { Actions as NavigationActions } from 'react-native-router-flux'
 
 class DrawerContent extends Component {
 
@@ -23,40 +21,10 @@ class DrawerContent extends Component {
     this.context.drawer.toggle()
   }
 
-  handlePressComponents = () => {
-    this.toggleDrawer()
-    NavigationActions.componentExamples()
-  }
-
-  handlePressUsage = () => {
-    this.toggleDrawer()
-    NavigationActions.usageExamples()
-  }
-
-  handlePressAPI = () => {
-    this.toggleDrawer()
-    NavigationActions.apiTesting()
-  }
-
-  handlePressTheme = () => {
-    this.toggleDrawer()
-    NavigationActions.theme()
-  }
-
-  handlePressDevice = () => {
-    this.toggleDrawer()
-    NavigationActions.deviceInfo()
-  }
-
   render () {
     return (
       <ScrollView style={styles.container}>
         <Image source={Images.logo} style={styles.logo} />
-        <DrawerButton text='Component Examples' onPress={this.handlePressComponents} />
-        <DrawerButton text='Usage Examples' onPress={this.handlePressUsage} />
-        <DrawerButton text='API Testing' onPress={this.handlePressAPI} />
-        <DrawerButton text='Themes' onPress={this.handlePressTheme} />
-        <DrawerButton text='Device Info' onPress={this.handlePressDevice} />
       </ScrollView>
     )
   }

--- a/packages/ignite-basic-structure/templates/Unholy/Containers/LoginScreen.js
+++ b/packages/ignite-basic-structure/templates/Unholy/Containers/LoginScreen.js
@@ -16,7 +16,6 @@ import Styles from './Styles/LoginScreenStyle'
 import {Images, Metrics} from '../Themes'
 import LoginActions from '../Redux/LoginRedux'
 import { Actions as NavigationActions } from 'react-native-router-flux'
-import I18n from 'react-native-i18n'
 
 type LoginScreenProps = {
   dispatch: () => any,
@@ -116,7 +115,7 @@ class LoginScreen extends React.Component {
         <Image source={Images.logo} style={[Styles.topLogo, this.state.topLogo]} />
         <View style={Styles.form}>
           <View style={Styles.row}>
-            <Text style={Styles.rowLabel}>{I18n.t('username')}</Text>
+            <Text style={Styles.rowLabel}>Username</Text>
             <TextInput
               ref='username'
               style={textInputStyle}
@@ -129,11 +128,11 @@ class LoginScreen extends React.Component {
               onChangeText={this.handleChangeUsername}
               underlineColorAndroid='transparent'
               onSubmitEditing={() => this.refs.password.focus()}
-              placeholder={I18n.t('username')} />
+              placeholder='Username' />
           </View>
 
           <View style={Styles.row}>
-            <Text style={Styles.rowLabel}>{I18n.t('password')}</Text>
+            <Text style={Styles.rowLabel}>Password</Text>
             <TextInput
               ref='password'
               style={textInputStyle}
@@ -147,18 +146,18 @@ class LoginScreen extends React.Component {
               onChangeText={this.handleChangePassword}
               underlineColorAndroid='transparent'
               onSubmitEditing={this.handlePressLogin}
-              placeholder={I18n.t('password')} />
+              placeholder='Password' />
           </View>
 
           <View style={[Styles.loginRow]}>
             <TouchableOpacity style={Styles.loginButtonWrapper} onPress={this.handlePressLogin}>
               <View style={Styles.loginButton}>
-                <Text style={Styles.loginText}>{I18n.t('signIn')}</Text>
+                <Text style={Styles.loginText}>Sign In</Text>
               </View>
             </TouchableOpacity>
             <TouchableOpacity style={Styles.loginButtonWrapper} onPress={NavigationActions.pop}>
               <View style={Styles.loginButton}>
-                <Text style={Styles.loginText}>{I18n.t('cancel')}</Text>
+                <Text style={Styles.loginText}>Cancel</Text>
               </View>
             </TouchableOpacity>
           </View>

--- a/packages/ignite-basic-structure/templates/Unholy/Transforms/ConvertFromKelvin.js
+++ b/packages/ignite-basic-structure/templates/Unholy/Transforms/ConvertFromKelvin.js
@@ -1,14 +1,8 @@
 // @flow
 
-import I18n from 'react-native-i18n'
-
 export default (kelvin: number) => {
   const celcius = kelvin - 273.15
   const farenheit = (celcius * 1.8000) + 32
 
-  if (I18n.t('tempIndicator') === 'F') {
-    return Math.round(farenheit)
-  } else {
-    return Math.round(celcius)
-  }
+  return Math.round(farenheit)
 }

--- a/packages/ignite/src/plugins/default/commands/new.js
+++ b/packages/ignite/src/plugins/default/commands/new.js
@@ -5,18 +5,19 @@
 const installWalkthrough = [
   {
     name: 'dev-screens',
-    message: 'Would you like Ignite Development Screens',
-    type: 'confirm'
+    message: 'Would you like Ignite Development Screens?',
+    type: 'list',
+    choices: ['No', 'Yes']
   }, {
     name: 'vector-icons',
-    message: 'What kind of vector icon library will you use?',
+    message: 'What vector icon library will you use?',
     type: 'list',
-    choices: ['react-native-vector-icons', 'none']
+    choices: ['none', 'react-native-vector-icons']
   }, {
     name: 'i18n',
-    message: 'What kind of internationalization library will you use?',
+    message: 'What internationalization library will you use?',
     type: 'list',
-    choices: ['react-native-i18n', 'none']
+    choices: ['none', 'react-native-i18n']
   }
 
 ]
@@ -73,7 +74,7 @@ module.exports = async function (context) {
   await system.run(`ignite add ${igniteDevPackagePrefix}basic-generators`)
 
   // now run install of Ignite Plugins
-  if (answers['dev-screens'] || parameters.options.max) {
+  if (answers['dev-screens'] === 'Yes' || parameters.options.max) {
     info('Add ignite dev screens')
     await system.run(`ignite add ${igniteDevPackagePrefix}dev-screens`)
   }


### PR DESCRIPTION
Closes #620.

- Make all prompts use `list` for consistency and ease of use.
- Make all prompts default to `none` or `no` for consistency and ease of use.
- Fixed lingering I18n references in Unholy that only appear if you chose not to install I18n.
- Fixed lingering drawer navigation items for moved dev screens.