### PR TITLE
Clears the build folder in ios when newclearing.

### DIFF
--- a/packages/ignite-basic-structure/templates/package.json.unholy.ejs
+++ b/packages/ignite-basic-structure/templates/package.json.unholy.ejs
@@ -9,7 +9,7 @@
     "fixcode": "standard --fix",
     "clean": "rm -rf $TMPDIR/react-* && watchman watch-del-all && npm cache clean",
     "clean:android": "cd android/ && ./gradlew clean && cd .. && react-native run-android",
-    "newclear": "rm -rf $TMPDIR/react-* && watchman watch-del-all && rm -rf ios/build/ModuleCache/* && rm -rf node_modules/ && npm cache clean && npm i",
+    "newclear": "rm -rf $TMPDIR/react-* && watchman watch-del-all && rm -rf ios/build && rm -rf node_modules/ && npm cache clean && npm i",
     "test": "NODE_ENV=production ava",
     "test:watch": "ava --watch",
     "coverage": "nyc ava && nyc report --reporter=html && open coverage/index.html || xdg-open coverage/index.html",


### PR DESCRIPTION
This clears the whole build folder under ios when using `newclear`.  Fixes #624.