### PR TITLE
Upgrades ignite doctor.

### DIFF
--- a/packages/ignite/package.json
+++ b/packages/ignite/package.json
@@ -26,7 +26,7 @@
   ],
   "license": "MIT",
   "dependencies": {
-    "gluegun": "0.10.0",
+    "gluegun": "0.11.0",
     "gluegun-patching": "^0.3.0",
     "json2toml": "^1.0.6",
     "minimist": "^1.2.0",

--- a/packages/ignite/src/commands/doctor.js
+++ b/packages/ignite/src/commands/doctor.js
@@ -1,49 +1,82 @@
 // @cliDescription Checks your dev environment for dependencies.
 // ----------------------------------------------------------------------------
 
-const R = require('ramda')
-const Shell = require('shelljs')
+const { split, last, replace, head, match } = require('ramda')
+const header = require('../brand/header')
+const os = require('os')
 
 module.exports = async function (context) {
-  const { filesystem: { exists, read } } = context
-  const { debug } = context.print
+  // fistful of features
+  const {
+    filesystem: { read },
+    system: { run, which },
+    print: { colors, info, table },
+    strings: { padEnd }
+  } = context
 
   // ... be the CLI you wish to see in the world
   const platform = process.platform
-  const ignitePath = R.trim(Shell.which('ignite') || '')
-  const igniteVersion = R.trim(Shell.exec('ignite version', { silent: true }).stdout)
-  const nodePath = R.trim(Shell.which('node'))
-  const npmVersion = R.trim(Shell.exec('npm --version', { silent: true }).stdout)
-  const npmPath = R.trim(Shell.which('npm'))
-  const nodeVersion = R.trim(Shell.exec('node --version', { silent: true }).stdout)
-  const ggPackageFile = `${process.cwd()}/node_modules/gluegun/package.json`
-  const ggVersion = exists(ggPackageFile) ? read(ggPackageFile, 'json').version : '¯\\_(ツ)_/¯'
+  const arch = os.arch()
+  const cpus = os.cpus() || []
+  const firstCpu = head(cpus) || {}
+  const cpu = `${firstCpu.model}`
+  const cores = `${cpus.length} cores`
+  const ignitePath = which('ignite')
+  const igniteVersion = await run('ignite version', { trim: true })
+  const nodePath = which('node')
+  const npmVersion = await run('npm --version', { trim: true })
+  const npmPath = which('npm')
+  const nodeVersion = replace('v', '', await run('node --version', { trim: true }))
+  const rnCli = split(/\s/, await run('react-native --version', { trim: true }))[1] // lulz
+  const xcodeVersion = split(/\s/, await run('xcodebuild -version', { trim: true }))[1] // lulz
+  const rnPkg = read(`${process.cwd()}/node_modules/react-native/package.json`, 'json')
+  const appReactNativeVersion = rnPkg ? rnPkg.version : '-'
+  const androidPath = process.env['ANDROID_HOME']
+  const javaVersionCmd = process.platform === 'win32' ? 'java -version' : 'java -version 2>&1'
+  const javaVersion = last(match(/"(.*)"/, await run(javaVersionCmd)))
+  const javaPath = which('java')
 
-  const rnCli = R.split(/\s/, R.trim(Shell.exec('react-native --version', { silent: true }).stdout))[1] // lulz
+  // display helpers
+  const column1 = (label, length = 16) => padEnd(label, length)
+  const column2 = label => colors.yellow(padEnd(label, 10))
+  const column3 = label => colors.muted(label)
 
-  const rnPackageFile = `${process.cwd()}/node_modules/react-native/package.json`
-  const appReactNativeVersion = Shell.test('-f', rnPackageFile) ? require(rnPackageFile).version : '¯\\_(ツ)_/¯'
+  // print ignite
+  header()
+  info('')
 
-  const body = `
-\`\`\`
-Computer
-  Platform: ${platform}
-Ignite
-  Version: ${igniteVersion}
-  Path: ${ignitePath}
-Node
-  Version: ${nodeVersion}
-  Path: ${nodePath}
-NPM
-  Version: ${npmVersion}
-  Path: ${npmPath}
-Gluegun
-  Version: ${ggVersion}
-React Native CLI
-  Version: ${rnCli}
-App
-  React Native Version: ${appReactNativeVersion}
-\`\`\`
-`
-  debug(body, 'Ignite Info')
+  info(colors.cyan('System'))
+  table([
+    [column1('platform'), column2(platform)],
+    [column1('arch'), column2(arch)],
+    [column1('cpu'), column2(cores), column3(cpu)]
+  ])
+
+  info('')
+  info(colors.cyan('JavaScript'))
+  table([
+    [column1('node'), column2(nodeVersion), column3(nodePath)],
+    [column1('npm'), column2(npmVersion), column3(npmPath)]
+  ])
+
+  info('')
+  info(colors.cyan('React Native'))
+  table([
+    [column1('react-native-cli'), column2(rnCli)],
+    [column1('app rn version'), column2(appReactNativeVersion)],
+  ])
+
+  info('')
+  info(colors.cyan('Ignite'))
+  table([
+    [column1('ignite'), column2(igniteVersion), column3(ignitePath)]
+  ])
+
+  info('')
+  info(colors.cyan('Native Mobile Platforms'))
+  table([
+    [column1('xcode'), column2(xcodeVersion)],
+    [column1('java'), column2(javaVersion), column3(javaPath)],
+    [column1('android home'), column2('-'), column3(androidPath)]
+  ])
 }

--- a/packages/ignite/src/commands/doctor.js
+++ b/packages/ignite/src/commands/doctor.js
@@ -26,11 +26,13 @@ module.exports = async function (context) {
   const nodePath = which('node')
   const npmVersion = await run('npm --version', { trim: true })
   const npmPath = which('npm')
+  const yarnVersion = await run('yarn --version', { trim: true })
+  const yarnPath = which('yarn')
   const nodeVersion = replace('v', '', await run('node --version', { trim: true }))
   const rnCli = split(/\s/, await run('react-native --version', { trim: true }))[1] // lulz
   const xcodeVersion = split(/\s/, await run('xcodebuild -version', { trim: true }))[1] // lulz
   const rnPkg = read(`${process.cwd()}/node_modules/react-native/package.json`, 'json')
-  const appReactNativeVersion = rnPkg ? rnPkg.version : '-'
+  const appReactNativeVersion = rnPkg && rnPkg.version
   const androidPath = process.env['ANDROID_HOME']
   const javaVersionCmd = process.platform === 'win32' ? 'java -version' : 'java -version 2>&1'
   const javaVersion = last(match(/"(.*)"/, await run(javaVersionCmd)))
@@ -56,15 +58,18 @@ module.exports = async function (context) {
   info(colors.cyan('JavaScript'))
   table([
     [column1('node'), column2(nodeVersion), column3(nodePath)],
-    [column1('npm'), column2(npmVersion), column3(npmPath)]
+    [column1('npm'), column2(npmVersion), column3(npmPath)],
+    [column1('yarn'), column2(yarnVersion), column3(yarnPath)]
   ])
 
   info('')
   info(colors.cyan('React Native'))
-  table([
-    [column1('react-native-cli'), column2(rnCli)],
-    [column1('app rn version'), column2(appReactNativeVersion)],
-  ])
+  const rnTable = []
+  rnTable.push([column1('react-native-cli'), column2(rnCli)])
+  if (appReactNativeVersion) {
+    rnTable.push([column1('app rn version'), column2(appReactNativeVersion)])
+  }
+  table(rnTable)
 
   info('')
   info(colors.cyan('Ignite'))

--- a/packages/ignite/src/extensions/ignite.js
+++ b/packages/ignite/src/extensions/ignite.js
@@ -1,6 +1,5 @@
 const { merge, pipe, prop, sortBy, propSatisfies, filter } = require('ramda')
 const { startsWith, dotPath } = require('ramdasauce')
-const Shell = require('shelljs')
 const exitCodes = require('../lib/exitCodes')
 
 /**
@@ -43,7 +42,7 @@ function attach (plugin, command, context) {
   const forceNpm = parameters.options.npm
 
   // you know what?  just turn off yarn for now.
-  const useYarn = !forceNpm && Shell.which('yarn')
+  const useYarn = !forceNpm && context.system.which('yarn')
 
   /**
    * Finds the gluegun plugins that are also ignite plugins.


### PR DESCRIPTION
This started by moving `which` into gluegun.  Ended up reworking the whole command.

I think there's even more we can do as well.  Like list the current installed android sdks and more.

```
❯ ignite doctor
-----------------------------------------------
  (                  )   (
  )\ )   (        ( /(   )\ )    *   )
 (()/(   )\ )     )\()) (()/(  ` )  /(   (
  /(_)) (()/(    ((_)\   /(_))  ( )(_))  )\
 (_))    /(_))_   _((_) (_))   (_(_())  ((_)
 |_ _|  (_)) __| | \| | |_ _|  |_   _|  | __|
  | |     | (_ | | .` |  | |     | |    | _|
 |___|     \___| |_|\_| |___|    |_|    |___|
-----------------------------------------------

An unfair headstart for your React Native apps.
https://infinite.red/ignite

-----------------------------------------------

System
  platform           darwin
  arch               x64
  cpu                8 cores      Intel(R) Core(TM) i7-4870HQ CPU @ 2.50GHz

JavaScript
  node               7.5.0        /usr/local/bin/node
  npm                4.1.2        /usr/local/bin/npm

React Native
  react-native-cli   2.0.1
  app rn version     0.40.0

Ignite
  ignite             2.0.0        /usr/local/bin/ignite

Native Mobile Platforms
  xcode              8.2.1
  java               1.8.0_45     /usr/bin/java
  android home       -            /Users/steve/Library/Android/sdk
```

I removed the triple backtick formatting as I think we can do something a little different/better for people trying to submit issues.

🚨 @jamonholmgren @kevinvangelder @GantMan 🚨  -> once this is merged in, we'll need to `cd packages/ignite && yarn` as gluegun got bumped to `0.11.0`.

