### PR TITLE
Fixes unholy package.json clobbering RN version.

### DIFF
--- a/packages/ignite-basic-structure/index.js
+++ b/packages/ignite-basic-structure/index.js
@@ -1,4 +1,6 @@
-const sourceFolder = `${process.cwd()}/node_modules/ignite-basic-structure/templates/`
+const sourceFolder = `${process.cwd()}/node_modules/ignite-basic-structure/templates`
+
+const REACT_NATIVE_VERSION = '0.41.1'
 
 const add = async function (context) {
   const { filesystem, parameters, ignite, strings, print } = context
@@ -42,17 +44,23 @@ const add = async function (context) {
 
   if (parameters.options.unholy) {
     // copy far too many opinions
-    filesystem.copy(`${sourceFolder}Unholy`, `${process.cwd()}/App`, { overwrite: true })
+    filesystem.copy(`${sourceFolder}/Unholy`, `${process.cwd()}/App`, { overwrite: true })
     copyJobs.push({
       template: 'package.json.unholy.ejs',
       target: 'package.json'
     })
   } else {
     // copy minimal structure YAY!
-    filesystem.copy(`${sourceFolder}App`, `${process.cwd()}/App`, { overwrite: true })
+    filesystem.copy(`${sourceFolder}/App`, `${process.cwd()}/App`, { overwrite: true })
   }
 
-  await ignite.copyBatch(context, copyJobs, {name: parameters.third})
+  // grab the react native version from the command line
+  const reactNativeVersion = parameters.options['react-native-version'] || REACT_NATIVE_VERSION
+
+  await ignite.copyBatch(context, copyJobs, {
+    name: parameters.third,
+    reactNativeVersion
+  })
 }
 
 // TODO

--- a/packages/ignite-basic-structure/templates/package.json.unholy.ejs
+++ b/packages/ignite-basic-structure/templates/package.json.unholy.ejs
@@ -29,7 +29,7 @@
     "querystringify": "0.0.4",
     "ramda": "^0.23.0",
     "react": "~15.4.0-rc.4",
-    "react-native": "0.40.0",
+    "react-native": "<%= props.reactNativeVersion %>",
     "react-native-config": "^0.2.1",
     "react-native-device-info": "^0.10.0",
     "react-native-drawer": "^2.3.0",

--- a/packages/ignite/src/commands/new.js
+++ b/packages/ignite/src/commands/new.js
@@ -82,7 +82,7 @@ module.exports = async function (context) {
   // switch to the newly created project directory to continue the rest of these commands
   process.chdir(projectName)
 
-  await system.spawn(`ignite add ${igniteDevPackagePrefix}basic-structure ${projectName} --unholy`, { stdio: 'inherit' })
+  await system.spawn(`ignite add ${igniteDevPackagePrefix}basic-structure ${projectName} --unholy --react-native-version ${reactNativeVersion}`, { stdio: 'inherit' })
 
   info(`🔥  installing ignite dependencies`)
   if (context.ignite.useYarn) {


### PR DESCRIPTION
The unholy template copies it's `package.json` overtop of the one installed by React Native so we end up losing the user's choice.

This fixes that.