### PR TITLE
Ignite app configuration is now JSON.

### DIFF
--- a/packages/ignite-animatable/package.json
+++ b/packages/ignite-animatable/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ignite-animatable",
-  "version": "0.0.1",
+  "version": "0.2.0-alpha.1",
   "devEngines": {
     "node": ">=7.x",
     "npm": ">=4.x"

--- a/packages/ignite-basic-generators/commands/component.js
+++ b/packages/ignite-basic-generators/commands/component.js
@@ -4,8 +4,10 @@
 
 module.exports = async function (context) {
   // grab some features
-  const { parameters, config, strings, print, ignite } = context
+  const { parameters, strings, print, ignite } = context
   const { pascalCase, isBlank } = strings
+  const config = ignite.loadIgniteConfig()
+  const { tests } = config
 
   // validation
   if (isBlank(parameters.first)) {
@@ -15,9 +17,7 @@ module.exports = async function (context) {
   }
 
   // read some configuration
-  const { tests } = config.ignite
   const name = pascalCase(parameters.first)
-
   const copyJobs = [
     {
       template: 'component.ejs',

--- a/packages/ignite-basic-generators/commands/redux.js
+++ b/packages/ignite-basic-generators/commands/redux.js
@@ -4,8 +4,9 @@ const generate = require('../shared/generate-utils')
 
 module.exports = async function (context) {
   // grab some features
-  const { parameters, config, strings, print } = context
+  const { parameters, ignite, strings, print } = context
   const { isBlank, pascalCase } = strings
+  const config = ignite.loadIgniteConfig()
 
   // validation
   if (isBlank(parameters.first)) {
@@ -20,9 +21,9 @@ module.exports = async function (context) {
   const jobs = [
     { template: `redux.ejs`, target: `App/Redux/${name}Redux.js` }
   ]
-  if (config.ignite.tests) {
+  if (config.tests) {
     jobs.push({
-      template: `redux-test-${config.ignite.tests}.ejs`,
+      template: `redux-test-${config.tests}.ejs`,
       target: `Tests/Redux/${name}ReduxTest.js`
     })
   }

--- a/packages/ignite-basic-generators/commands/saga.js
+++ b/packages/ignite-basic-generators/commands/saga.js
@@ -4,8 +4,10 @@ const generate = require('../shared/generate-utils')
 
 module.exports = async function (context) {
   // grab some features
-  const { parameters, config, print, strings } = context
+  const { parameters, ignite, print, strings } = context
   const { pascalCase, isBlank } = strings
+  const config = ignite.loadIgniteConfig()
+  const { tests } = config
 
   // validation
   if (isBlank(parameters.first)) {
@@ -14,7 +16,6 @@ module.exports = async function (context) {
     return
   }
 
-  const { tests } = config.ignite
   const name = pascalCase(parameters.first)
   const props = { name }
 

--- a/packages/ignite-basic-generators/package.json
+++ b/packages/ignite-basic-generators/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ignite-basic-generators",
-  "version": "0.2.0",
+  "version": "0.2.0-alpha.1",
   "devEngines": {
     "node": ">=7.x",
     "npm": ">=4.x"

--- a/packages/ignite-basic-generators/shared/generate-utils.js
+++ b/packages/ignite-basic-generators/shared/generate-utils.js
@@ -6,12 +6,13 @@
  */
 module.exports = async function (context, jobs, props) {
   // grab some features
-  const { config, ignite, prompt, filesystem, print } = context
+  const { ignite, prompt, filesystem, print } = context
   const { generate } = ignite
   const { confirm } = prompt
+  const config = ignite.loadIgniteConfig()
 
   // read some configuration
-  const { askToOverwrite } = config.ignite
+  const { askToOverwrite } = config
 
   // If the file exists
   const shouldGenerate = async (target) => {

--- a/packages/ignite-basic-structure/index.js
+++ b/packages/ignite-basic-structure/index.js
@@ -28,8 +28,8 @@ const add = async function (context) {
       target: 'README.md'
     },
     {
-      template: 'ignite.toml',
-      target: 'ignite/ignite.toml'
+      template: 'ignite.json.ejs',
+      target: 'ignite/ignite.json'
     },
     {
       template: '.editorconfig',
@@ -59,7 +59,8 @@ const add = async function (context) {
 
   await ignite.copyBatch(context, copyJobs, {
     name: parameters.third,
-    reactNativeVersion
+    reactNativeVersion,
+    igniteVersion: ignite.version
   })
 }
 

--- a/packages/ignite-basic-structure/package.json
+++ b/packages/ignite-basic-structure/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ignite-basic-structure",
-  "version": "0.0.5",
+  "version": "0.2.0-alpha.1",
   "devEngines": {
     "node": ">=7.x",
     "npm": ">=4.x"

--- a/packages/ignite-basic-structure/templates/ignite.json.ejs
+++ b/packages/ignite-basic-structure/templates/ignite.json.ejs
@@ -1,5 +1,3 @@
 {
-  "ignite": {
-    "createdWith": "<%= props.igniteVersion %>"
-  }
+  "createdWith": "<%= props.igniteVersion %>"
 }

--- a/packages/ignite-basic-structure/templates/ignite.json.ejs
+++ b/packages/ignite-basic-structure/templates/ignite.json.ejs
@@ -1,0 +1,5 @@
+{
+  "ignite": {
+    "createdWith": "<%= props.igniteVersion %>"
+  }
+}

--- a/packages/ignite-basic-structure/templates/ignite.toml
+++ b/packages/ignite-basic-structure/templates/ignite.toml
@@ -1,2 +1,0 @@
-[ignite]
-createdWith = "2.0pre"

--- a/packages/ignite-dev-screens/index.js
+++ b/packages/ignite-dev-screens/index.js
@@ -30,7 +30,7 @@ const add = async function (context) {
   const { warning } = print
 
   // Set Examples to "classic" in Ignite config
-  context.ignite.setGlobalConfig('examples', 'classic')
+  context.ignite.setIgniteConfig('examples', 'classic')
 
   // // Copy the the screens to containers folder
   await copyDevScreens(context)
@@ -62,7 +62,7 @@ const remove = async function (context) {
   console.log('Removing Ignite Dev Screens')
 
   // Set Examples to "false" in Ignite config
-  context.ignite.removeGlobalConfig('examples')
+  context.ignite.removeIgniteConfig('examples')
 
   // Delete screens from containers folder
   filesystem.remove('ignite/DevScreens')

--- a/packages/ignite-dev-screens/package.json
+++ b/packages/ignite-dev-screens/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ignite-dev-screens",
-  "version": "0.0.3",
+  "version": "0.2.0-alpha.1",
   "devEngines": {
     "node": ">=7.x",
     "npm": ">=4.x"

--- a/packages/ignite-i18n/package.json
+++ b/packages/ignite-i18n/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ignite-i18n",
-  "version": "0.0.1",
+  "version": "0.2.0-alpha.1",
   "devEngines": {
     "node": ">=7.x",
     "npm": ">=4.x"

--- a/packages/ignite-vector-icons/package.json
+++ b/packages/ignite-vector-icons/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ignite-vector-icons",
-  "version": "0.1.0",
+  "version": "0.2.0-alpha.1",
   "devEngines": {
     "node": ">=7.x",
     "npm": ">=4.x"

--- a/packages/ignite/package.json
+++ b/packages/ignite/package.json
@@ -28,7 +28,6 @@
   "dependencies": {
     "gluegun": "0.11.0",
     "gluegun-patching": "^0.3.0",
-    "json2toml": "^1.0.6",
     "minimist": "^1.2.0",
     "ramda": "^0.22.1",
     "ramdasauce": "^1.1.1",

--- a/packages/ignite/package.json
+++ b/packages/ignite/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ignite",
-  "version": "2.0.0",
+  "version": "2.0.0-alpha.1",
   "description": "Ignite - The next version.",
   "main": "src/index.js",
   "bin": {
@@ -14,10 +14,13 @@
     "lint": "standard"
   },
   "author": {
-    "name": "Gant Laborde",
-    "email": "gantman@gmail.com",
+    "name": "Infinite Red",
+    "email": "reactnative@infinite.red",
     "url": "https://github.com/infinitered/ignite"
   },
+  "contributors": [
+    "https://github.com/infinitered/ignite/graphs/contributors"
+  ],
   "files": [
     "LICENSE",
     "readme.md",

--- a/packages/ignite/src/cli/cli.js
+++ b/packages/ignite/src/cli/cli.js
@@ -14,7 +14,6 @@ module.exports = async function run (argv) {
   // create a runtime
   const runtime = build()
     .brand('ignite')
-    .configFile('ignite/ignite.toml')
     .loadDefault(`${__dirname}/..`)
     .loadAll(`${process.cwd()}/node_modules`, { matching: 'ignite-*', hidden: true })
     .token('commandName', 'cliCommand')

--- a/packages/ignite/src/commands/add.js
+++ b/packages/ignite/src/commands/add.js
@@ -4,7 +4,6 @@
 
 const Toml = require('toml')
 const R = require('ramda')
-const { dotPath } = require('ramdasauce')
 const detectedChanges = require('../lib/detectedChanges')
 const detectInstall = require('../lib/detectInstall')
 const exitCodes = require('../lib/exitCodes')
@@ -36,18 +35,17 @@ const removeIgnitePlugin = async (moduleName, context) => {
  */
 async function importPlugin (context, opts) {
   const { moduleName, type, directory } = opts
-  const { system } = context
+  const { ignite, system } = context
   const isDirectory = type === 'directory'
   const target = isDirectory ? directory : moduleName
 
   try {
-    // NOTE(steve): disabling yarn again because their cache busting doesn't work
-    // if (ignite.useYarn) {
-    //   const yarnTarget = isDirectory ? `file:${target}` : target
-    //   await system.run(`yarn add ${yarnTarget} --dev --force`)
-    // } else {
-    await system.run(`npm i ${target} --save-dev`)
-    // }
+    if (ignite.useYarn) {
+      const yarnTarget = isDirectory ? `file:${target}` : target
+      await system.run(`yarn add ${yarnTarget} --dev`)
+    } else {
+      await system.run(`npm i ${target} --save-dev`)
+    }
   } catch (e) {
     context.print.error(`💩  ${target} does not appear to be an NPM module. Does it exist and have a valid package.json?`)
     process.exit(exitCodes.PLUGIN_INVALID)
@@ -55,7 +53,7 @@ async function importPlugin (context, opts) {
 }
 
 module.exports = async function (context) {
-    // grab a fist-full of features...
+  // grab a fist-full of features...
   const { print, filesystem, prompt, ignite, parameters, strings } = context
   const { info, warning, error } = print
   const config = ignite.loadIgniteConfig()

--- a/packages/ignite/src/commands/generate.js
+++ b/packages/ignite/src/commands/generate.js
@@ -27,7 +27,8 @@ const header = require('../brand/header')
  */
 module.exports = async function (context) {
   // grab some features
-  const { ignite, config, print, parameters } = context
+  const { ignite, print, parameters } = context
+  const config = ignite.loadIgniteConfig()
 
   // little bit of branding
   header()
@@ -59,7 +60,7 @@ module.exports = async function (context) {
   // ---------------------
 
   // the list of what the user wants
-  const userPrefs = dotPath('ignite.generators', config) || {}
+  const userPrefs = config.generators || {}
 
   // find the exact match of plugin name & type
   const userRegistry = mapObjIndexed(

--- a/packages/ignite/src/commands/new.js
+++ b/packages/ignite/src/commands/new.js
@@ -3,6 +3,7 @@
 // ----------------------------------------------------------------------------
 const { test } = require('ramda')
 const exitCodes = require('../lib/exitCodes')
+const path = require('path')
 
 // The default version of React Native to install. We will want to upgrade
 // this when we test out new releases and they work well with our setup.
@@ -54,7 +55,7 @@ module.exports = async function (context) {
   // To test what live is like, you can run `ignite new FooTown --live`.
   //
   // TODO(steve): Don't forget to remove this when we launch... open to better ways of handling it.
-  const igniteDevPackagePrefix = parameters.options.live || `${__dirname}/../../../ignite-`
+  const igniteDevPackagePrefix = parameters.options.live || path.resolve(`${__dirname}/../../..`) + '/ignite-'
 
   // First we ask!
   let answers = {}


### PR DESCRIPTION
### JSON

Ignite's configuration (`ignite/ignite.json`) is now `json`.  

![image](https://cloud.githubusercontent.com/assets/68273/22655714/fbcaf4f2-ec5e-11e6-9bfc-96e6f749373c.png)

I also dropped the `ignite` key which removes 1 level.  It wasn't needed because we're not sharing this with gluegun any longer.

### New API

If you need to work with this config from a plugin:

```js
// to read
const config = context.ignite.loadIgniteConfig()

// to write
config.omg = 'yussss'
context.ignite.saveIgniteConfig(config)
```

### Breaking API

This also changes the API a bit.  These two functions were renamed.

```js
`setGlobalConfig` -> `setIgniteConfig`
`removeGlobalConfig` -> `removeIgniteConfig`
```

I kept wonder just what config `Global` meant.  It means the Ignite config.

`setGlobalConfig` also no-longer has a 3rd parameter.  I couldn't find any examples of it in action. @kevinvangelder lemme know if that's the case.


### Package Changes

See all those `package.json` changes?  They all have new version numbers now.

I had a lot of issues with caching that even `npm cache clean` couldn't fix... turns out we're going to need to start bumping `version` inside `package.json` of each package.json.

This was blocking me, so I fixed it here since I was testing everything end to end.

Nice side-effect now is `yarn` is now fully supported again.


