### PR TITLE
Temporarily switches to Inquirer.js until enquirer fixes their output

### DIFF
--- a/packages/ignite/package.json
+++ b/packages/ignite/package.json
@@ -35,7 +35,8 @@
     "ramda": "^0.23.0",
     "ramdasauce": "^1.2.0",
     "shelljs": "^0.7.6",
-    "toml": "^2.3.1"
+    "toml": "^2.3.1",
+    "inquirer": "^3.0.1"
   },
   "devDependencies": {
     "ava": "^0.18.1",

--- a/packages/ignite/src/commands/new.js
+++ b/packages/ignite/src/commands/new.js
@@ -4,6 +4,7 @@
 const { test } = require('ramda')
 const exitCodes = require('../lib/exitCodes')
 const path = require('path')
+const inquirer = require('inquirer')
 
 // The default version of React Native to install. We will want to upgrade
 // this when we test out new releases and they work well with our setup.
@@ -50,7 +51,10 @@ const maxOptions = {
 const walkthrough = async (context) => {
   if (context.parameters.options.min) { return minOptions }
   if (context.parameters.options.max) { return maxOptions }
-  return await context.prompt.ask(installWalkthrough)
+  // TODO: Switch back to context.prompt.ask when this issue is resolved:
+  // https://github.com/enquirer/prompt-list/issues/2
+  // return await context.prompt.ask(installWalkthrough)
+  return await inquirer.prompt(installWalkthrough)
 }
 
 module.exports = async function (context) {

--- a/packages/ignite/src/commands/plugin.js
+++ b/packages/ignite/src/commands/plugin.js
@@ -3,6 +3,7 @@
 // ----------------------------------------------------------------------------
 
 const exitCodes = require('../lib/exitCodes')
+const inquirer = require('inquirer')
 
 /**
  * Does a walkthrough of questions and returns the answers as an object.
@@ -17,7 +18,10 @@ const walkthrough = async (context) => {
   if (context.parameters.options.max) { return maxOptions }
 
   // Okay, we'll ask one by one, fine
-  return await context.prompt.ask([
+  // TODO: Switch back to context.prompt.ask when this issue is resolved:
+  // https://github.com/enquirer/prompt-list/issues/2
+  // return await context.prompt.ask([
+  return await inquirer.prompt([
     {
       name: 'template',
       message: 'Would you like to generate an example component?',


### PR DESCRIPTION
![image](https://cloud.githubusercontent.com/assets/1479215/22858387/7ad20460-f070-11e6-8013-609523a1cb83.png)

This is temporary. Once upstream fixes their problem (including Gluegun updating to the new version) we'll want to revert this commit.

Fixes #634.
