### PR TITLE
Fixes local dev caching of packages.

### DIFF
--- a/packages/ignite/src/commands/add.js
+++ b/packages/ignite/src/commands/add.js
@@ -40,11 +40,12 @@ async function importPlugin (context, opts) {
   const target = isDirectory ? directory : moduleName
 
   try {
-    if (ignite.useYarn) {
-      const yarnTarget = isDirectory ? `file:${target}` : target
-      await system.run(`yarn add ${yarnTarget} --dev`)
+    // yarn caches wierd for file-based deps, lets use npm for these.... gah!
+    if (ignite.useYarn && !isDirectory) {
+      await system.run(`yarn add ${target} --dev`)
     } else {
-      await system.run(`npm i ${target} --save-dev`)
+      const cacheBusting = isDirectory ? '--cache-min=0' : ''
+      await system.run(`npm i ${target} --save-dev ${cacheBusting}`)
     }
   } catch (e) {
     context.print.error(`💩  ${target} does not appear to be an NPM module. Does it exist and have a valid package.json?`)


### PR DESCRIPTION
It's awkward to have to bump package.json version numbers everytime you want to end-to-end test something.   

This skips caching.  And also, I can't get it work on yarn either, so I'm falling back to `npm` for directory based `ignite add`'s.

⭐️ 