### PR TITLE
Fix/update generated package json

### DIFF
--- a/packages/ignite/src/commands/plugin.js
+++ b/packages/ignite/src/commands/plugin.js
@@ -81,6 +81,7 @@ const createNewPlugin = async (context) => {
     { template: 'plugin/index.js.ejs', target: `${pluginName}/index.js` },
     { template: 'plugin/ignite.toml.ejs', target: `${pluginName}/ignite.toml` },
     { template: 'plugin/package.json.ejs', target: `${pluginName}/package.json` },
+    { template: 'plugin/README.md', target: `${pluginName}/README.md` },
     (answers.template === 'Yes') &&
       { template: 'plugin/templates/Example.js.ejs', target: `${pluginName}/templates/${name}Example.js` },
     (answers.command === 'Yes') &&

--- a/packages/ignite/src/commands/plugin.js
+++ b/packages/ignite/src/commands/plugin.js
@@ -83,9 +83,9 @@ const createNewPlugin = async (context) => {
     { template: 'plugin/package.json.ejs', target: `${pluginName}/package.json` },
     { template: 'plugin/README.md', target: `${pluginName}/README.md` },
     (answers.template === 'Yes') &&
-      { template: 'plugin/templates/Example.js.ejs', target: `${pluginName}/templates/${name}Example.js` },
+      { template: 'plugin/templates/Example.js.ejs', target: `${pluginName}/templates/${name}Example.js.ejs` },
     (answers.command === 'Yes') &&
-      { template: 'plugin/commands/example.js.ejs', target: `${pluginName}/commands/example.js` }
+      { template: 'plugin/commands/example.js.ejs', target: `${pluginName}/commands/example.js.ejs` }
   ]
 
   // copy over the files

--- a/packages/ignite/src/commands/plugin.js
+++ b/packages/ignite/src/commands/plugin.js
@@ -85,7 +85,7 @@ const createNewPlugin = async (context) => {
     (answers.template === 'Yes') &&
       { template: 'plugin/templates/Example.js.ejs', target: `${pluginName}/templates/${name}Example.js.ejs` },
     (answers.command === 'Yes') &&
-      { template: 'plugin/commands/example.js.ejs', target: `${pluginName}/commands/example.js.ejs` }
+      { template: 'plugin/commands/example.js.ejs', target: `${pluginName}/commands/example.js` }
   ]
 
   // copy over the files

--- a/packages/ignite/src/templates/plugin/README.md
+++ b/packages/ignite/src/templates/plugin/README.md
@@ -1,0 +1,10 @@
+# My Plugin
+
+This is where you would put an intro to your plugin, and maybe a few examples of usage. 
+
+## Example
+
+```js
+console.log("Hello World")
+```
+

--- a/packages/ignite/src/templates/plugin/package.json.ejs
+++ b/packages/ignite/src/templates/plugin/package.json.ejs
@@ -1,6 +1,10 @@
 {
   "name": "<%= props.pluginName %>",
+  "description": "A description of your plugin.",
   "version": "0.0.1",
+  "license": "MIT",
+  "author": "Your Name",
+  "url": "https://example.com/path/to/your/plugin",
   "devEngines": {
     "node": ">=7.x",
     "npm": ">=4.x"


### PR DESCRIPTION
## Please verify the following:
- [x] Everything works on iOS/Android
- [x] `ignite-base` **ava** tests pass
- [x] `fireDrill.sh` passed

## Describe your PR

Fixes https://github.com/infinitered/ignite/issues/680

This adds additional fields to the generated `package.json` for new plugins, and also corrects the issue where generated example files were `.js` instead of `.js.ejs`. 

I also added a sample README to new plugins. 

