### PR TITLE
Debug switch + placebo package.json during install

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,8 +4,6 @@
 
 All active development is taking place on the `master` branch.  If you're contributing to v2, welcome!  You're in the right place.
 
-If you're using Ignite 1.x during this transition, you can find it living over on the `legacy` tag.
-
 We're aiming to release around the end of February.
 
 ### Ignite

--- a/docs/contributors.md
+++ b/docs/contributors.md
@@ -81,3 +81,7 @@ Also, included is a bunch of 3rd party ignite plugins.  These will be plugins th
 * `ignite-animatable` - for `react-native-animatable`
 * `ignite-i18n` - for `react-native-i18n`
 * `ignite-vector-icons` for `react-native-vector-icons`
+
+## Debugging
+
+As we iron out the kinks, you might find that passing `--debug` (as in `ignite new Thing --debug`) might help debugging things.

--- a/packages/ignite-cli/src/commands/new.js
+++ b/packages/ignite-cli/src/commands/new.js
@@ -7,8 +7,9 @@ const header = require('../brand/header')
 const { forEach } = require('ramda')
 
 module.exports = async function (context) {
-  const { parameters, strings, print, system, filesystem } = context
+  const { parameters, strings, print, system, filesystem, ignite } = context
   const { isBlank } = strings
+  const { log } = ignite
 
   // grab the project name
   const projectName = parameters.second
@@ -28,12 +29,24 @@ module.exports = async function (context) {
   }
 
   // make & jump into the project directory
+  log(`making directory ${projectName}`)
   filesystem.dir(projectName)
   process.chdir(projectName)
+  log(`switched directory to ${process.cwd()}`)
+
+  // make a temporary package.json file so node stops walking up the diretories
+  filesystem.write('package.json', {
+    name: 'ignite-shim',
+    description: 'A temporary package.json created to prevent node from wandering too far.',
+    repository: 'infinitered/ignite',
+    license: 'MIT'
+  })
 
   // pretty bird, yes, pretty bird... petey is a pretty bird.
-  header()
-  print.newline()
+  if (!parameters.options.debug) {
+    header()
+    print.newline()
+  }
   print.info(`🔥 igniting app ${print.colors.yellow(projectName)}`)
 
   /**
@@ -80,30 +93,40 @@ module.exports = async function (context) {
   // NOTE(steve):
   //   I'd like to see this go away by introducing a new addTemplate command... baby steps though.
   //   Another thing to consider is just passing through *all* options.
-  if (parameters.options.max) {
-    extraAddOptions.push('--max')
-  }
+  if (parameters.options.max) extraAddOptions.push('--max')
+
+  // pass debug down the chain
+  if (parameters.options.debug) extraAddOptions.push('--debug')
 
   // let's kick off the template
   let ok = false
   try {
     const command = `ignite add ${igniteDevPackagePrefix}${appTemplatePackage} ${projectName} ${extraAddOptions.join(' ')}`
+    log(`running app template: ${command}`)
     await system.spawn(command, { stdio: 'inherit' })
+    log('finished app template')
     ok = true
   } catch (e) {
+    log('error running app template')
+    log(e.message)
   }
 
   // always clean up the app-template stuff
+  log('cleaning temporary files')
   filesystem.remove('node_modules')
   filesystem.remove('ignite')
+  filesystem.remove('package.json')
 
   // did we install everything successfully?
   if (ok) {
+    log(`moving contents of ${projectName} into place`)
     // move everything that's 1 deep back up to here
     forEach(
       filename => filesystem.move(path.join(projectName, filename), filename)
       , filesystem.list(projectName)
     )
+    log(`removing unused sub directory ${projectName}`)
     filesystem.remove(projectName)
   }
+  log('finished running new')
 }

--- a/packages/ignite-cli/src/extensions/ignite.js
+++ b/packages/ignite-cli/src/extensions/ignite.js
@@ -495,6 +495,26 @@ function attach (plugin, command, context) {
     return await template.generate(merge(opts, overrides))
   }
 
+  /**
+   * Prints a debug message to the console.  Used when the user wants to run in --debug.
+   *
+   * @param {string|Object} message - The message to write
+   */
+  function log (message) {
+    // jet if we're not running in debug mode
+    if (!context.parameters.options.debug) return
+
+    const date = new Date().toISOString().slice(11, 19)
+    const prefix = context.print.colors.muted(date) + ' ' + context.print.colors.magenta('[ignite]')
+
+    if (typeof message === 'object') {
+      console.log(`${prefix}`)
+      console.dir(message)
+    } else {
+      console.log(`${prefix} ${message}`)
+    }
+  }
+
   // send back the extension
   return {
     ignitePluginPath,
@@ -516,6 +536,7 @@ function attach (plugin, command, context) {
     removeDebugConfig,
     patchInFile,
     generate,
+    log,
     version: igniteVersion
   }
 }

--- a/packages/ignite-minimal-app-template/index.js
+++ b/packages/ignite-minimal-app-template/index.js
@@ -35,7 +35,8 @@ const add = async function (context) {
   spinner.stop()
 
   // install the ignite-basic-generators
-  const basicGeneratorsCommand = `ignite add ${igniteDevPackagePrefix}basic-generators`
+  const debugFlag = parameters.options.debug ? '--debug' : 'p'
+  const basicGeneratorsCommand = `ignite add ${igniteDevPackagePrefix}basic-generators ${debugFlag}`
   await system.spawn(basicGeneratorsCommand, { stdio: 'inherit' })
 
   // Wrap it up with our success message.

--- a/packages/ignite-unholy-app-template/index.js
+++ b/packages/ignite-unholy-app-template/index.js
@@ -32,6 +32,7 @@ const maxOptions = {
 
 const add = async function (context) {
   const { filesystem, parameters, ignite, reactNative, print, system, prompt } = context
+  const { log } = ignite
   const name = parameters.third
   const igniteDevPackagePrefix = parameters.options['ignite-dev-package-prefix'] // NOTE(steve): going away soon
   const spinner = print.spin(`using Infinite Red's ${print.colors.cyan('unholy')} app template`).succeed()
@@ -81,23 +82,26 @@ const add = async function (context) {
   await system.spawn('react-native link', { stdio: 'ignore' })
   spinner.stop()
 
-  await system.spawn(`ignite add ${igniteDevPackagePrefix}basic-generators`, { stdio: 'inherit' })
+  // pass long the debug flag if we're running in that mode
+  const debugFlag = parameters.options.debug ? '--debug' : 'p'
+
+  await system.spawn(`ignite add ${igniteDevPackagePrefix}basic-generators ${debugFlag}`, { stdio: 'inherit' })
 
   // now run install of Ignite Plugins
   if (answers['dev-screens'] === 'Yes') {
-    await system.spawn(`ignite add ${igniteDevPackagePrefix}dev-screens`, { stdio: 'inherit' })
+    await system.spawn(`ignite add ${igniteDevPackagePrefix}dev-screens ${debugFlag}`, { stdio: 'inherit' })
   }
 
   if (answers['vector-icons'] === 'react-native-vector-icons') {
-    await system.spawn(`ignite add ${igniteDevPackagePrefix}vector-icons`, { stdio: 'inherit' })
+    await system.spawn(`ignite add ${igniteDevPackagePrefix}vector-icons ${debugFlag}`, { stdio: 'inherit' })
   }
 
   if (answers['i18n'] === 'react-native-i18n') {
-    await system.spawn(`ignite add ${igniteDevPackagePrefix}i18n`, { stdio: 'inherit' })
+    await system.spawn(`ignite add ${igniteDevPackagePrefix}i18n ${debugFlag}`, { stdio: 'inherit' })
   }
 
   if (answers['animatable'] === 'react-native-animatable') {
-    await system.spawn(`ignite add ${igniteDevPackagePrefix}animatable`, { stdio: 'inherit' })
+    await system.spawn(`ignite add ${igniteDevPackagePrefix}animatable ${debugFlag}`, { stdio: 'inherit' })
   }
 
   // Wrap it up with our success message.


### PR DESCRIPTION
* adds a debug switch `ignite new Something --debug` for better tracing
* adds a temporary `package.json` during install to prevent node from walking up directories
* removes bad advice about Ignite 1 from the readme.md.

Fixes #709 

Example:

![image](https://cloud.githubusercontent.com/assets/68273/23171953/2c06d82e-f822-11e6-84e2-3c81630ed8ce.png)
