### PR TITLE
Fixes RN Version + Safely merges package.jsons

### DIFF
--- a/packages/ignite-cli/src/commands/new.js
+++ b/packages/ignite-cli/src/commands/new.js
@@ -98,6 +98,9 @@ module.exports = async function (context) {
   // pass debug down the chain
   if (parameters.options.debug) extraAddOptions.push('--debug')
 
+  // pass react-native version down the chain
+  if (parameters.options['react-native-version']) extraAddOptions.push(`--react-native-version ${parameters.options['react-native-version']}`)
+
   // let's kick off the template
   let ok = false
   try {

--- a/packages/ignite-cli/src/extensions/reactNative.js
+++ b/packages/ignite-cli/src/extensions/reactNative.js
@@ -38,7 +38,10 @@ function attach (plugin, command, context) {
     const versionAvailable = test(new RegExp(reactNativeVersion, ''), versionCheck || '')
     if (!versionAvailable) {
       print.error(`💩  react native version ${print.colors.yellow(reactNativeVersion)} not found on NPM -- ${print.colors.yellow(REACT_NATIVE_VERSION)} recommended`)
-      return exitCodes.REACT_NATIVE_VERSION
+      return {
+        exitCode: exitCodes.REACT_NATIVE_VERSION,
+        version: reactNativeVersion
+      }
     }
 
     // craft the additional options to pass to the react-native cli
@@ -55,7 +58,7 @@ function attach (plugin, command, context) {
     const cmd = `react-native init ${name} ${rnOptions.join(' ')}`
     log('initializing react native')
     log(cmd)
-    const spinner = print.spin(`adding ${print.colors.cyan('React Native ' + reactNativeVersion)} ${print.colors.muted('(~60 seconds)')}`)
+    const spinner = print.spin(`adding ${print.colors.cyan('React Native ' + reactNativeVersion)} ${print.colors.muted('(60 seconds-ish)')}`)
     if (parameters.options.debug) spinner.stop()
 
     // ok, let's do this
@@ -73,7 +76,10 @@ function attach (plugin, command, context) {
     // Create ./ignite/plugins/.gitkeep
     filesystem.write(`${process.cwd()}/ignite/plugins/.gitkeep`, '')
 
-    return 0
+    return {
+      exitCode: exitCodes.OK,
+      version: reactNativeVersion
+    }
   }
 
   return {

--- a/packages/ignite-empty-app-template/index.js
+++ b/packages/ignite-empty-app-template/index.js
@@ -9,8 +9,8 @@ const add = async function (context) {
   const spinner = print.spin(`using an ${print.colors.cyan('empty')} app template`).succeed()
 
   // attempt to install React Native or die trying
-  const rnExitCode = await reactNative.install({ name })
-  if (rnExitCode > 0) process.exit(rnExitCode)
+  const rnInstall = await reactNative.install({ name })
+  if (rnInstall.exitCode > 0) process.exit(rnInstall.exitCode)
 
   // ignite/ignite.json
   const igniteJson = {

--- a/packages/ignite-minimal-app-template/index.js
+++ b/packages/ignite-minimal-app-template/index.js
@@ -10,8 +10,8 @@ const add = async function (context) {
   const spinner = print.spin(`using Infinite Red's ${print.colors.cyan('minimal')} app template`).succeed()
 
   // attempt to install React Native or die trying
-  const rnExitCode = await reactNative.install({ name })
-  if (rnExitCode > 0) process.exit(rnExitCode)
+  const rnInstall = await reactNative.install({ name })
+  if (rnInstall.exitCode > 0) process.exit(rnInstall.exitCode)
 
   // copy the App folder
   spinner.text = '▸ copying files'

--- a/packages/ignite-unholy-app-template/index.js
+++ b/packages/ignite-unholy-app-template/index.js
@@ -38,8 +38,8 @@ const add = async function (context) {
   const spinner = print.spin(`using Infinite Red's ${print.colors.cyan('unholy')} app template`).succeed()
 
   // attempt to install React Native or die trying
-  const rnExitCode = await reactNative.install({ name, skipJest: true })
-  if (rnExitCode > 0) process.exit(rnExitCode)
+  const rnInstall = await reactNative.install({ name, skipJest: true })
+  if (rnInstall.exitCode > 0) process.exit(rnInstall.exitCode)
 
   // copy our App directory
   spinner.text = '▸ copying files'

--- a/packages/ignite-unholy-app-template/package.json
+++ b/packages/ignite-unholy-app-template/package.json
@@ -26,5 +26,8 @@
   "devDependencies": {
     "babel-eslint": "^7.1.1",
     "standard": "^8.6.0"
+  },
+  "dependencies": {
+    "ramda": "^0.23.0"
   }
 }

--- a/packages/ignite-unholy-app-template/templates/package.json.ejs
+++ b/packages/ignite-unholy-app-template/templates/package.json.ejs
@@ -1,9 +1,6 @@
 {
-  "name": "<%= props.name %>",
   "version": "0.0.1",
-  "private": true,
   "scripts": {
-    "start": "node node_modules/react-native/local-cli/cli.js start",
     "lint": "standard --verbose | snazzy",
     "lintdiff": "git diff --name-only --cached --relative | grep '\\.js$' | xargs standard | snazzy",
     "fixcode": "standard --fix",
@@ -13,7 +10,6 @@
     "test": "NODE_ENV=production ava",
     "test:watch": "ava --watch",
     "coverage": "nyc ava && nyc report --reporter=html && open coverage/index.html || xdg-open coverage/index.html",
-    "tron": "node_modules/.bin/reactotron",
     "android:build": "cd android && ./gradlew assembleRelease",
     "android:install": "cd android && ./gradlew assembleRelease && ./gradlew installRelease",
     "android:hockeyapp": "cd android && ./gradlew assembleRelease && puck -submit=auto app/build/outputs/apk/app-release.apk",
@@ -23,13 +19,11 @@
     "flow": "flow --show-all-errors"
   },
   "dependencies": {
-    "apisauce": "^0.8.0",
+    "apisauce": "^0.10.0",
     "format-json": "^1.0.3",
     "lodash": "^4.17.2",
     "querystringify": "0.0.4",
     "ramda": "^0.23.0",
-    "react": "~15.4.0-rc.4",
-    "react-native": "<%= props.reactNativeVersion %>",
     "react-native-config": "^0.2.1",
     "react-native-device-info": "^0.10.0",
     "react-native-drawer": "^2.3.0",
@@ -54,10 +48,10 @@
     "react-addons-test-utils": "^15.3.1",
     "react-dom": "^15.4.0",
     "react-native-mock": "^0.2.8",
-    "reactotron-apisauce": "^1.6.0",
-    "reactotron-react-native": "^1.6.0",
-    "reactotron-redux": "^1.6.1",
-    "reactotron-redux-saga": "^1.6.0",
+    "reactotron-apisauce": "^1.7.0",
+    "reactotron-react-native": "^1.7.0",
+    "reactotron-redux": "^1.7.0",
+    "reactotron-redux-saga": "^1.7.0",
     "snazzy": "^6.0.0",
     "standard": "8.6.0",
     "standard-flow": "^1.0.0"


### PR DESCRIPTION
`ignite new Something --react-native-version 0.41.0` is working again.

Also, in unholy, we don't just copy our package.json overtop of the one that `react-native --init` creates.  We merge them together.  This will help us with subtle bugs when dependencies change in future releases on React Native.
