### PR TITLE
Removes __tests__ during an unholy ignite.

### DIFF
--- a/packages/ignite-unholy-app-template/index.js
+++ b/packages/ignite-unholy-app-template/index.js
@@ -42,6 +42,9 @@ const add = async function (context) {
   const rnInstall = await reactNative.install({ name, skipJest: true })
   if (rnInstall.exitCode > 0) process.exit(rnInstall.exitCode)
 
+  // remove the __tests__ directory that come with React Native
+  filesystem.remove('__tests__')
+
   // copy our App directory
   spinner.text = '▸ copying files'
   spinner.start()


### PR DESCRIPTION
For Unholy, we use `ava` currently.  This deletes that `__tests__` directory.

If we do switch to `jest` it won't be before 2.0 launches.

Fixes #724 