### PR TITLE
Adds support for React Native templates.

### DIFF
--- a/packages/ignite-cli/src/commands/new.js
+++ b/packages/ignite-cli/src/commands/new.js
@@ -99,7 +99,14 @@ module.exports = async function (context) {
   if (parameters.options.debug) extraAddOptions.push('--debug')
 
   // pass react-native version down the chain
-  if (parameters.options['react-native-version']) extraAddOptions.push(`--react-native-version ${parameters.options['react-native-version']}`)
+  if (parameters.options['react-native-version']) {
+    extraAddOptions.push(`--react-native-version ${parameters.options['react-native-version']}`)
+  }
+
+  // pass react-native version down the chain
+  if (parameters.options['react-native-template']) {
+    extraAddOptions.push(`--react-native-template ${parameters.options['react-native-template']}`)
+  }
 
   // let's kick off the template
   let ok = false

--- a/packages/ignite-cli/src/lib/exitCodes.js
+++ b/packages/ignite-cli/src/lib/exitCodes.js
@@ -45,5 +45,10 @@ module.exports = {
   /**
    * This directory already exists
    */
-  DIRECTORY_EXISTS: 8
+  DIRECTORY_EXISTS: 8,
+
+  /**
+   * Problem installing React Native
+   */
+  REACT_NATIVE_INSTALL: 9
 }


### PR DESCRIPTION
Closes #730.

```sh
ignite new SweetBabyJesus \
  --empty \
  --react-native-version 0.42.0-rc.3 \
  --react-native-template navigation
```


This was quick & dirty, but it'd be nice to integrate at a deeper level.  

For example, I'd like to explore embracing their templates as being the blessed way to do our app templates.  It's kinda awkward having both.

![image](https://cloud.githubusercontent.com/assets/68273/23272281/992d0d0e-f9c8-11e6-85a6-3577d5cfcded.png)

![image](https://cloud.githubusercontent.com/assets/68273/23272427/335b050c-f9c9-11e6-8a31-abd31139111e.png)

Their fallback of checking `react-native-template-*` on npm is 💯 (see https://github.com/facebook/react-native/pull/12548).


