### PR TITLE
Bumps gluegun to require 7.6

### DIFF
--- a/packages/ignite-cli/bin/ignite
+++ b/packages/ignite-cli/bin/ignite
@@ -1,4 +1,4 @@
-#!/usr/bin/env node --harmony
+#!/usr/bin/env node
 
 const sourceDir = `${__dirname}/../src/cli`
 

--- a/packages/ignite-cli/package.json
+++ b/packages/ignite-cli/package.json
@@ -7,10 +7,10 @@
   },
   "preferGlobal": true,
   "scripts": {
-    "test": "node --harmony node_modules/.bin/ava",
-    "watch": "node --harmony node_modules/.bin/ava --watch",
+    "test": "ava",
+    "watch": "ava --watch",
     "coverage": "nyc ava",
-    "start": "node --harmony src/index.js",
+    "start": "node src/index.js",
     "lint": "standard"
   },
   "repository": "infinitered/ignite",
@@ -29,7 +29,7 @@
   ],
   "license": "MIT",
   "dependencies": {
-    "gluegun": "^0.14.0",
+    "gluegun": "^0.15.0",
     "gluegun-patching": "^0.3.0",
     "minimist": "^1.2.0",
     "ramda": "^0.23.0",

--- a/packages/ignite-cli/src/cli/check.js
+++ b/packages/ignite-cli/src/cli/check.js
@@ -3,13 +3,13 @@ const { nodeVersion, isNewEnough, hasAsyncAwait } = require('gluegun/sniff')
 
 // check the node version
 if (!isNewEnough) {
-  console.log(`Node.js 7+ is required to run. You have ${nodeVersion}. Womp, womp.`)
+  console.log(`Node.js 7.6+ is required to run. You have ${nodeVersion}. Womp, womp.`)
   process.exit(1)
 }
 
 // check for async and await
 if (!hasAsyncAwait) {
-  console.log(`Node.js --harmony is required.`)
+  console.log(`The async feature is not available. Please ensure your Node is up to date.`)
   process.exit(2)
 }
 


### PR DESCRIPTION
This PR makes node 7.6 a requirement now.

`async` and `await` are now part of the core.   No more living in `--harmony`.

Don't forget to upgrade to Node 7.6 `n 7.6` and `npm run bootstrap` after grabbing master.

