### PR TITLE
Updates ignite new to check/install react-native-cli

### DIFF
--- a/packages/ignite-cli/src/extensions/reactNative.js
+++ b/packages/ignite-cli/src/extensions/reactNative.js
@@ -56,6 +56,17 @@ function attach (plugin, command, context) {
       rnOptions.push('--skip-jest')
     }
 
+    // install React Native CLI if it isn't found
+    const rncliSpinner = print.spin(`installing react-native-cli`)
+    try {
+      await system.exec('which react-native', { stdio: 'ignore' })
+      rncliSpinner.succeed(`checked react-native-cli`)
+    } catch (e) {
+      // No React Native installed, let's get it
+      await system.exec('npm install -g react-native-cli', { stdio: 'ignore' })
+      rncliSpinner.succeed(`installed react-native-cli`)
+    }
+
     // react-native init
     const cmd = `react-native init ${name} ${rnOptions.join(' ')}`
     log('initializing react native')


### PR DESCRIPTION
Fixes #612.

When `react-native-cli` is not installed:

![screen shot 2017-02-26 at 4 35 12 pm](https://cloud.githubusercontent.com/assets/1479215/23345339/933bb050-fc41-11e6-82f1-4687d1e3f6b1.png)

When `react-native-cli` is already installed:

![screen shot 2017-02-26 at 4 35 17 pm](https://cloud.githubusercontent.com/assets/1479215/23345341/9ead7112-fc41-11e6-8340-11b670dea703.png)

