### PR TITLE
Adds temporary spinner during Unholy install

### DIFF
--- a/packages/ignite-cli/src/commands/new.js
+++ b/packages/ignite-cli/src/commands/new.js
@@ -49,6 +49,10 @@ module.exports = async function (context) {
   }
   print.info(`🔥 igniting app ${print.colors.yellow(projectName)}`)
 
+  // Display a temporary spinner to indicate something's happening
+  const spinner = print.spin('initializing Ignite')
+  setTimeout(() => spinner.stop(), 4000)
+
   /**
    * Figures out which app template we'll be using (without the ignite- prefix).
    *

--- a/packages/ignite-cli/src/extensions/reactNative.js
+++ b/packages/ignite-cli/src/extensions/reactNative.js
@@ -57,12 +57,13 @@ function attach (plugin, command, context) {
     }
 
     // install React Native CLI if it isn't found
-    const rncliSpinner = print.spin(`installing react-native-cli`)
-    try {
-      await system.exec('which react-native', { stdio: 'ignore' })
+    const rncliSpinner = print.spin(`checking react-native-cli`)
+    const cliInstalled = await system.which('react-native')
+    if (cliInstalled) {
       rncliSpinner.succeed(`checked react-native-cli`)
-    } catch (e) {
+    } else {
       // No React Native installed, let's get it
+      rncliSpinner.text = 'installing react-native-cli'
       await system.exec('npm install -g react-native-cli', { stdio: 'ignore' })
       rncliSpinner.succeed(`installed react-native-cli`)
     }

--- a/packages/ignite-unholy-app-template/index.js
+++ b/packages/ignite-unholy-app-template/index.js
@@ -1,5 +1,12 @@
 const { merge, pipe, assoc, omit, __ } = require('ramda')
 
+// Hack to get around `ignite add <x>` spin-up delay
+const addTemporarySpinner = (package, spinner) => {
+  spinner.text = `initializing ${package}`
+  spinner.start()
+  setTimeout(() => spinner.stop(), 8000)
+}
+
 // Questions to ask during install if the chatty route is chosen.
 const installQuestions = [
   {
@@ -118,22 +125,27 @@ const add = async function (context) {
   // pass long the debug flag if we're running in that mode
   const debugFlag = parameters.options.debug ? '--debug' : 'p'
 
+  addTemporarySpinner('basic-generators', spinner)
   await system.spawn(`ignite add ${igniteDevPackagePrefix}basic-generators ${debugFlag}`, { stdio: 'inherit' })
 
   // now run install of Ignite Plugins
   if (answers['dev-screens'] === 'Yes') {
+    addTemporarySpinner('dev-screens', spinner)
     await system.spawn(`ignite add ${igniteDevPackagePrefix}dev-screens ${debugFlag}`, { stdio: 'inherit' })
   }
 
   if (answers['vector-icons'] === 'react-native-vector-icons') {
+    addTemporarySpinner('vector-icons', spinner)
     await system.spawn(`ignite add ${igniteDevPackagePrefix}vector-icons ${debugFlag}`, { stdio: 'inherit' })
   }
 
   if (answers['i18n'] === 'react-native-i18n') {
+    addTemporarySpinner('i18n', spinner)
     await system.spawn(`ignite add ${igniteDevPackagePrefix}i18n ${debugFlag}`, { stdio: 'inherit' })
   }
 
   if (answers['animatable'] === 'react-native-animatable') {
+    addTemporarySpinner('animatable', spinner)
     await system.spawn(`ignite add ${igniteDevPackagePrefix}animatable ${debugFlag}`, { stdio: 'inherit' })
   }
 


### PR DESCRIPTION
We'll need to do the same for other templates when we expand those, but this makes the standard unholy app template look better during `ignite new`. Fixes #717.


![ignite-new2](https://cloud.githubusercontent.com/assets/1479215/23346044/8e0f36d8-fc4b-11e6-8364-56796cbe77f0.gif)

