### PR TITLE
Adds a warning if trying to ignite remove /path/to/plugin

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 
 All active development is taking place on the `master` branch.  If you're contributing to v2, welcome!  You're in the right place.
 
-We're aiming to release around the end of February.
+We're aiming to release around the first week of March.
 
 ### Ignite
 
@@ -15,15 +15,13 @@ We're aiming to release around the end of February.
 <p align="center">
   :fire: The ideal starting app for React Native, best practices, generators, and more. :fire:
   <br/>
-  <a href="https://infiniteredcommunity.herokuapp.com/">
+  <a href="https://community.infinite.red/">
     <img src="https://infiniteredcommunity.herokuapp.com/badge.svg">
   </a>
-  <a href="https://gitter.im/infinitered/ignite?utm_source=badge&utm_medium=badge&utm_campaign=pr-badge&utm_content=badge" target="_blank"><img src="https://badges.gitter.im/infinitered/ignite.svg" alt="Join the chat at https://gitter.im/infinitered/ignite"></a>
   <a href="https://www.codacy.com/app/gantman/ignite?utm_source=github.com&amp;utm_medium=referral&amp;utm_content=infinitered/ignite&amp;utm_campaign=Badge_Grade" target="_blank"><img src="https://api.codacy.com/project/badge/Grade/1c6e04abe7224bdc88095129b5eb43fb"/></a>
   <img src=https://img.shields.io/badge/code%20style-standard-brightgreen.svg?style=flat alt='js-standard-style'/>
   <a href="https://semaphoreci.com/ir/ignite" target="_blank"><img src=https://semaphoreci.com/api/v1/ir/ignite/branches/master/shields_badge.svg alt='Build Status'/></a>
   <a href="https://badge.fury.io/js/react-native-ignite" target="_blank"><img src="https://badge.fury.io/js/react-native-ignite.svg" alt="npm version" height="20"></a>
-
 </p>
 
 #### :earth_americas: [Tour Video and More on Ignite Web Page](https://infinite.red/ignite)

--- a/packages/ignite-cli/src/commands/add.js
+++ b/packages/ignite-cli/src/commands/add.js
@@ -7,6 +7,7 @@ const R = require('ramda')
 const detectedChanges = require('../lib/detectedChanges')
 const detectInstall = require('../lib/detectInstall')
 const isIgniteDirectory = require('../lib/isIgniteDirectory')
+const prependIgnite = require('../lib/prependIgnite')
 const exitCodes = require('../lib/exitCodes')
 
 /**

--- a/packages/ignite-cli/src/commands/plugin.js
+++ b/packages/ignite-cli/src/commands/plugin.js
@@ -3,6 +3,7 @@
 // ----------------------------------------------------------------------------
 
 const exitCodes = require('../lib/exitCodes')
+const prependIgnite = require('../lib/prependIgnite')
 
 /**
  * Does a walkthrough of questions and returns the answers as an object.
@@ -57,7 +58,7 @@ const validateName = (pluginName, context) => {
   }
 
   // Force prepend `ignite-*` to plugin name
-  return /^ignite-/.test(pluginName) ? pluginName : 'ignite-' + pluginName
+  return prependIgnite(pluginName)
 }
 
 /**

--- a/packages/ignite-cli/src/commands/remove.js
+++ b/packages/ignite-cli/src/commands/remove.js
@@ -3,7 +3,7 @@
 // ----------------------------------------------------------------------------
 
 const Shell = require('shelljs')
-const R = require('ramda')
+const { reduce, concat, keys, pathOr, join, map, assoc } = require('ramda')
 const isIgniteDirectory = require('../lib/isIgniteDirectory')
 const exitCodes = require('../lib/exitCodes')
 
@@ -11,18 +11,18 @@ const exitCodes = require('../lib/exitCodes')
 const useYarn = false
 
 const detectRemovals = (configObject, moduleName) => {
-  return R.reduce((acc, k) => {
+  return reduce((acc, k) => {
     if (configObject[k] === moduleName) {
-      return R.concat([`${k}`], acc)
+      return concat([`${k}`], acc)
     }
     return acc
-  }, [], R.keys(configObject))
+  }, [], keys(configObject))
 }
 
 const existsLocally = (moduleName) => {
   // we take a look at the local package.json
   const pack = require(`${process.cwd()}/package.json`)
-  return R.pathOr(null, ['devDependencies', moduleName], pack)
+  return pathOr(null, ['devDependencies', moduleName], pack)
 }
 
 const noMegusta = (moduleName) => {
@@ -58,12 +58,12 @@ module.exports = async function (context) {
     // Ask user if they are sure.
     if (changes.length > 0) {
       // we warn the user on changes
-      warning(`The following generators would be removed: ${R.join(', ', changes)}`)
+      warning(`The following generators would be removed: ${join(', ', changes)}`)
       const ok = await prompt.confirm('You ok with that?')
       if (ok) {
         const generatorsList = Object.assign({}, config.generators)
-        R.map((k) => delete generatorsList[k], changes)
-        const updatedConfig = R.assoc('generators', generatorsList, config)
+        map((k) => delete generatorsList[k], changes)
+        const updatedConfig = assoc('generators', generatorsList, config)
         ignite.saveIgniteConfig(updatedConfig)
       } else {
         process.exit(exitCodes.GENERIC)

--- a/packages/ignite-cli/src/lib/detectInstall.js
+++ b/packages/ignite-cli/src/lib/detectInstall.js
@@ -1,18 +1,4 @@
-const { startsWith } = require('ramdasauce')
-const { unless, concat } = require('ramda')
-
-/**
- * Ensures the given string starts with 'ignite-'.
- *
- * @param {string} value The string to check.
- * @returns {string} The same string, but better.
- */
-const alwaysStartWithIgnite = function (value) {
-  return unless(
-    startsWith('ignite-'),
-    concat('ignite-')
-  )(value)
-}
+const prependIgnite = require('./prependIgnite')
 
 /**
  * Detects the type of install the user is requesting for this plugin.
@@ -49,7 +35,7 @@ function detectInstall (context) {
 
   // this is a npmjs module
   return {
-    moduleName: alwaysStartWithIgnite(thing),
+    moduleName: prependIgnite(thing),
     type: 'npm'
   }
 }

--- a/packages/ignite-cli/src/lib/prependIgnite.js
+++ b/packages/ignite-cli/src/lib/prependIgnite.js
@@ -1,0 +1,11 @@
+/**
+ * Ensures the given string starts with 'ignite-'.
+ *
+ * @param {string} value The string to check.
+ * @returns {string} The same string, but better.
+ */
+const prependIgnite = function (value) {
+  return /^ignite-/.test(value) ? value : 'ignite-' + value
+}
+
+module.exports = prependIgnite


### PR DESCRIPTION
Per #702 , this PR adds a warning if you try to remove via a path.

![screen shot 2017-02-26 at 7 02 09 pm](https://cloud.githubusercontent.com/assets/1479215/23347299/18942af2-fc56-11e6-9b49-b7a9bc78a027.png)

I also fixed a bug where doing `ignite remove ignite-<plugin>` would try to remove `ignite-ignite-<plugin>`, and also refactored the prepending function to be used consistently from everywhere. Also a bit less Rambda/Rambdasauce and more vanilla JS.

I then snuck in a launch deadline update to the README. Steve will kill me for so many unrelated things in this PR if he notices.