### PR TITLE
Adds an ignite.json to plugin template with optional command

### DIFF
--- a/packages/ignite-cli/src/commands/plugin.js
+++ b/packages/ignite-cli/src/commands/plugin.js
@@ -92,7 +92,7 @@ const createNewPlugin = async (context) => {
   ]
 
   // copy over the files
-  await ignite.copyBatch(context, copyJobs, {name, pluginName, answers})
+  await ignite.copyBatch(context, copyJobs, {name, pluginName, answers, isGenerator: answers.command === 'Yes'})
 }
 
 /**

--- a/packages/ignite-cli/src/templates/plugin/ignite.json.ejs
+++ b/packages/ignite-cli/src/templates/plugin/ignite.json.ejs
@@ -1,0 +1,5 @@
+{
+  <% if (props.isGenerator) { %>
+    'generators': [ 'thing' ]
+  <% } %>
+}


### PR DESCRIPTION
There's an issue with `ignite plugin new <x>` where it's looking for an ignite.json file. This PR adds one.

