### PR TITLE
Escapes plugin command template properly

### DIFF
--- a/packages/ignite-cli/src/templates/plugin/templates/thing.js.ejs.ejs
+++ b/packages/ignite-cli/src/templates/plugin/templates/thing.js.ejs.ejs
@@ -1,3 +1,4 @@
 // Replace with your own template "thing".
 
-<%= '<%= props.name %>' %> // Pass in props from your command.
+// Pass in props from your command.
+<%- '<' + '%= props.name %' + '>' /* i'm so sorry */ %>

--- a/packages/ignite-cli/src/templates/plugin/templates/thing.js.ejs.ejs
+++ b/packages/ignite-cli/src/templates/plugin/templates/thing.js.ejs.ejs
@@ -1,3 +1,3 @@
 // Replace with your own template "thing".
 
-<%= props.name %> // Pass in props from your command.
+<%= '<%= props.name %>' %> // Pass in props from your command.

--- a/packages/ignite-cli/src/templates/plugin/templates/thing.js.ejs.ejs
+++ b/packages/ignite-cli/src/templates/plugin/templates/thing.js.ejs.ejs
@@ -1,4 +1,8 @@
 // Replace with your own template "thing".
 
 // Pass in props from your command.
-<%- '<' + '%= props.name %' + '>' /* i'm so sorry */ %>
+<%-
+  // i'm so sorry - the right answer is in
+  // https://github.com/mde/ejs/blob/master/docs/syntax.md somewhere
+  '<' + '%= props.name %' + '>'
+%>


### PR DESCRIPTION
Since we're emitting an ejs file from an ejs file, things get wonky. This fixes that and adds a comment to make it better later.