### PR TITLE
Add current working directory to ignite doctor

### DIFF
--- a/packages/ignite-cli/src/commands/doctor.js
+++ b/packages/ignite-cli/src/commands/doctor.js
@@ -31,12 +31,14 @@ module.exports = async function (context) {
   const firstCpu = head(cpus) || {}
   const cpu = `${firstCpu.model}`
   const cores = `${cpus.length} cores`
+  const directory = `${process.cwd()}`
 
   info(colors.cyan('System'))
   table([
     [column1('platform'), column2(platform)],
     [column1('arch'), column2(arch)],
-    [column1('cpu'), column2(cores), column3(cpu)]
+    [column1('cpu'), column2(cores), column3(cpu)],
+    [column1('directory'), column2(directory)]
   ])
 
   // -=-=-=- javascript -=-=-=-


### PR DESCRIPTION
## Please verify the following:
- [x] Everything works on iOS/Android
- [ ] `ignite-base` **ava** tests pass
     One test failure, I believe is unrelated. 
- [x] `fireDrill.sh` passed

## Describe your PR

This is for https://github.com/infinitered/ignite/issues/710.

Adds a line to the output of `ignite doctor` that is the directory in which `ignite doctor` was run. 

