### PR TITLE
Fixes path resolving issues.

### DIFF
--- a/packages/ignite-cli/src/lib/detectInstall.js
+++ b/packages/ignite-cli/src/lib/detectInstall.js
@@ -31,19 +31,20 @@ function detectInstall (context) {
       filesystem.exists(`${candidate}/package.json`) === 'file'
 
   // the plugin we're trying to install
-  const plugin = prependIgnite(parameters.second)
+  const plugin = parameters.second
+  const ignitePlugin = prependIgnite(plugin)
 
   // do we have overrides?
   if (pluginOverrides.length > 0) {
     // look for the plugin into one of our override paths
     const foundPath = find(
-      overridePath => isValidIgnitePluginDirectory(`${overridePath}/${plugin}`),
+      overridePath => isValidIgnitePluginDirectory(`${overridePath}/${ignitePlugin}`),
       pluginOverrides
     )
 
     // did we find it?
     if (foundPath) {
-      const path = `${foundPath}/${plugin}`
+      const path = `${foundPath}/${ignitePlugin}`
       return {
         directory: path,
         override: true,
@@ -65,7 +66,7 @@ function detectInstall (context) {
 
   // the default is to assume that npm can figure out where to get this
   return {
-    moduleName: plugin,
+    moduleName: ignitePlugin,
     type: 'npm'
   }
 }

--- a/packages/ignite-cli/tests/lib/detectInstall.test.js
+++ b/packages/ignite-cli/tests/lib/detectInstall.test.js
@@ -57,7 +57,18 @@ test('detects invalid plugin directories', async t => {
   t.deepEqual(actual, expected)
 })
 
-test('plugins from a directory that is an override', async t => {
+/**
+ * 🚨 SUPER DANGER SAUCE 🚨
+ *
+ * This test has a serial function on it.  That means, AVA will run this first
+ * before the other tests.  The reason why is because mockFs changes the environment.
+ * And the other test expects the environment to be sane.
+ *
+ * Both tests are legit, it's just they can't be run in parallel.
+ *
+ * Slow clap standing ovation to AVA for having test.serial!
+ */
+test.serial('plugins from a relative directory that is an override', async t => {
   const moduleName = 'ignite-some-plugin'
 
   // pretend we have a directory with a plugin
@@ -82,6 +93,27 @@ test('plugins from a directory that is an override', async t => {
     filesystem,
     parameters: { second: moduleName },
     ignite: { pluginOverrides: ['override-land'] }
+  })
+
+  t.deepEqual(actual, expected)
+})
+
+test('plugins from a absolute directory that is an override', async t => {
+  const fixturesPath = path.resolve(`${__dirname}/../fixtures`)
+
+  // we're looking for the override version
+  const expected = {
+    type: 'directory',
+    moduleName: 'ignite-valid-plugin',
+    override: true,
+    directory: `${fixturesPath}/ignite-valid-plugin`
+  }
+
+  // detect
+  const actual = detectInstall({
+    filesystem,
+    parameters: { second: 'valid-plugin' },
+    ignite: { pluginOverrides: [fixturesPath] }
   })
 
   t.deepEqual(actual, expected)

--- a/packages/ignite-integration-tests/test/ignite-new/newMin.test.js
+++ b/packages/ignite-integration-tests/test/ignite-new/newMin.test.js
@@ -1,6 +1,7 @@
 const test = require('ava')
 const execa = require('execa')
 const jetpack = require('fs-jetpack')
+const path = require('path')
 
 const IGNITE = '../../../ignite-cli/bin/ignite'
 const VERSION = jetpack.read('../ignite-cli/package.json', 'json').version
@@ -15,7 +16,11 @@ test.before(async () => {
   jetpack.remove(RUN_DIR)
   jetpack.dir(RUN_DIR)
   process.chdir(RUN_DIR)
-  await execa(IGNITE, ['new', APP, '--min'])
+  await execa(IGNITE, ['new', APP, '--min'], {
+    env: {
+      IGNITE_PLUGIN_PATH: path.resolve(BACK_DIR, '..')
+    }
+  })
 })
 
 // always clean up


### PR DESCRIPTION
`ignite-` was being prepended to absolute paths.  

`ignite-/Users/steve/plugin` when it should have been `/Users/steve/ignite-plugin`.

