### PR TITLE
Adds the flag '-y' as an alias of '--confirm' to ignite remove

### DIFF
--- a/docs/quick-start/ignite-commands.md
+++ b/docs/quick-start/ignite-commands.md
@@ -98,11 +98,11 @@ command or generator.
 ### Remove
 
 ```
-ignite remove {ignite plugin name} [--confirm]
+ignite remove {ignite plugin name} [-y]
 ```
 
-Removes an Ignite plugin. You can add `--confirm` which automatically answers
-"yes" to the remove generator confirmation question.
+Removes an Ignite plugin. You can add `-y` which automatically answers
+"yes" to any confirmation questions.
   
 The opposite of `ignite add`, this removes a plugin from your project. Be warned
 that this may change other files in your project, e.g. to undo changes made by

--- a/packages/ignite-cli/src/commands/remove.js
+++ b/packages/ignite-cli/src/commands/remove.js
@@ -46,6 +46,7 @@ module.exports = async function (context) {
   // grab a fist-full of features...
   const { print, parameters, prompt, filesystem, ignite } = context
   const { info, warning, xmark, error, success } = print
+  const { options } = parameters
 
   // take the last parameter (because of https://github.com/infinitered/gluegun/issues/123)
   const moduleParam = parameters.array.pop()
@@ -71,8 +72,7 @@ module.exports = async function (context) {
     if (changes.length > 0) {
       // we warn the user on changes
       let ok
-      // print.debug(parameters)
-      if (parameters.options.confirm) {
+      if (options.y || options.yes || options.confirm) {
         ok = true
       } else {
         warning(`The following generators would be removed: ${join(', ', changes)}`)


### PR DESCRIPTION
Per #787, you can now use `-y` or `--yes` in addition to `--confirm`.