### PR TITLE
Adds ignite --help and modifies the output slightly.

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,3 @@
+// Place your settings in this file to overwrite default and user settings.
+{
+}

--- a/packages/ignite-cli/src/cli/cli.js
+++ b/packages/ignite-cli/src/cli/cli.js
@@ -43,11 +43,14 @@ module.exports = async function run (argv) {
   // run the command
   const context = await runtime.run()
 
-  // print the commands (TODO: but not if we just ran i guess)
-  if (isNil(context.plugin) || isNil(context.command)) {
+  if (commandLine.help || commandLine.h || isNil(context.plugin) || isNil(context.command)) {
+    // no args, show help
+    print.info('')
     header()
     printCommands(context)
-    return context
+    print.info('')
+    print.info(print.colors.magenta('If you need additional help, join our Slack at http://community.infinite.red'))
+    print.info('')
   }
 
   if (context.error) {

--- a/packages/ignite-cli/src/commands/doctor.js
+++ b/packages/ignite-cli/src/commands/doctor.js
@@ -2,7 +2,6 @@
 // ----------------------------------------------------------------------------
 
 const { split, last, replace, head, match } = require('ramda')
-const header = require('../brand/header')
 const os = require('os')
 const isWindows = process.platform === 'win32'
 const isMac = process.platform === 'darwin'
@@ -20,9 +19,6 @@ module.exports = async function (context) {
   const column1 = (label, length = 16) => padEnd(label || '', length)
   const column2 = label => colors.yellow(padEnd(label || '-', 10))
   const column3 = label => colors.muted(label)
-
-  header()
-  info('')
 
   // -=-=-=- system -=-=-=-
   const platform = process.platform

--- a/packages/ignite-cli/src/commands/new.js
+++ b/packages/ignite-cli/src/commands/new.js
@@ -49,11 +49,8 @@ module.exports = async function (context) {
     license: 'MIT'
   })
 
-  // pretty bird, yes, pretty bird... petey is a pretty bird.
-  if (!parameters.options.debug) {
-    header()
-    print.newline()
-  }
+  header()
+  print.newline()
   print.info(`🔥 igniting app ${print.colors.yellow(projectName)}`)
 
   /**


### PR DESCRIPTION
More judicious use of the Ignite header too.

<img width="645" alt="screen shot 2017-03-02 at 1 10 08 pm" src="https://cloud.githubusercontent.com/assets/1479215/23527319/56c00836-ff4a-11e6-9b5e-f3ae62318f72.png">
