### PR TITLE
Rename plugin methods

### DIFF
--- a/packages/ignite-basic-generators/index.js
+++ b/packages/ignite-basic-generators/index.js
@@ -18,12 +18,12 @@ const screenExamples = [
 
 const add = async function (context) {
   // examples of generated screens
-  await context.ignite.addScreenExamples(screenExamples)
+  await context.ignite.addPluginScreenExamples(screenExamples)
 }
 
 const remove = async function (context) {
   // remove screens
-  await context.ignite.removeScreenExamples(screenExamples)
+  await context.ignite.removePluginScreenExamples(screenExamples)
 }
 
 module.exports = { add, remove }

--- a/packages/ignite-cli/src/commands/add.js
+++ b/packages/ignite-cli/src/commands/add.js
@@ -230,7 +230,7 @@ Examples:
         return exitCodes.OK
       } catch (err) {
         // it's up to the throwers of this error to ensure the error message is human friendly.
-        // to do this, we need to ensure all our core features like `addModule`, `addComponentExample`, etc
+        // to do this, we need to ensure all our core features like `addModule`, `addPluginComponentExample`, etc
         // all play along nicely.
         spinner.fail(err.message)
         process.exit(exitCodes.PLUGIN_INSTALL)

--- a/packages/ignite-cli/src/extensions/ignite.js
+++ b/packages/ignite-cli/src/extensions/ignite.js
@@ -7,11 +7,15 @@ const igniteConfigExt = require('./ignite/igniteConfig')
 const findIgnitePluginsExt = require('./ignite/findIgnitePlugins')
 const addModuleExt = require('./ignite/addModule')
 const removeModuleExt = require('./ignite/removeModule')
-const addScreenExamplesExt = require('./ignite/addScreenExamples')
-const removeScreenExamplesExt = require('./ignite/removeScreenExamples')
+const addScreenExamplesExt = require('./ignite/addScreenExamples')//Deprecated 3/2/17, Ignite 2 Beta
+const addPluginScreenExamplesExt = require('./ignite/addPluginScreenExamples')
+const removeScreenExamplesExt = require('./ignite/removeScreenExamples') //Deprecated 3/2/17, Ignite 2 Beta
+const removePluginScreenExamplesExt = require('./ignite/removePluginScreenExamples')
 const copyBatchExt = require('./ignite/copyBatch')
-const addComponentExampleExt = require('./ignite/addComponentExample')
-const removeComponentExampleExt = require('./ignite/removeComponentExample')
+const addComponentExampleExt = require('./ignite/addComponentExample') //Deprecated 3/2/17, Ignite 2 Beta
+const addPluginComponentExampleExt = require('./ignite/addPluginComponentExample')
+const removeComponentExampleExt = require('./ignite/removeComponentExample') //Deprecated 3/2/17, Ignite 2 Beta
+const removePluginComponentExampleExt = require('./ignite/removePluginComponentExample')
 const setDebugConfigExt = require('./ignite/setDebugConfig')
 const removeDebugConfigExt = require('./ignite/removeDebugConfig')
 const patchInFileExt = require('./ignite/patchInFile')
@@ -61,10 +65,14 @@ function attach (plugin, command, context) {
     addModule: addModuleExt(plugin, command, context),
     removeModule: removeModuleExt(plugin, command, context),
     copyBatch: copyBatchExt(plugin, command, context),
-    addComponentExample: addComponentExampleExt(plugin, command, context),
-    removeComponentExample: removeComponentExampleExt(plugin, command, context),
-    addScreenExamples: addScreenExamplesExt(plugin, command, context),
-    removeScreenExamples: removeScreenExamplesExt(plugin, command, context),
+    addComponentExample: addComponentExampleExt(plugin, command, context), //Deprecated 3/2/17, Ignite 2 Beta
+    addPluginComponentExample: addPluginComponentExampleExt(plugin, command, context),
+    removeComponentExample: removeComponentExampleExt(plugin, command, context), //Deprecated 3/2/17, Ignite 2 Beta
+    removePluginComponentExample: removePluginComponentExampleExt(plugin, command, context),
+    addScreenExamples: addScreenExamplesExt(plugin, command, context), //Deprecated 3/2/17, Ignite 2 Beta
+    addPluginScreenExamples: addPluginScreenExamplesExt(plugin, command, context),
+    removeScreenExamples: removeScreenExamplesExt(plugin, command, context), //Deprecated 3/2/17, Ignite 2 Beta
+    removePluginScreenExamples: removePluginScreenExamplesExt(plugin, command, context),
     setDebugConfig: setDebugConfigExt(plugin, command, context),
     removeDebugConfig: removeDebugConfigExt(plugin, command, context),
     patchInFile: patchInFileExt(plugin, command, context),

--- a/packages/ignite-cli/src/extensions/ignite/addComponentExample.js
+++ b/packages/ignite-cli/src/extensions/ignite/addComponentExample.js
@@ -5,37 +5,11 @@ module.exports = (plugin, command, context) => {
    * @param {string} fileName - The js file to create. (.ejs will be appended to pick up the template.)
    * @param {Object} props - The properties to use for template expansion.
    */
+  // DEPRECATED as of 3/2/17 as part of Ignite 2 Beta (https://github.com/infinitered/ignite/issues/636)
   async function addComponentExample (fileName, props = {}) {
     const { filesystem, patching, ignite, print, template } = context
-    const { ignitePluginPath } = ignite
-    const config = ignite.loadIgniteConfig()
-
-    // do we want to use examples in the classic format?
-    if (config.examples === 'classic') {
-      const spinner = print.spin(`▸ adding component example`)
-
-      // generate the file
-      const templatePath = ignitePluginPath()
-        ? `${ignitePluginPath()}/templates`
-        : `templates`
-      template.generate({
-        directory: templatePath,
-        template: `${fileName}.ejs`,
-        target: `ignite/Examples/Components/${fileName}`,
-        props
-      })
-
-      // adds reference to usage example screen (if it exists)
-      const destinationPath = `${process.cwd()}/ignite/DevScreens/PluginExamplesScreen.js`
-      if (filesystem.exists(destinationPath)) {
-        patching.insertInFile(
-          destinationPath,
-          'import ExamplesRegistry',
-          `import '../Examples/Components/${fileName}'`
-        )
-      }
-      spinner.stop()
-    }
+    print.warning('DEPRECATION WARNING: Heads up! `ignite.addComponentExample` is deprecated. Please use `ignite.addPluginComponentExample` instead!')
+    ignite.addPluginComponentExample(fileName, props)
   }
 
   return addComponentExample

--- a/packages/ignite-cli/src/extensions/ignite/addPluginComponentExample.js
+++ b/packages/ignite-cli/src/extensions/ignite/addPluginComponentExample.js
@@ -1,0 +1,42 @@
+module.exports = (plugin, command, context) => {
+  /**
+   * Generates an example for use with the dev screens.
+   *
+   * @param {string} fileName - The js file to create. (.ejs will be appended to pick up the template.)
+   * @param {Object} props - The properties to use for template expansion.
+   */
+  async function addPluginComponentExample (fileName, props = {}) {
+    const { filesystem, patching, ignite, print, template } = context
+    const { ignitePluginPath } = ignite
+    const config = ignite.loadIgniteConfig()
+
+    // do we want to use examples in the classic format?
+    if (config.examples === 'classic') {
+      const spinner = print.spin(`▸ adding component example`)
+
+      // generate the file
+      const templatePath = ignitePluginPath()
+        ? `${ignitePluginPath()}/templates`
+        : `templates`
+      template.generate({
+        directory: templatePath,
+        template: `${fileName}.ejs`,
+        target: `ignite/Examples/Components/${fileName}`,
+        props
+      })
+
+      // adds reference to usage example screen (if it exists)
+      const destinationPath = `${process.cwd()}/ignite/DevScreens/PluginExamplesScreen.js`
+      if (filesystem.exists(destinationPath)) {
+        patching.insertInFile(
+          destinationPath,
+          'import ExamplesRegistry',
+          `import '../Examples/Components/${fileName}'`
+        )
+      }
+      spinner.stop()
+    }
+  }
+
+  return addPluginComponentExample
+}

--- a/packages/ignite-cli/src/extensions/ignite/addPluginScreenExamples.js
+++ b/packages/ignite-cli/src/extensions/ignite/addPluginScreenExamples.js
@@ -1,0 +1,101 @@
+const { reduce, flatten, takeLast, split, map, replace } = require('ramda')
+const path = require('path')
+
+module.exports = (plugin, command, context) => {
+  /**
+   * Generates example screens for in dev screens.
+   *
+   * @param {Array} files - Array of Screens and properties
+   * @param {Object} props - The properties to use for template expansion.
+   *
+   * example:
+   * addScreenExamples([
+   *   {title: 'Row Example', screen: 'Row.js', ancillary: ['file1', 'file2']},
+   *   {title: 'Grid Example', screen: 'Grid.js', ancillary: ['file']},
+   *   {title: 'Section Example', screen: 'Section.js', ancillary: ['file']},
+   * ])
+   */
+  async function addPluginScreenExamples (files, props = {}) {
+    const { filesystem, patching, ignite, print, template } = context
+    const { ignitePluginPath } = ignite
+
+    const config = ignite.loadIgniteConfig()
+    // consider this being part of context.ignite
+    const pluginName = takeLast(1, split(path.sep, ignitePluginPath()))[0]
+
+    // currently only supporting 1 form of examples
+    if (config.examples === 'classic') {
+      const spinner = print.spin(`▸ adding screen examples`)
+
+      // merge and flatten all dem files yo.
+      let allFiles = reduce(
+        (acc, v) => {
+          acc.push(v.screen)
+          if (v.ancillary) acc.push(v.ancillary)
+          return flatten(acc)
+        },
+        [],
+        files
+      )
+
+      // generate stamped copy of all template files
+      const templatePath = ignitePluginPath()
+        ? `${ignitePluginPath()}/templates`
+        : `templates`
+      map(
+        fileName => {
+          template.generate({
+            directory: templatePath,
+            template: `${fileName}.ejs`,
+            target: `ignite/Examples/Containers/${pluginName}/${fileName}`,
+            props
+          })
+        },
+        allFiles
+      )
+
+      // insert screen, route, and buttons in PluginExamples (if exists)
+      const destinationPath = `${process.cwd()}/ignite/DevScreens/PluginExamplesScreen.js`
+      map(
+        file => {
+          // turn things like "examples/This File-Example.js" into "ThisFileExample"
+          // for decent component names
+          // TODO: check for collisions in the future
+          const exampleFileName = takeLast(1, split(path.sep, file.screen))[0]
+          const componentName = replace(/.js|\s|-/g, '', exampleFileName)
+
+          if (filesystem.exists(destinationPath)) {
+            // insert screen import
+            patching.insertInFile(
+              destinationPath,
+              'import RoundedButton',
+              `import ${componentName} from '../Examples/Containers/${pluginName}/${file.screen}'`
+            )
+
+            // insert screen route
+            patching.insertInFile(
+              destinationPath,
+              'screen: PluginExamplesScreen',
+              `  ${componentName}: {screen: ${componentName}, navigationOptions: {header: {visible: true}}},`
+            )
+
+            // insert launch button
+            patching.insertInFile(
+              destinationPath,
+              'styles.screenButtons',
+              `
+            <RoundedButton onPress={() => this.props.navigation.navigate('${componentName}')}>
+              ${file.title}
+            </RoundedButton>`
+            )
+          } // if
+        },
+        files
+      )
+
+      spinner.stop()
+    }
+  }
+
+  return addPluginScreenExamples
+}

--- a/packages/ignite-cli/src/extensions/ignite/addScreenExamples.js
+++ b/packages/ignite-cli/src/extensions/ignite/addScreenExamples.js
@@ -15,86 +15,11 @@ module.exports = (plugin, command, context) => {
    *   {title: 'Section Example', screen: 'Section.js', ancillary: ['file']},
    * ])
    */
+  // DEPRECATED as of 3/2/17 as part of Ignite 2 Beta (https://github.com/infinitered/ignite/issues/636)
   async function addScreenExamples (files, props = {}) {
     const { filesystem, patching, ignite, print, template } = context
-    const { ignitePluginPath } = ignite
-
-    const config = ignite.loadIgniteConfig()
-    // consider this being part of context.ignite
-    const pluginName = takeLast(1, split(path.sep, ignitePluginPath()))[0]
-
-    // currently only supporting 1 form of examples
-    if (config.examples === 'classic') {
-      const spinner = print.spin(`▸ adding screen examples`)
-
-      // merge and flatten all dem files yo.
-      let allFiles = reduce(
-        (acc, v) => {
-          acc.push(v.screen)
-          if (v.ancillary) acc.push(v.ancillary)
-          return flatten(acc)
-        },
-        [],
-        files
-      )
-
-      // generate stamped copy of all template files
-      const templatePath = ignitePluginPath()
-        ? `${ignitePluginPath()}/templates`
-        : `templates`
-      map(
-        fileName => {
-          template.generate({
-            directory: templatePath,
-            template: `${fileName}.ejs`,
-            target: `ignite/Examples/Containers/${pluginName}/${fileName}`,
-            props
-          })
-        },
-        allFiles
-      )
-
-      // insert screen, route, and buttons in PluginExamples (if exists)
-      const destinationPath = `${process.cwd()}/ignite/DevScreens/PluginExamplesScreen.js`
-      map(
-        file => {
-          // turn things like "examples/This File-Example.js" into "ThisFileExample"
-          // for decent component names
-          // TODO: check for collisions in the future
-          const exampleFileName = takeLast(1, split(path.sep, file.screen))[0]
-          const componentName = replace(/.js|\s|-/g, '', exampleFileName)
-
-          if (filesystem.exists(destinationPath)) {
-            // insert screen import
-            patching.insertInFile(
-              destinationPath,
-              'import RoundedButton',
-              `import ${componentName} from '../Examples/Containers/${pluginName}/${file.screen}'`
-            )
-
-            // insert screen route
-            patching.insertInFile(
-              destinationPath,
-              'screen: PluginExamplesScreen',
-              `  ${componentName}: {screen: ${componentName}, navigationOptions: {header: {visible: true}}},`
-            )
-
-            // insert launch button
-            patching.insertInFile(
-              destinationPath,
-              'styles.screenButtons',
-              `
-            <RoundedButton onPress={() => this.props.navigation.navigate('${componentName}')}>
-              ${file.title}
-            </RoundedButton>`
-            )
-          } // if
-        },
-        files
-      )
-
-      spinner.stop()
-    }
+    print.warning('DEPRECATION_WARNING: Heads up! `ignite.addScreenExamples` is deprecated. Please use `ignite.addPluginScreenExamples` instead.')
+    ignite.addPluginScreenExamples(files, props)
   }
 
   return addScreenExamples

--- a/packages/ignite-cli/src/extensions/ignite/removeComponentExample.js
+++ b/packages/ignite-cli/src/extensions/ignite/removeComponentExample.js
@@ -2,22 +2,11 @@ module.exports = (plugin, command, context) => {
   /**
    * Removes the component example.
    */
+  // DEPRECATED as of 3/2/17 as part of Ignite 2 Beta (https://github.com/infinitered/ignite/issues/636)
   function removeComponentExample (fileName) {
-    const { filesystem, patching, print } = context
-    print.info(`    ${print.checkmark} removing component example`)
-    // remove file from Components/Examples folder
-    filesystem.remove(
-      `${process.cwd()}/ignite/Examples/Components/${fileName}`
-    )
-    // remove reference in usage example screen (if it exists)
-    const destinationPath = `${process.cwd()}/ignite/DevScreens/PluginExamplesScreen.js`
-    if (filesystem.exists(destinationPath)) {
-      patching.replaceInFile(
-        destinationPath,
-        `import '../Examples/Components/${fileName}`,
-        ''
-      )
-    }
+    const { filesystem, patching, print, ignite } = context
+    print.warning('DEPRECATION_WARNING: Heads up! `ignite.removeComponentExample` is deprecated. Please use `ignite.removePluginComponentExample` instead.')
+    ignite.removePluginComponentExample(fileName)
   }
 
   return removeComponentExample

--- a/packages/ignite-cli/src/extensions/ignite/removePluginComponentExample.js
+++ b/packages/ignite-cli/src/extensions/ignite/removePluginComponentExample.js
@@ -1,0 +1,24 @@
+module.exports = (plugin, command, context) => {
+  /**
+   * Removes the component example.
+   */
+  function removePluginComponentExample (fileName) {
+    const { filesystem, patching, print } = context
+    print.info(`    ${print.checkmark} removing component example`)
+    // remove file from Components/Examples folder
+    filesystem.remove(
+      `${process.cwd()}/ignite/Examples/Components/${fileName}`
+    )
+    // remove reference in usage example screen (if it exists)
+    const destinationPath = `${process.cwd()}/ignite/DevScreens/PluginExamplesScreen.js`
+    if (filesystem.exists(destinationPath)) {
+      patching.replaceInFile(
+        destinationPath,
+        `import '../Examples/Components/${fileName}`,
+        ''
+      )
+    }
+  }
+
+  return removePluginComponentExample
+}

--- a/packages/ignite-cli/src/extensions/ignite/removePluginScreenExamples.js
+++ b/packages/ignite-cli/src/extensions/ignite/removePluginScreenExamples.js
@@ -1,0 +1,91 @@
+const { flatten, replace, reduce, map, takeLast, split } = require('ramda')
+const path = require('path')
+
+module.exports = (plugin, command, context) => {
+  /**
+   * Remove example screens from dev screens.
+   *
+   * @param {Array} files - Array of Screens and properties
+   *
+   * example:
+   * removeScreenExamples([
+   *   {screen: 'Row.js', ancillary: ['file1', 'file2']},
+   *   {screen: 'Grid.js', ancillary: ['file']},
+   *   {screen: 'Section.js', ancillary: ['file']},
+   * ])
+   */
+  async function removePluginScreenExamples (files) {
+    const { filesystem, patching, ignite, print } = context
+    const { ignitePluginPath } = ignite
+
+    const config = ignite.loadIgniteConfig()
+
+    // consider this being part of context.ignite
+    const pluginName = takeLast(1, split(path.sep, ignitePluginPath()))[0]
+
+    // currently only supporting 1 form of examples
+    if (config.examples === 'classic') {
+      const spinner = print.spin(`▸ removing screen examples`)
+
+      // merge and flatten all dem files yo.
+      let allFiles = reduce(
+        (acc, v) => {
+          acc.push(v.screen)
+          if (v.ancillary) acc.push(v.ancillary)
+          return flatten(acc)
+        },
+        [],
+        files
+      )
+
+      // delete all files that were inserted
+      map(
+        fileName => {
+          filesystem.removeAsync(
+            `ignite/Examples/Containers/${pluginName}/${fileName}`
+          )
+        },
+        allFiles
+      )
+
+      // delete screen, route, and buttons in PluginExamples (if exists)
+      const destinationPath = `${process.cwd()}/ignite/DevScreens/PluginExamplesScreen.js`
+      map(
+        file => {
+          // turn things like "examples/This File-Example.js" into "ThisFileExample"
+          // for decent component names
+          const exampleFileName = takeLast(1, split(path.sep, file.screen))[0]
+          const componentName = replace(/.js|\s|-/g, '', exampleFileName)
+
+          if (filesystem.exists(destinationPath)) {
+            // remove screen import
+            patching.replaceInFile(
+              destinationPath,
+              `import ${componentName} from '../Examples/Containers/${pluginName}/${file.screen}'`,
+              ''
+            )
+
+            // remove screen route
+            patching.replaceInFile(
+              destinationPath,
+              `  ${componentName}: {screen: ${componentName}, navigationOptions: {header: {visible: true}}},`,
+              ''
+            )
+
+            // remove launch button
+            patching.replaceInFile(
+              destinationPath,
+              `<RoundedButton.+${componentName}.+[\\s\\S].+\\s*<\\/RoundedButton>`,
+              ''
+            )
+          } // if
+        },
+        files
+      )
+
+      spinner.stop()
+    }
+  }
+
+  return removePluginScreenExamples
+}

--- a/packages/ignite-cli/src/extensions/ignite/removeScreenExamples.js
+++ b/packages/ignite-cli/src/extensions/ignite/removeScreenExamples.js
@@ -14,77 +14,11 @@ module.exports = (plugin, command, context) => {
    *   {screen: 'Section.js', ancillary: ['file']},
    * ])
    */
+  // DEPRECATED as of 3/2/17 as part of Ignite 2 Beta (https://github.com/infinitered/ignite/issues/636)
   async function removeScreenExamples (files) {
     const { filesystem, patching, ignite, print } = context
-    const { ignitePluginPath } = ignite
-
-    const config = ignite.loadIgniteConfig()
-
-    // consider this being part of context.ignite
-    const pluginName = takeLast(1, split(path.sep, ignitePluginPath()))[0]
-
-    // currently only supporting 1 form of examples
-    if (config.examples === 'classic') {
-      const spinner = print.spin(`▸ removing screen examples`)
-
-      // merge and flatten all dem files yo.
-      let allFiles = reduce(
-        (acc, v) => {
-          acc.push(v.screen)
-          if (v.ancillary) acc.push(v.ancillary)
-          return flatten(acc)
-        },
-        [],
-        files
-      )
-
-      // delete all files that were inserted
-      map(
-        fileName => {
-          filesystem.removeAsync(
-            `ignite/Examples/Containers/${pluginName}/${fileName}`
-          )
-        },
-        allFiles
-      )
-
-      // delete screen, route, and buttons in PluginExamples (if exists)
-      const destinationPath = `${process.cwd()}/ignite/DevScreens/PluginExamplesScreen.js`
-      map(
-        file => {
-          // turn things like "examples/This File-Example.js" into "ThisFileExample"
-          // for decent component names
-          const exampleFileName = takeLast(1, split(path.sep, file.screen))[0]
-          const componentName = replace(/.js|\s|-/g, '', exampleFileName)
-
-          if (filesystem.exists(destinationPath)) {
-            // remove screen import
-            patching.replaceInFile(
-              destinationPath,
-              `import ${componentName} from '../Examples/Containers/${pluginName}/${file.screen}'`,
-              ''
-            )
-
-            // remove screen route
-            patching.replaceInFile(
-              destinationPath,
-              `  ${componentName}: {screen: ${componentName}, navigationOptions: {header: {visible: true}}},`,
-              ''
-            )
-
-            // remove launch button
-            patching.replaceInFile(
-              destinationPath,
-              `<RoundedButton.+${componentName}.+[\\s\\S].+\\s*<\\/RoundedButton>`,
-              ''
-            )
-          } // if
-        },
-        files
-      )
-
-      spinner.stop()
-    }
+    print.warning('DEPRECATION_WARNING: Heads up! `ignite.removeScreenExamples` is deprecated. Please use `ignite.removePluginScreenExamples` instead.')
+    ignite.removePluginScreenExamples(files)
   }
 
   return removeScreenExamples

--- a/packages/ignite-cli/src/templates/plugin/index.js.ejs
+++ b/packages/ignite-cli/src/templates/plugin/index.js.ejs
@@ -12,7 +12,7 @@ const add = async function (context) {
   // install a npm module and link it
   await ignite.addModule(NPM_MODULE_NAME, { link: true })
 
-  <% if (props.answers.template === 'Yes') { %>await ignite.addComponentExample(EXAMPLE_FILE, { title: '<%= props.name %> Example' })<% } %>
+  <% if (props.answers.template === 'Yes') { %>await ignite.addPluginComponentExample(EXAMPLE_FILE, { title: '<%= props.name %> Example' })<% } %>
 
   // Example of copying templates/<%= props.name %> to App/<%= props.name %>
   // if (!filesystem.exists(`${APP_PATH}/App/<%= props.name %>`)) {
@@ -35,7 +35,7 @@ const remove = async function (context) {
   // remove the npm module and unlink it
   await ignite.removeModule(NPM_MODULE_NAME, { unlink: true })
 
-  <% if (props.answers.template === 'Yes') { %>await ignite.removeComponentExample(EXAMPLE_FILE)<% } %>
+  <% if (props.answers.template === 'Yes') { %>await ignite.removePluginComponentExample(EXAMPLE_FILE)<% } %>
 
   // Example of removing App/<%= props.name %> folder
   // const remove<%= props.name %> = await context.prompt.confirm(

--- a/packages/ignite-cli/src/templates/plugin/test/add.js.ejs
+++ b/packages/ignite-cli/src/templates/plugin/test/add.js.ejs
@@ -5,18 +5,18 @@ const plugin = require('../index')
 test('adds the proper npm module and component example', async t => {
   // spy on few things so we know they're called
   const addModule = sinon.spy()
-  const addComponentExample = sinon.spy()
+  const addPluginComponentExample = sinon.spy()
   
   // mock a context
   const context = {
-    ignite: { addModule, addComponentExample }
+    ignite: { addModule, addPluginComponentExample }
   }
 
   await plugin.add(context)
   
   t.true(addModule.calledWith('react-native-MODULENAME', { link: true }))
   t.true(
-    addComponentExample.calledWith('<%= props.name %>Example.js', {
+    addPluginComponentExample.calledWith('<%= props.name %>Example.js', {
       title: '<%= props.name %> Example'
     })
   )

--- a/packages/ignite-cli/src/templates/plugin/test/remove.js.ejs
+++ b/packages/ignite-cli/src/templates/plugin/test/remove.js.ejs
@@ -4,14 +4,14 @@ const plugin = require('../index')
 
 test('removes <%= props.name %>', async t => {
   const removeModule = sinon.spy()
-  const removeComponentExample = sinon.spy()
+  const removePluginComponentExample = sinon.spy()
 
   const context = {
-    ignite: { removeModule, removeComponentExample }
+    ignite: { removeModule, removePluginComponentExample }
   }
 
   await plugin.remove(context)
 
   t.true(removeModule.calledWith('react-native-MODULENAME', { unlink: true }))
-  t.true(removeComponentExample.calledWith('<%= props.name %>Example.js'))
+  t.true(removePluginComponentExample.calledWith('<%= props.name %>Example.js'))
 })

--- a/packages/ignite-cli/tests/extensions/ignite.test.js
+++ b/packages/ignite-cli/tests/extensions/ignite.test.js
@@ -23,10 +23,14 @@ test('has the right interface', t => {
   t.is(typeof extension.addModule, 'function')
   t.is(typeof extension.removeModule, 'function')
   t.is(typeof extension.copyBatch, 'function')
-  t.is(typeof extension.addComponentExample, 'function')
-  t.is(typeof extension.removeComponentExample, 'function')
-  // t.is(typeof extension.addScreenExamples, 'function')
-  t.is(typeof extension.removeScreenExamples, 'function')
+  t.is(typeof extension.addComponentExample, 'function') //Deprecated 3/2/17 Ignite 2 Beta
+  t.is(typeof extension.addPluginComponentExample, 'function')
+  t.is(typeof extension.removeComponentExample, 'function') //Deprecated 3/2/17 Ignite 2 Beta
+  t.is(typeof extension.removePluginComponentExample, 'function')
+  //t.is(typeof extension.addScreenExamples, 'function') //Deprecated 3/2/17 Ignite 2 Beta
+  //t.is(typeof extension.addPluginScreenExamples, 'function')
+  t.is(typeof extension.removeScreenExamples, 'function') //Deprecated 3/2/17 Ignite 2 Beta
+  t.is(typeof extension.removePluginScreenExamples, 'function')
   t.is(typeof extension.loadIgniteConfig, 'function')
   t.is(typeof extension.saveIgniteConfig, 'function')
   t.is(typeof extension.setIgniteConfig, 'function')


### PR DESCRIPTION
This is for issue: https://github.com/infinitered/ignite/issues/636

Renamed Methods:
`addComponentExample` -> `addPluginComponentExample`
`addScreenExample`s ->`addPluginScreenExamples`
`removeComponentExample` -> `emovePluginComponentExample`
`removeScreenExamples` ->` removePluginScreenExamples`

Left old methods in place that call the new methods and print
deprecation warnings

<img width="1045" alt="screen shot 2017-03-02 at 2 21 49 pm" src="https://cloud.githubusercontent.com/assets/6894653/23529904/4a75cd36-ff54-11e6-953e-6c983747bb87.png">

