### PR TITLE
Adds a more helpful error if DevScreens can't auto-insert itself

### DIFF
--- a/packages/ignite-dev-screens/index.js
+++ b/packages/ignite-dev-screens/index.js
@@ -1,5 +1,18 @@
 const sourceFolder = `${process.cwd()}/node_modules/ignite-dev-screens/templates`
 
+const MANUAL_INSTALL_INFO = `
+✨ DevScreens installed!
+
+We couldn't automatically add them to your project. But it's pretty easy!
+Just add the following to your primary screen or navigation:
+
+${print.colors.bold('import DevscreensButton from \'../../ignite/DevScreens/DevscreensButton.js\'')}
+
+${print.colors.darkGray('// In your view JSX somewhere...')}
+
+<DevscreensButton />
+`
+
 const add = async function (context) {
   const { patching, filesystem, print, ignite } = context
   const { warning } = print
@@ -13,11 +26,11 @@ const add = async function (context) {
   // Copy the the screens to containers folder
   filesystem.copyAsync(`${sourceFolder}`, `${process.cwd()}/ignite/DevScreens`, { overwrite: true })
 
-  // Set App/Config/DebugConfig.js showDevScreens to __DEV__
+  // Set showDevScreens to __DEV__
   context.ignite.setDebugConfig('showDevScreens', '__DEV__', true)
 
   // Insert a function that renders the dev screens as part of the JSX in the navigation
-  const launchScreen = `${process.cwd()}/App/Containers/LaunchScreen.js`
+  const launchScreen = `${process.cwd()}/App/Containers/LaunchScreen2.js`
   if (filesystem.exists(launchScreen)) {
     if (!patching.isInFile(launchScreen, 'import DevscreensButton')) {
       patching.insertInFile(launchScreen, 'from \'react-native\'', 'import DevscreensButton from \'../../ignite/DevScreens/DevscreensButton.js\'\n')
@@ -26,7 +39,7 @@ const add = async function (context) {
       patching.insertInFile(launchScreen, '</ScrollView>', '          <DevscreensButton />', false)
     }
   } else {
-    warning('LaunchScreen.js not found. Please manually link the PresentationScreen from your primary screen/navigation.')
+    print.info(MANUAL_INSTALL_INFO)
   }
 
   // Call the function in the navigation, which adds/provides the dev screens

--- a/packages/ignite-dev-screens/index.js
+++ b/packages/ignite-dev-screens/index.js
@@ -30,7 +30,7 @@ const add = async function (context) {
   context.ignite.setDebugConfig('showDevScreens', '__DEV__', true)
 
   // Insert a function that renders the dev screens as part of the JSX in the navigation
-  const launchScreen = `${process.cwd()}/App/Containers/LaunchScreen2.js`
+  const launchScreen = `${process.cwd()}/App/Containers/LaunchScreen.js`
   if (filesystem.exists(launchScreen)) {
     if (!patching.isInFile(launchScreen, 'import DevscreensButton')) {
       patching.insertInFile(launchScreen, 'from \'react-native\'', 'import DevscreensButton from \'../../ignite/DevScreens/DevscreensButton.js\'\n')


### PR DESCRIPTION
This doesn't entirely fix #819 but I think it helps by making it less painful if they're not using our folder structure.

<img width="650" alt="screen shot 2017-03-03 at 7 00 39 pm" src="https://cloud.githubusercontent.com/assets/1479215/23575618/730df25a-0044-11e7-963c-570c8b27c04a.png">

