### PR TITLE
Temporary fix for mock-fs.

### DIFF
--- a/packages/ignite-cli/package.json
+++ b/packages/ignite-cli/package.json
@@ -39,7 +39,7 @@
   "devDependencies": {
     "ava": "^0.18.1",
     "babel-eslint": "^7.1.1",
-    "mock-fs": "^4.1.0",
+    "mock-fs": "git://github.com/not-an-aardvark/mock-fs/#06868bbd7724707f9324b237bdde28f05f7a01d5",
     "mockery": "^2.0.0",
     "nyc": "^10.1.2",
     "pretty-error": "^2.0.2",


### PR DESCRIPTION
Until mock-fs accepts that patch, this will hook us up.

This is what eslint did (https://github.com/eslint/eslint/commit/0fd9d2712aeeebc65399083f5249729da91c7bf6) as a temporary work around.

I've tested this on 7.6 and 7.7.1.