### PR TITLE
Adds warning if Android not installed properly. Fixes #483

### DIFF
--- a/packages/ignite-ir-boilerplate-2016/boilerplate.js
+++ b/packages/ignite-ir-boilerplate-2016/boilerplate.js
@@ -1,5 +1,20 @@
+const Shell = require('shelljs')
 const options = require('./options')
 const { merge, pipe, assoc, omit, __ } = require('ramda')
+
+const verifyAndroidInstalled = function (context) {
+  let androidInstalled = true
+  if (!Shell.which('android')) {
+    console.log(`Unable to find 'android' in your PATH.`)
+    androidInstalled = false
+  }
+  const androidPath = process.env['ANDROID_HOME']
+  if (!androidPath || !Shell.test('-d', androidPath)) {
+    console.log(`Unable to find 'ANDROID_HOME' environment variable.`)
+    androidInstalled = false
+  }
+  return androidInstalled
+}
 
 const finish = async function (context) {
   const { parameters, system, print, ignite } = context
@@ -28,9 +43,14 @@ const finish = async function (context) {
   print.info(print.colors.yellow(`  cd ${name}`))
   print.info(print.colors.yellow('  react-native run-ios'))
   print.info('')
-  print.info('To run in Android:')
-  print.info(print.colors.yellow(`  cd ${name}`))
-  print.info(print.colors.yellow('  react-native run-android'))
+  if (verifyAndroidInstalled()) {
+    print.info('To run in Android:')
+    print.info(print.colors.yellow(`  cd ${name}`))
+    print.info(print.colors.yellow('  react-native run-android'))
+  } else {
+    print.info('Android not set up properly!')
+    print.info(`Make sure you've followed the latest react-native setup instructions at https://facebook.github.io/react-native/docs/getting-started.html before using ignite.\nYou won't be able to run ${print.colors.yellow('react-native run-android')} successfully until you have.`)
+  }
   print.info('')
   print.info('To see what ignite can do for you:')
   print.info(print.colors.yellow(`  cd ${name}`))

--- a/packages/ignite-ir-boilerplate-2016/boilerplate.js
+++ b/packages/ignite-ir-boilerplate-2016/boilerplate.js
@@ -4,7 +4,7 @@ const { merge, pipe, assoc, omit, __ } = require('ramda')
 
 const verifyAndroidInstalled = function (context) {
   let androidInstalled = true
-  if (!Shell.which('android')) {
+  if (!context.system.which('android')) {
     console.log(`Unable to find 'android' in your PATH.`)
     androidInstalled = false
   }

--- a/packages/ignite-ir-boilerplate-2016/boilerplate.js
+++ b/packages/ignite-ir-boilerplate-2016/boilerplate.js
@@ -43,7 +43,7 @@ const finish = async function (context) {
   print.info(print.colors.yellow(`  cd ${name}`))
   print.info(print.colors.yellow('  react-native run-ios'))
   print.info('')
-  if (verifyAndroidInstalled()) {
+  if (verifyAndroidInstalled(context)) {
     print.info('To run in Android:')
     print.info(print.colors.yellow(`  cd ${name}`))
     print.info(print.colors.yellow('  react-native run-android'))

--- a/packages/ignite-ir-boilerplate-2016/boilerplate.js
+++ b/packages/ignite-ir-boilerplate-2016/boilerplate.js
@@ -1,19 +1,20 @@
-const Shell = require('shelljs')
 const options = require('./options')
 const { merge, pipe, assoc, omit, __ } = require('ramda')
 
-const verifyAndroidInstalled = function (context) {
-  let androidInstalled = true
-  if (!context.system.which('android')) {
-    console.log(`Unable to find 'android' in your PATH.`)
-    androidInstalled = false
-  }
-  const androidPath = process.env['ANDROID_HOME']
-  if (!androidPath || !Shell.test('-d', androidPath)) {
-    console.log(`Unable to find 'ANDROID_HOME' environment variable.`)
-    androidInstalled = false
-  }
-  return androidInstalled
+/**
+ * Is Android installed?
+ *
+ * $ANDROID_HOME/tools folder has to exist.
+ *
+ * @param {*} context - The gluegun context.
+ * @returns {boolean}
+ */
+const isAndroidInstalled = function (context) {
+  const androidHome = process.env['ANDROID_HOME']
+  const hasAndroidEnv = !context.strings.isBlank(androidHome)
+  const hasAndroid = hasAndroidEnv && context.filesystem.exists(`${androidHome}/tools`) === 'dir'
+
+  return Boolean(hasAndroid)
 }
 
 const finish = async function (context) {
@@ -40,21 +41,20 @@ const finish = async function (context) {
   print.info('🍽 Time to get cooking!')
   print.info('')
   print.info('To run in iOS:')
-  print.info(print.colors.yellow(`  cd ${name}`))
-  print.info(print.colors.yellow('  react-native run-ios'))
+  print.info(print.colors.bold(`  cd ${name}`))
+  print.info(print.colors.bold('  react-native run-ios'))
   print.info('')
-  if (verifyAndroidInstalled(context)) {
+  if (isAndroidInstalled(context)) {
     print.info('To run in Android:')
-    print.info(print.colors.yellow(`  cd ${name}`))
-    print.info(print.colors.yellow('  react-native run-android'))
   } else {
-    print.info('Android not set up properly!')
-    print.info(`Make sure you've followed the latest react-native setup instructions at https://facebook.github.io/react-native/docs/getting-started.html before using ignite.\nYou won't be able to run ${print.colors.yellow('react-native run-android')} successfully until you have.`)
+    print.info(`To run in Android, make sure you've followed the latest react-native setup instructions at https://facebook.github.io/react-native/docs/getting-started.html before using ignite.\nYou won't be able to run ${print.colors.bold('react-native run-android')} successfully until you have. Then:`)
   }
+  print.info(print.colors.bold(`  cd ${name}`))
+  print.info(print.colors.bold('  react-native run-android'))
   print.info('')
   print.info('To see what ignite can do for you:')
-  print.info(print.colors.yellow(`  cd ${name}`))
-  print.info(print.colors.yellow('  ignite'))
+  print.info(print.colors.bold(`  cd ${name}`))
+  print.info(print.colors.bold('  ignite'))
   print.info('')
 }
 


### PR DESCRIPTION
If `android` isn't in your path or `ANDROID_HOME` doesn't point to a directory, this displays an error.

This is added at the boilerplate level, because different boilerplates will have different requirements.

<img width="1277" alt="screen shot 2017-03-04 at 12 37 01 pm" src="https://cloud.githubusercontent.com/assets/1479215/23582089/8c96b746-00d7-11e7-931c-cf53c04aee2f.png">

Fixes #483 

