### PR TITLE
Bumps ignite-dev-screens to version 2.0.0-beta.1.

### DIFF
--- a/packages/ignite-dev-screens/package.json
+++ b/packages/ignite-dev-screens/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ignite-dev-screens",
-  "version": "1.9.4",
+  "version": "2.0.0-beta.1",
   "license": "MIT",
   "files": [
     "templates",


### PR DESCRIPTION
Not quite sure, but `ignite-dev-screens` didn't make the push yesterday.  Thankfully we had `0.2.0` in place, but it's not the latest.

I'm going to publish this manually right now.