### PR TITLE
We love Windows too!

### DIFF
--- a/packages/ignite-cli/package.json
+++ b/packages/ignite-cli/package.json
@@ -29,7 +29,7 @@
   ],
   "license": "MIT",
   "dependencies": {
-    "gluegun": "^0.15.0",
+    "gluegun": "^0.16.0",
     "gluegun-patching": "^0.3.0",
     "minimist": "^1.2.0",
     "ramda": "^0.23.0",

--- a/packages/ignite-cli/src/extensions/ignite/addModule.js
+++ b/packages/ignite-cli/src/extensions/ignite/addModule.js
@@ -23,10 +23,14 @@ module.exports = (plugin, command, context) => {
     // install the module
     if (useYarn) {
       const addSwitch = options.dev ? '--dev' : ''
-      await system.run(`yarn add ${moduleFullName} ${addSwitch}`)
+      const cmd = `yarn add ${moduleFullName} ${addSwitch}`
+      ignite.log(cmd)
+      await system.spawn(cmd, { stdio: 'ignore' })
     } else {
       const installSwitch = options.dev ? '--save-dev' : '--save'
-      await system.run(`npm i ${moduleFullName} ${installSwitch}`)
+      const cmd = `npm i ${moduleFullName} ${installSwitch}`
+      ignite.log(cmd)
+      await system.spawn(cmd, { stdio: 'ignore' })
     }
     spinner.stop()
 

--- a/packages/ignite-cli/src/extensions/reactNative.js
+++ b/packages/ignite-cli/src/extensions/reactNative.js
@@ -64,7 +64,7 @@ function attach (plugin, command, context) {
     } else {
       // No React Native installed, let's get it
       rncliSpinner.text = 'installing react-native-cli'
-      await system.exec('npm install -g react-native-cli', { stdio: 'ignore' })
+      await system.spawn('npm install -g react-native-cli', { stdio: 'ignore' })
       rncliSpinner.succeed(`installed react-native-cli`)
     }
 
@@ -79,7 +79,7 @@ function attach (plugin, command, context) {
     // ok, let's do this
     const stdioMode = parameters.options.debug ? 'inherit' : 'ignore'
     try {
-      await system.exec(cmd, { stdio: stdioMode })
+      await system.spawn(cmd, { stdio: stdioMode })
     } catch (e) {
       spinner.fail(`failed to add ${print.colors.cyan('React Native ' + reactNativeVersion)}${withTemplate}`)
       if (reactNativeTemplate) {

--- a/packages/ignite-cli/src/lib/importPlugin.js
+++ b/packages/ignite-cli/src/lib/importPlugin.js
@@ -60,13 +60,13 @@ async function importPlugin (context, opts) {
       ? `yarn add file:${target} --force --dev`
       : `yarn add ${target} --dev`
     log(cmd)
-    await system.exec(cmd, { stdio: 'pipe' })
+    await system.spawn(cmd, { stdio: 'ignore' })
     log('finished yarn command')
   } else {
     const cacheBusting = isDirectory ? '--cache-min=0' : ''
     const cmd = `npm i ${target} --save-dev ${cacheBusting}`
     log(cmd)
-    await system.exec(cmd, { stdio: 'pipe' })
+    await system.spawn(cmd, { stdio: 'ignore' })
     log('finished npm command')
   }
 }


### PR DESCRIPTION
Just kidding, no we don't.  Only @kevinvangelder does.  

But!!! We will support it because it's damn popular!

So, some of the commands we shell out and don't work on windows.  

Specifically `react-native link` (again... we had issues with this on the mac which is why we had to switch to `stdio: ignore`).

This PR bumps gluegun as I've added `cross-spawn` to power `context.system.spawn` now.  It works the same as Node's spawn but ensures things work properly with Windows.

I don't know the who story, but apparently grandchild processes don't inherit the path, and there's some issues with escaping with the out-of-the-box node spawn experience.

Cross-spawn makes this patching invisible to us.  👍 

Address #862 .  I won't say "fixed" just yet, but I will say, it's working on my machine.  Will push a beta 2 once this is merged and circle back with the folks in that ticket to follow up.