### PR TITLE
Adds more fixes to support windows.

### DIFF
--- a/packages/ignite-cli/src/commands/new.js
+++ b/packages/ignite-cli/src/commands/new.js
@@ -84,9 +84,9 @@ async function command (context) {
   // let's kick off the template
   let ok = false
   try {
-    const command = `ignite boilerplate-install ${boilerplateName} ${projectName} ${forwardingOptions}`
+    const command = trim(`ignite boilerplate-install ${boilerplateName} ${projectName} ${forwardingOptions}`)
     log(`running boilerplate: ${command}`)
-    await system.spawn(command, { stdio: 'inherit' })
+    await system.exec(command, { stdio: 'inherit' })
     log('finished boilerplate')
     ok = true
   } catch (e) {

--- a/packages/ignite-cli/src/extensions/ignite/addModule.js
+++ b/packages/ignite-cli/src/extensions/ignite/addModule.js
@@ -1,3 +1,5 @@
+const { trim } = require('ramda')
+
 module.exports = (plugin, command, context) => {
   /**
    * Adds a npm-based module to the project.
@@ -23,14 +25,14 @@ module.exports = (plugin, command, context) => {
     // install the module
     if (useYarn) {
       const addSwitch = options.dev ? '--dev' : ''
-      const cmd = `yarn add ${moduleFullName} ${addSwitch}`
+      const cmd = trim(`yarn add ${moduleFullName} ${addSwitch}`)
       ignite.log(cmd)
-      await system.spawn(cmd, { stdio: 'ignore' })
+      await system.run(cmd)
     } else {
       const installSwitch = options.dev ? '--save-dev' : '--save'
-      const cmd = `npm i ${moduleFullName} ${installSwitch}`
+      const cmd = trim(`npm i ${moduleFullName} ${installSwitch}`)
       ignite.log(cmd)
-      await system.spawn(cmd, { stdio: 'ignore' })
+      await system.run(cmd)
     }
     spinner.stop()
 

--- a/packages/ignite-cli/src/extensions/reactNative.js
+++ b/packages/ignite-cli/src/extensions/reactNative.js
@@ -1,4 +1,4 @@
-const { test } = require('ramda')
+const { test, trim } = require('ramda')
 const exitCodes = require('../lib/exitCodes')
 
 // The default version of React Native to install. We will want to upgrade
@@ -64,12 +64,12 @@ function attach (plugin, command, context) {
     } else {
       // No React Native installed, let's get it
       rncliSpinner.text = 'installing react-native-cli'
-      await system.spawn('npm install -g react-native-cli', { stdio: 'ignore' })
+      await system.run('npm install -g react-native-cli')
       rncliSpinner.succeed(`installed react-native-cli`)
     }
 
     // react-native init
-    const cmd = `react-native init ${name} ${rnOptions.join(' ')}`
+    const cmd = trim(`react-native init ${name} ${rnOptions.join(' ')}`)
     log('initializing react native')
     log(cmd)
     const withTemplate = reactNativeTemplate ? ` with ${print.colors.cyan(reactNativeTemplate)} template` : ''
@@ -79,7 +79,7 @@ function attach (plugin, command, context) {
     // ok, let's do this
     const stdioMode = parameters.options.debug ? 'inherit' : 'ignore'
     try {
-      await system.spawn(cmd, { stdio: stdioMode })
+      await system.exec(cmd, { stdio: stdioMode })
     } catch (e) {
       spinner.fail(`failed to add ${print.colors.cyan('React Native ' + reactNativeVersion)}${withTemplate}`)
       if (reactNativeTemplate) {

--- a/packages/ignite-cli/src/lib/importPlugin.js
+++ b/packages/ignite-cli/src/lib/importPlugin.js
@@ -1,4 +1,4 @@
-const { isEmpty, forEach } = require('ramda')
+const { isEmpty, forEach, trim } = require('ramda')
 const exitCodes = require('../lib/exitCodes')
 const path = require('path')
 
@@ -60,13 +60,13 @@ async function importPlugin (context, opts) {
       ? `yarn add file:${target} --force --dev`
       : `yarn add ${target} --dev`
     log(cmd)
-    await system.spawn(cmd, { stdio: 'ignore' })
+    await system.run(cmd)
     log('finished yarn command')
   } else {
     const cacheBusting = isDirectory ? '--cache-min=0' : ''
-    const cmd = `npm i ${target} --save-dev ${cacheBusting}`
+    const cmd = trim(`npm i ${target} --save-dev ${cacheBusting}`)
     log(cmd)
-    await system.spawn(cmd, { stdio: 'ignore' })
+    await system.run(cmd)
     log('finished npm command')
   }
 }


### PR DESCRIPTION
Windows gets cranky when you pass it blank parameters.  So this trims it up where necessary.

Also `spawn` is only necessary with `react-native link` and `react-native unlink`, so I'm changing spawn to exec everywhere else.  

I'd like to minimize the footprint of spawn in gluegun because I'd like for it to go away shortly.  Once I get to the bottom of `react-native link`.