### PR TITLE
updated dev screen modal to quell android propTypes

### DIFF
--- a/packages/ignite-dev-screens/templates/DevscreensButton.js
+++ b/packages/ignite-dev-screens/templates/DevscreensButton.js
@@ -1,5 +1,5 @@
 import React from 'react'
-import { View, Modal, Platform } from 'react-native'
+import { View, Modal } from 'react-native'
 import DebugConfig from '../../App/Config/DebugConfig'
 import RoundedButton from '../../App/Components/RoundedButton'
 import PresentationScreen from './PresentationScreen'
@@ -25,10 +25,7 @@ export default class DevscreensButton extends React.Component {
           </RoundedButton>
           <Modal
             visible={this.state.showModal}
-            onRequestClose={
-              Platform.OS === 'android' ? this.toggleModal : undefined
-            }
-          >
+            onRequestClose={this.toggleModal}>
             <PresentationScreen screenProps={{ toggle: this.toggleModal }} />
           </Modal>
         </View>

--- a/packages/ignite-dev-screens/templates/DevscreensButton.js
+++ b/packages/ignite-dev-screens/templates/DevscreensButton.js
@@ -14,7 +14,7 @@ export default class DevscreensButton extends React.Component {
 
   toggleModal = () => {
     this.setState({ showModal: !this.state.showModal })
-  };
+  }
 
   render () {
     if (DebugConfig.showDevScreens) {

--- a/packages/ignite-dev-screens/templates/DevscreensButton.js
+++ b/packages/ignite-dev-screens/templates/DevscreensButton.js
@@ -1,35 +1,40 @@
-import React from 'react'
-import { View, Modal } from 'react-native'
-import DebugConfig from '../../App/Config/DebugConfig'
-import RoundedButton from '../../App/Components/RoundedButton'
-import PresentationScreen from './PresentationScreen'
+import React from 'react';
+import { View, Modal, Platform } from 'react-native';
+import DebugConfig from '../../App/Config/DebugConfig';
+import RoundedButton from '../../App/Components/RoundedButton';
+import PresentationScreen from './PresentationScreen';
 
 export default class DevscreensButton extends React.Component {
-  constructor (props) {
-    super(props)
+  constructor(props) {
+    super(props);
     this.state = {
       showModal: false
-    }
+    };
   }
 
   toggleModal = () => {
-    this.setState({showModal: !this.state.showModal})
-  }
+    this.setState({ showModal: !this.state.showModal });
+  };
 
-  render () {
+  render() {
     if (DebugConfig.showDevScreens) {
       return (
         <View>
           <RoundedButton onPress={this.toggleModal}>
             Open DevScreens
           </RoundedButton>
-          <Modal visible={this.state.showModal} >
-            <PresentationScreen screenProps={{toggle: this.toggleModal}} />
+          <Modal
+            visible={this.state.showModal}
+            onRequestClose={
+              Platform.OS === 'android' ? () => this.toggleModal() : undefined
+            }
+          >
+            <PresentationScreen screenProps={{ toggle: this.toggleModal }} />
           </Modal>
         </View>
-      )
+      );
     } else {
-      return (<View />)
+      return <View />;
     }
   }
 }

--- a/packages/ignite-dev-screens/templates/DevscreensButton.js
+++ b/packages/ignite-dev-screens/templates/DevscreensButton.js
@@ -1,22 +1,22 @@
-import React from 'react';
-import { View, Modal, Platform } from 'react-native';
-import DebugConfig from '../../App/Config/DebugConfig';
-import RoundedButton from '../../App/Components/RoundedButton';
-import PresentationScreen from './PresentationScreen';
+import React from 'react'
+import { View, Modal, Platform } from 'react-native'
+import DebugConfig from '../../App/Config/DebugConfig'
+import RoundedButton from '../../App/Components/RoundedButton'
+import PresentationScreen from './PresentationScreen'
 
 export default class DevscreensButton extends React.Component {
-  constructor(props) {
-    super(props);
+  constructor (props) {
+    super(props)
     this.state = {
       showModal: false
-    };
+    }
   }
 
   toggleModal = () => {
-    this.setState({ showModal: !this.state.showModal });
+    this.setState({ showModal: !this.state.showModal })
   };
 
-  render() {
+  render () {
     if (DebugConfig.showDevScreens) {
       return (
         <View>
@@ -26,15 +26,15 @@ export default class DevscreensButton extends React.Component {
           <Modal
             visible={this.state.showModal}
             onRequestClose={
-              Platform.OS === 'android' ? () => this.toggleModal() : undefined
+              Platform.OS === 'android' ? this.toggleModal : undefined
             }
           >
             <PresentationScreen screenProps={{ toggle: this.toggleModal }} />
           </Modal>
         </View>
-      );
+      )
     } else {
-      return <View />;
+      return <View />
     }
   }
 }


### PR DESCRIPTION
## Please verify the following:
- [x] Everything works on iOS/Android
- [x] `npm test` **ava** tests pass with new tests, if relevant
- [x] `./docs/` has been updated with your changes, if relevant

## Describe your PR

On android, the onRequestClose prop is required for Modals to instruct how to handle the hardware back button.  I just implemented a quick check to quell this message and toggle the modal in the same fashion as the 'X' button.

I know things have changed for ignite 2, so let me know if there's anything I need to address.
