### PR TITLE
Adds support for create-react-native-app, Expo, and more!

### DIFF
--- a/docs/quick-start/getting-started.md
+++ b/docs/quick-start/getting-started.md
@@ -52,6 +52,22 @@ To see what ignite can do for you:
   ignite
 ```
 
+## Attaching to Existing Projects
+
+If you already have an existing project on the go, you can make it enable ignite support by typing `ignite attach` in the project directory.  This creates a `ignite` directory with a file called `ignite.json` and an empty `plugins` directory (with a `.gitkeep` to play nice with `git`).
+
+You're now ready to start using ignite plugins!
+
+This works great for:
+
+* [create-react-native-app](https://github.com/react-community/create-react-native-app)
+* [Expo](https://expo.io)
+* [create-react-app](https://github.com/facebookincubator/create-react-app)
+* normal React JS projects
+* empty directories ( not even joking! you can use this with other programming languages.  :O )
+
+Not all plugins work in all environments, but you can certainly take advantage of the many features of Ignite (such as the code generators).
+
 ## Continue your Learning
 
 To continue your introduction to Ignite, see the Editing an Ignite App (working title) page.

--- a/packages/ignite-cli/src/commands/attach.js
+++ b/packages/ignite-cli/src/commands/attach.js
@@ -1,0 +1,26 @@
+// @cliDescription Attaches Ignite to an existing project.
+
+const isIgniteDirectory = require('../lib/isIgniteDirectory')
+
+module.exports = async function (context) {
+  const { filesystem, ignite, print } = context
+
+  // ensure we're in a supported directory
+  if (isIgniteDirectory(process.cwd())) {
+    context.print.info('🍻  Good news! This project is already Ignite-enabled!')
+    return
+  }
+
+  // ignite/ignite.json
+  const igniteJson = {
+    'createdWith': ignite.version,
+    'boilerplate': 'empty',
+    'examples': 'none'
+  }
+  filesystem.write('ignite/ignite.json', igniteJson)
+
+  // the plugins folder
+  filesystem.write('ignite/plugins/.gitkeep', '')
+
+  context.print.info(`🔥  Good to go! Type ${print.colors.bold('ignite')} to get started.`)
+}


### PR DESCRIPTION
If you have an existing project and still want to use ignite:

`ignite attach`

This works great for:

* [create-react-native-app](https://github.com/react-community/create-react-native-app)
* [Expo](https://expo.io)
* [create-react-app](https://github.com/facebookincubator/create-react-app)
* normal React JS projects
* empty directories ( not even joking! you can use this with other programming languages.  :O )

Gluegun FTW.