### PR TITLE
Added links to README docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,9 +70,9 @@ First, make sure you're set up for [React Native](https://facebook.github.io/rea
 
 then...
 
-Make sure you have Node 7.6+. 
+Make sure you have Node 7.6+.
 
-You can check your version of node by running 
+You can check your version of node by running
 
 ```
 node -v
@@ -84,6 +84,9 @@ then...
 $ npm install -g ignite-cli
 $ ignite new MyNewAppName
 ```
+## :arrow_forward: Documentation
+
+Want to dive into the Ignite 2 documentation? [Go here](./docs/README.md)
 
 ## :arrow_forward: Troubleshooting
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -5,6 +5,7 @@
 * Installing
 * [Getting started](./quick-start/getting-started.md)
 * [Ignite commands](./quick-start/ignite-commands.md)
+* [Project Structure](./quick-start/project-structure.md)
 * [Using boilerplates](./quick-start/using-boilerplates.md)
 * Removing plugins
 * Spork! - tweaking 3rd-party generators
@@ -13,6 +14,10 @@
 
 * [Creating plugins](./advanced-guides/creating-plugins.md)
 * [Creating project plugins](./advanced-guides/creating-project-plugins.md)
+* [Creating boilerplates](./advanced-guides/creating-boilerplates.md)
+* [Creating generators](./advanced-guides/creating-generators.md)
+* [How to Contribute](./advanced-guides/how-to-contribute.md)
+* [Using development build](./advanced-guides/using-development-build.md)
 * Writing tests for plugins
 * Releasing plugins
 * Creating extensions


### PR DESCRIPTION
## Please verify the following:
- [x] Everything works on iOS/Android
- [x] `npm test` **ava** tests pass with new tests, if relevant
- [x] `./docs/` has been updated with your changes, if relevant

## Describe your PR
* I added a link to docs/README.md from the initial README.md doc under a 'Documentation' header so users can easily find the detailed documentation without having to search the codebase for the /docs directory

* New docs have been added under docs/advanced-guides and docs/quick-start without having links from docs/README.md. I added the missing links.
