### PR TITLE
Prevents new from running when node_modules/react-native exists.

### DIFF
--- a/packages/ignite-cli/src/commands/new.js
+++ b/packages/ignite-cli/src/commands/new.js
@@ -33,6 +33,13 @@ async function command (context) {
     process.exit(exitCodes.NOT_IGNITE_PROJECT)
   }
 
+  // prevent installing when node_modules/react-native exists
+  if (filesystem.exists('node_modules/react-native')) {
+    context.print.error('The `ignite new` command cannot be run within a directory with `node_modules/react-native` installed.')
+    context.print.error('Try installing from a directory without a `node_modules` directory.')
+    process.exit(exitCodes.EXISTING_REACT_NATIVE)
+  }
+
   // verify the project name is a thing
   if (isBlank(projectName)) {
     print.info(`${context.runtime.brand} new <projectName>\n`)

--- a/packages/ignite-cli/src/lib/exitCodes.js
+++ b/packages/ignite-cli/src/lib/exitCodes.js
@@ -55,5 +55,10 @@ module.exports = {
   /**
    * This is not a compatible Ignite directory.
    */
-  NOT_IGNITE_PROJECT: 10
+  NOT_IGNITE_PROJECT: 10,
+
+  /**
+   * node_modules/react-native already exists.
+   */
+  EXISTING_REACT_NATIVE: 11
 }


### PR DESCRIPTION
Fixes #913 .

`react-native init` already checks for this condition.  We didn't.  Now we do.