### PR TITLE
Allows specifying the package name when checking dependencies

### DIFF
--- a/packages/ignite-cli/src/cli/check.js
+++ b/packages/ignite-cli/src/cli/check.js
@@ -30,6 +30,7 @@ var rnCli = enforceGlobalDependency({
   optional: false,
   range: '>=2.0.0',
   which: 'react-native',
+  package: 'react-native-cli',
   versionCommand: 'react-native --version',
   installMessage: 'To install: npm i -g react-native-cli'
 })

--- a/packages/ignite-cli/src/cli/enforceGlobalDependency.js
+++ b/packages/ignite-cli/src/cli/enforceGlobalDependency.js
@@ -36,7 +36,7 @@ function defaultVersionMatcher (raw) {
  * @param  {boolean}  opts.optional       Is this an optional dependency?
  * @param  {string}   opts.range          The semver range to test against.
  * @param  {string}   opts.which          The command to run `which` on.
- * @param  {string}   opts.package        The npm package we're checking for.
+ * @param  {string}   opts.packageName    The npm package we're checking for.
  * @param  {string}   opts.versionCommand The command to run which returns text containing the version number.
  * @param  {string}   opts.installMessage What to print should we fail.
  * @param  {function} opts.versionMatcher A way to override the method to discover the version number.
@@ -47,7 +47,7 @@ function enforce (opts = {}) {
   var optional = opts.optional || false
   var range = opts.range
   var which = opts.which
-  var package = opts.package || opts.which
+  var packageName = opts.packageName || opts.which
   var versionCommand = opts.versionCommand
   var installMessage = opts.installMessage
   var versionMatcher = opts.versionMatcher || defaultVersionMatcher
@@ -58,7 +58,7 @@ function enforce (opts = {}) {
    * @param {string} installedVersion - current version if installed.
    */
   function printNotMetMessage (installedVersion) {
-    console.log('Ignite requires ' + package + ' ' + range + ' to be installed.')
+    console.log('Ignite requires ' + packageName + ' ' + range + ' to be installed.')
     if (installedVersion) {
       console.log('')
       console.log('You currently have ' + installedVersion + ' installed.')

--- a/packages/ignite-cli/src/cli/enforceGlobalDependency.js
+++ b/packages/ignite-cli/src/cli/enforceGlobalDependency.js
@@ -36,6 +36,7 @@ function defaultVersionMatcher (raw) {
  * @param  {boolean}  opts.optional       Is this an optional dependency?
  * @param  {string}   opts.range          The semver range to test against.
  * @param  {string}   opts.which          The command to run `which` on.
+ * @param  {string}   opts.package        The npm package we're checking for.
  * @param  {string}   opts.versionCommand The command to run which returns text containing the version number.
  * @param  {string}   opts.installMessage What to print should we fail.
  * @param  {function} opts.versionMatcher A way to override the method to discover the version number.
@@ -46,6 +47,7 @@ function enforce (opts = {}) {
   var optional = opts.optional || false
   var range = opts.range
   var which = opts.which
+  var package = opts.package || opts.which
   var versionCommand = opts.versionCommand
   var installMessage = opts.installMessage
   var versionMatcher = opts.versionMatcher || defaultVersionMatcher
@@ -56,7 +58,7 @@ function enforce (opts = {}) {
    * @param {string} installedVersion - current version if installed.
    */
   function printNotMetMessage (installedVersion) {
-    console.log('Ignite requires ' + which + ' ' + range + ' to be installed.')
+    console.log('Ignite requires ' + package + ' ' + range + ' to be installed.')
     if (installedVersion) {
       console.log('')
       console.log('You currently have ' + installedVersion + ' installed.')


### PR DESCRIPTION
Currently, Ignite warns if you have the wrong react-native-cli version installed:

```
~/Documents/Ignite2Experiments > ignite new fontfix
Ignite requires react-native >=2.0.0 to be installed.

You currently have 1.3.0 installed.

To install: npm i -g react-native-cli
```

However, it's misleading. This allows specifying the npm package name to more accurately reflect what is missing.
