### PR TITLE
References proper react-native binary - Fixes #949

### DIFF
--- a/bin/testRelease
+++ b/bin/testRelease
@@ -35,7 +35,7 @@ setup()
   rm -rf ./testgrounds
 
   echo '~~~🌟 Preparing packages'
-  npm install -g lerna@2.0.0-beta.37
+  npm install -g lerna@2.0.0-beta.38
   test_command lerna bootstrap
 
   echo '~~~🌟 Linking local for Testing'

--- a/packages/ignite-cli/package.json
+++ b/packages/ignite-cli/package.json
@@ -36,7 +36,8 @@
     "ramda": "^0.23.0",
     "ramdasauce": "^1.2.0",
     "semver": "^5.3.0",
-    "shelljs": "^0.7.6"
+    "shelljs": "^0.7.6",
+    "which": "^1.2.14"
   },
   "devDependencies": {
     "ava": "^0.18.1",

--- a/packages/ignite-cli/src/cli/check.js
+++ b/packages/ignite-cli/src/cli/check.js
@@ -31,7 +31,7 @@ var rnCli = enforceGlobalDependency({
   range: '>=2.0.0',
   which: 'react-native',
   packageName: 'react-native-cli',
-  versionCommand: '$(which react-native) --version',
+  versionCommand: '--version',
   installMessage: 'To install: npm i -g react-native-cli'
 })
 
@@ -59,7 +59,7 @@ var yarn = enforceGlobalDependency({
   optional: true,
   range: '>=0.21.0',
   which: 'yarn',
-  versionCommand: 'yarn --version',
+  versionCommand: '--version',
   installMessage: 'See https://yarnpkg.com/en/docs/install on how to upgrade for your OS.'
 })
 

--- a/packages/ignite-cli/src/cli/check.js
+++ b/packages/ignite-cli/src/cli/check.js
@@ -31,7 +31,7 @@ var rnCli = enforceGlobalDependency({
   range: '>=2.0.0',
   which: 'react-native',
   packageName: 'react-native-cli',
-  versionCommand: 'react-native --version',
+  versionCommand: '$(which react-native) --version',
   installMessage: 'To install: npm i -g react-native-cli'
 })
 

--- a/packages/ignite-cli/src/cli/enforceGlobalDependency.js
+++ b/packages/ignite-cli/src/cli/enforceGlobalDependency.js
@@ -2,6 +2,7 @@
 var shell = require('shelljs')
 var semver = require('semver')
 var ramda = require('ramda')
+var which = require('which')
 
 /**
  * Extracts the version number from a somewhere within a string.
@@ -46,7 +47,7 @@ function enforce (opts = {}) {
   // opts to pass in
   var optional = opts.optional || false
   var range = opts.range
-  var which = opts.which
+  var whichExec = opts.which
   var packageName = opts.packageName || opts.which
   var versionCommand = opts.versionCommand
   var installMessage = opts.installMessage
@@ -75,8 +76,11 @@ function enforce (opts = {}) {
   function getVersion () {
     // parse the version number
     try {
+      // find the executable
+      var resolvedPath = which.sync(whichExec)
+
       // grab the raw output
-      var result = shell.exec(versionCommand, { silent: true })
+      var result = shell.exec(resolvedPath + ' ' + versionCommand, { silent: true })
       var rawOut = ramda.trim(result.stdout || '')
       var rawErr = ramda.trim(result.stderr || '') // java -version does this... grr
 
@@ -97,7 +101,7 @@ function enforce (opts = {}) {
   }
 
   // are we installed?
-  var isInstalled = Boolean(shell.which(which))
+  var isInstalled = Boolean(shell.which(whichExec))
 
   if (!isInstalled) {
     if (optional) {


### PR DESCRIPTION
Fixes #949

[According to @skellock](https://github.com/infinitered/ignite/issues/949#issuecomment-291283847):

> when we shell out, node is giving precedence to the node_modules/.bin/react-native executable instead of the global one on the path.

This change calls `$(which react-native) --version` rather than `react-native --version` which should address the problem in issue #949 and others.
