### PR TITLE
Adds gluegun plugin detection.

### DIFF
--- a/packages/ignite-cli/src/cli/cli.js
+++ b/packages/ignite-cli/src/cli/cli.js
@@ -11,6 +11,7 @@ const buildIgnite = () => {
     .loadDefault(`${__dirname}/..`)
     .loadAll(`${process.cwd()}/ignite/plugins`)
     .loadAll(`${process.cwd()}/node_modules`, { matching: 'ignite-*', hidden: true })
+    .loadAll(`${process.cwd()}/node_modules`, { matching: 'gluegun-*', hidden: true })
     .token('commandName', 'cliCommand')
     .token('commandHidden', 'cliHidden')
     .token('commandAlias', 'cliAlias')

--- a/packages/ignite-cli/tests/cli/cliConfig.test.js
+++ b/packages/ignite-cli/tests/cli/cliConfig.test.js
@@ -32,6 +32,10 @@ test('ignite', async t => {
         {
           dir: `${process.cwd()}/node_modules`,
           opts: { hidden: true, matching: 'ignite-*' }
+        },
+        {
+          dir: `${process.cwd()}/node_modules`,
+          opts: { hidden: true, matching: 'gluegun-*' }
         }
       ],
       loadDefault: `${process.cwd()}/src/cli/..`,


### PR DESCRIPTION
I have a suite of gluegun extensions incoming, and I'd like them to be available in ignite as well.

For example https://github.com/skellock/gluegun-prettier.

This makes these extensions auto-detectable.

```sh
yarn add --dev gluegun-prettier
```

```js
context.prettier.reformat('/path/to/the/ugly.js')
// or
const pretty = context.prettier.format(` console\n.tab(   'lol'\t\t\t)\n\n\n`)
context.print.info(pretty)
```

