### PR TITLE
Add clarification about final npm install command after saying to install Yarn

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,13 +82,11 @@ You can check your version of node by running
 node -v
 ```
 
-_Currently, Yarn global doesn't work on Windows - so feel free to skip installing Yarn if you're running on Windows_
-_...otherwise..._
-
-install [Yarn](https://yarnpkg.com/lang/en/docs/install/) for your system
+then install [Yarn](https://yarnpkg.com/lang/en/docs/install/) for your system
 
 finally...
 
+_All global installs below are using npm over yarn because of [this bug](https://github.com/yarnpkg/yarn/issues/859) on Windows._
 ```
 $ npm install -g ignite-cli
 $ ignite new MyNewAppName

--- a/README.md
+++ b/README.md
@@ -82,7 +82,9 @@ You can check your version of node by running
 node -v
 ```
 
-then install [Yarn](https://yarnpkg.com/lang/en/docs/install/) for your system
+_Currently, Yarn global doesn't work on Windows - so feel free to skip installing Yarn if you're running on Windows_
+_...otherwise..._
+install [Yarn](https://yarnpkg.com/lang/en/docs/install/) for your system
 
 finally...
 

--- a/README.md
+++ b/README.md
@@ -84,6 +84,7 @@ node -v
 
 _Currently, Yarn global doesn't work on Windows - so feel free to skip installing Yarn if you're running on Windows_
 _...otherwise..._
+
 install [Yarn](https://yarnpkg.com/lang/en/docs/install/) for your system
 
 finally...


### PR DESCRIPTION
## Describe your PR
Added note about Yarn global not working on Windows.
I thought it was strange that we say to install Yarn, and then the final install command uses npm.
This adds a little clarification.

