### PR TITLE
Adds ability to customize paths for generators

### DIFF
--- a/docs/quick-start/project-structure.md
+++ b/docs/quick-start/project-structure.md
@@ -193,5 +193,35 @@ For example, you may:
 
 ## Ignite directory
 
-TODO:
 The Ignite directory stores all things Ignite. Here you will find generators, plugins and examples to help you get started with React Native.
+
+The `ignite.json` file is where you can customize how Ignite behaves in your project to some degree. For example, you can edit the paths that your plugin generators use when creating new components, screens, and the like.
+
+```json
+{
+  "generators": {
+    "component": "ignite-ir-next",
+    "container": "ignite-ir-next",
+    "listview": "ignite-ir-next",
+    "redux": "ignite-ir-next",
+    "saga": "ignite-ir-next",
+    "screen": "ignite-ir-next"
+  },
+  "paths": {
+    "app": "App",
+    "tests": "Tests",
+    "components": "Components",
+    "config": "Config",
+    "containers": "Containers",
+    "fixtures": "Fixtures",
+    "images": "Images",
+    "navigation": "Navigation",
+    "services": "Services"
+  },
+  "createdWith": "2.0.0-beta.8",
+  "examples": "classic",
+  "navigation": "react-navigation"
+}
+```
+
+_TODO: Need more info on the ignite directory._

--- a/packages/ignite-cli/src/commands/add.js
+++ b/packages/ignite-cli/src/commands/add.js
@@ -30,7 +30,7 @@ const removeIgnitePlugin = async (moduleName, context) => {
 
 module.exports = async function (context) {
   // grab a fist-full of features...
-  const { print, filesystem, prompt, ignite, parameters, strings } = context
+  const { print, prompt, ignite, parameters, strings } = context
   const { log } = ignite
 
   log('running add command')
@@ -117,7 +117,6 @@ Examples:
     spinner.text = `adding ${print.colors.cyan(moduleName)}`
     spinner.start()
   }
-
 
   // ok, are we ready?
   try {

--- a/packages/ignite-cli/src/commands/generate.js
+++ b/packages/ignite-cli/src/commands/generate.js
@@ -37,7 +37,7 @@ module.exports = async function (context) {
   }
 
   // grab some features
-  const { ignite, print, parameters, filesystem } = context
+  const { ignite, print, parameters } = context
   const { colors } = print
   const config = ignite.loadIgniteConfig()
 

--- a/packages/ignite-cli/src/commands/generate.js
+++ b/packages/ignite-cli/src/commands/generate.js
@@ -38,6 +38,7 @@ module.exports = async function (context) {
 
   // grab some features
   const { ignite, print, parameters, filesystem } = context
+  const { colors } = print
   const config = ignite.loadIgniteConfig()
 
   print.newline()
@@ -47,7 +48,7 @@ module.exports = async function (context) {
     // with each plugin
     map(plugin => {
       // load the list of generators they support within their ignite.json
-      const config = context.ignite.loadConfig(`${plugin.directory}/ignite.json`)
+      const config = ignite.loadConfig(`${plugin.directory}/ignite.json`)
       const generators = config.generators || []
 
       // then make a row out of them
@@ -72,7 +73,7 @@ module.exports = async function (context) {
     (pluginName, type) => {
       // let's find what the user has asked for in the list
       const lookup = find(
-        option => pluginName.plugin.name == option,
+        option => equals(pluginName, dotPath('plugin.name', option)),
         registry[type] || []
       )
 
@@ -109,19 +110,19 @@ module.exports = async function (context) {
    */
   const footer = () => {
     print.info(
-      print.colors.muted(
+      colors.muted(
         '\n  --------------------------------------------------------------------------'
       )
     )
     print.info(
-      print.colors.muted(
-        `  Check out ${print.colors.white(
+      colors.muted(
+        `  Check out ${colors.white(
           'https://github.com/infinitered/ignite'
         )} for instructions on how to`
       )
     )
     print.info(
-      print.colors.muted('  install some or how to build some for yourself.')
+      colors.muted('  install some or how to build some for yourself.')
     )
   }
 
@@ -129,7 +130,7 @@ module.exports = async function (context) {
   if (isEmpty(userRegistry)) {
     print.warning('⚠️  No generators detected.\n')
     print.info(
-      `  ${print.colors.bold(
+      `  ${colors.bold(
         'Generators'
       )} allow you to quickly make frequently created files such as:\n`
     )
@@ -148,7 +149,7 @@ module.exports = async function (context) {
   // didn't find what we wanted?
   if (isNil(registryItem)) {
     print.info(
-      `✨ Type ${print.colors.bold('ignite generate')} ${print.colors.yellow(
+      `✨ Type ${colors.bold('ignite generate')} ${colors.yellow(
         '________'
       )} to run one of these generators:\n`
     )
@@ -159,9 +160,9 @@ module.exports = async function (context) {
     const data = pipe(
       values,
       map(item => [
-        print.colors.yellow(item.type),
+        colors.yellow(item.type),
         item.error || item.description,
-        showSource && print.colors.muted(item.pluginName)
+        showSource && colors.muted(item.pluginName)
       ])
     )(userRegistry)
 
@@ -183,7 +184,7 @@ module.exports = async function (context) {
       rawCommand: newCommand,
       options: parameters.options
     })
-  } catch e {
+  } catch (e) {
     if (e.error) {
       print.debug(e.error)
     }

--- a/packages/ignite-cli/src/commands/plugin.js
+++ b/packages/ignite-cli/src/commands/plugin.js
@@ -18,7 +18,7 @@ const walkthrough = async (context) => {
   if (context.parameters.options.max) { return maxOptions }
 
   // Okay, we'll ask one by one, fine
-  return await context.prompt.ask([
+  return context.prompt.ask([
     {
       name: 'boilerplate',
       message: 'Is this an app boilerplate plugin?',

--- a/packages/ignite-cli/src/extensions/ignite.js
+++ b/packages/ignite-cli/src/extensions/ignite.js
@@ -46,12 +46,13 @@ function attach (plugin, command, context) {
     setIgnitePluginPath
   } = ignitePluginPathExt(plugin, command, context)
 
-  // a 4-pack of ignite config
+  // a 5-pack of ignite config
   const {
     loadIgniteConfig,
     saveIgniteConfig,
     setIgniteConfig,
-    removeIgniteConfig
+    removeIgniteConfig,
+    loadConfig
   } = igniteConfigExt(plugin, command, context)
 
   // here's the extension's abilities
@@ -63,6 +64,7 @@ function attach (plugin, command, context) {
     saveIgniteConfig,
     setIgniteConfig,
     removeIgniteConfig,
+    loadConfig,
     findIgnitePlugins: findIgnitePluginsExt(plugin, command, context),
     addModule: addModuleExt(plugin, command, context),
     addAndroidPermission: addAndroidPermissionExt(plugin, command, context),

--- a/packages/ignite-cli/src/extensions/ignite/copyBatch.js
+++ b/packages/ignite-cli/src/extensions/ignite/copyBatch.js
@@ -25,7 +25,7 @@ module.exports = (plugin, command, context) => {
     const shouldGenerate = async target => {
       if (!askToOverwrite) return true
       if (!filesystem.exists(target)) return true
-      return await confirm(`overwrite ${target}`)
+      return confirm(`overwrite ${target}`)
     }
 
     // old school loop because of async stuff

--- a/packages/ignite-cli/src/extensions/ignite/generate.js
+++ b/packages/ignite-cli/src/extensions/ignite/generate.js
@@ -18,7 +18,7 @@ module.exports = (plugin, command, context) => {
     const overrides = isSporked ? { directory: sporkDirectory } : {}
 
     // now make the call to the gluegun generate
-    return await template.generate(merge(opts, overrides))
+    return template.generate(merge(opts, overrides))
   }
 
   return generate

--- a/packages/ignite-cli/src/extensions/ignite/igniteConfig.js
+++ b/packages/ignite-cli/src/extensions/ignite/igniteConfig.js
@@ -4,15 +4,15 @@ const igniteConfigFilename = `${process.cwd()}/ignite/ignite.json`
 const defaultConfig = {
   generators: {},
   paths: {
-    app: "App",
-    tests: "Tests",
-    components: "Components",
-    config: "Config",
-    containers: "Containers",
-    fixtures: "Fixtures",
-    images: "Images",
-    navigation: "Navigation",
-    services: "Services"
+    app: 'App',
+    tests: 'Tests',
+    components: 'Components',
+    config: 'Config',
+    containers: 'Containers',
+    fixtures: 'Fixtures',
+    images: 'Images',
+    navigation: 'Navigation',
+    services: 'Services'
   }
 }
 

--- a/packages/ignite-cli/src/extensions/ignite/igniteConfig.js
+++ b/packages/ignite-cli/src/extensions/ignite/igniteConfig.js
@@ -1,17 +1,41 @@
-const { dissoc } = require('ramda')
+const { dissoc, merge } = require('ramda')
 const igniteConfigFilename = `${process.cwd()}/ignite/ignite.json`
+
+const defaultConfig = {
+  generators: {},
+  paths: {
+    app: "App",
+    tests: "Tests",
+    components: "Components",
+    config: "Config",
+    containers: "Containers",
+    fixtures: "Fixtures",
+    images: "Images",
+    navigation: "Navigation",
+    services: "Services"
+  }
+}
 
 module.exports = (plugin, command, context) => {
   const { filesystem } = context
 
   /**
    * Reads the contents of the ignite/ignite.json configuration.
+   * Sets some defaults if not set.
    *
    * @return {Object} The configuration.
    */
   function loadIgniteConfig () {
-    return filesystem.exists(igniteConfigFilename)
-      ? filesystem.read(igniteConfigFilename, 'json') || {}
+    const appConfig = loadConfig(igniteConfigFilename)
+    return merge(defaultConfig, appConfig)
+  }
+
+  /**
+   * Reads the contents of a configuration file.
+   */
+  function loadConfig (filename) {
+    return filesystem.exists(filename)
+      ? filesystem.read(filename, 'json') || {}
       : {}
   }
 
@@ -50,6 +74,7 @@ module.exports = (plugin, command, context) => {
     setIgniteConfig,
     removeIgniteConfig,
     saveIgniteConfig,
-    loadIgniteConfig
+    loadIgniteConfig,
+    loadConfig
   }
 }

--- a/packages/ignite-cli/src/templates/plugin/commands/thing.js.ejs
+++ b/packages/ignite-cli/src/templates/plugin/commands/thing.js.ejs
@@ -5,6 +5,7 @@ module.exports = async function (context) {
   // Learn more about context: https://infinitered.github.io/gluegun/#/context-api.md
   const { parameters, strings, print, ignite } = context
   const { pascalCase, isBlank } = strings
+  const { paths } = ignite.loadIgniteConfig()
 
   // validation
   if (isBlank(parameters.first)) {
@@ -16,11 +17,11 @@ module.exports = async function (context) {
   const name = pascalCase(parameters.first)
   const props = { name }
 
-  // Copies the `thing.js.ejs` in your plugin's templates folder
-  // into App/Things/${name}.js.
+  // copies the `thing.js.ejs` in your plugin's templates folder
+  // into App/Components/${name}.js, or some customized version of this path
   const jobs = [{
     template: 'thing.js.ejs',
-    target: `App/Things/${name}.js`
+    target: `${paths.app}/${paths.components}/${name}.js`
   }]
 
   // make the templates and pass in props with the third argument here


### PR DESCRIPTION
Previously, generator paths were set by the host plugin and not customizable. This allows developers to edit their `ignite/ignite.json` files to specify other paths.

```json
{
  "paths": {
    "app": "App",
    "tests": "Tests",
    "components": "Components",
    "config": "Config",
    "containers": "Containers",
    "fixtures": "Fixtures",
    "images": "Images",
    "navigation": "Navigation",
    "services": "Services"
  }
}
```

I'll annotate various parts of this fairly wide-ranging pull request for easier review. Please review carefully -- I touched many parts of Ignite in this update.


