### PR TITLE
Adds testRelease script back in as bin/ci

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,11 +10,11 @@ install:
   - tar -xvf android-sdk_r24.4-linux.tgz
   # list possible installs
   # - ./android-sdk-linux/tools/android list sdk --all --extended
-  # -u means no ui / -a means all / -t means filter to specifc SDK items / -a means 
+  # -u means no ui / -a means all / -t means filter to specifc SDK items / -a means
   # pipe echo y to automatically accept android licenses
   # Libs selected: SDK Build Tools 23.0.3, .2, and .1, SDK Platform 23, Google APIs 23, Support Repo, Google Repo
   - echo y | ./android-sdk-linux/tools/android update sdk -u -a -t android-23,build-tools-23.0.3,build-tools-23.0.2,build-tools-23.0.1,addon-google_apis-google-23,extra-android-m2repository,extra-google-m2repository
 env:
   - ANDROID_HOME=~/build/infinitered/ignite/android-sdk-linux
 script:
-  - ./bin/testRelease
+  - ./bin/ci

--- a/bin/ci
+++ b/bin/ci
@@ -1,0 +1,137 @@
+#! /bin/bash
+
+#################### Running this Script #######################
+# Verify Git status is clean
+# Run this with `./bin/testRelease`
+################################################################
+
+SOMETHING_FAILED=0
+echo "#########################################################"
+echo '# Test a release of Ignite before actually releasing it #'
+echo '#                  ._______.                            #'
+echo '#                   | \   / |                           #'
+echo '#                .--|.O.|.O.|______.                    #'
+echo '#              __).-| = | = |/   \ |                    #'
+echo "#              >__) (.'---\`.)Q.|.Q.|--.                 #"
+echo '#                    \\___// = | = |-.(__               #'
+echo "#                     \`---'( .---. ) (__<               #"
+echo "#                           \\\\.-.//                     #"
+echo "#                            \`---'                      #"
+echo '#########################################################'
+
+# Runs command and on failure turns on the SOMETHING_FAILED flag
+function test_command {
+  "$@"
+  local status=$?
+  if [ $status -ne 0 ]; then
+      echo "👎 👎 👎 👎 👎 👎 👎 👎 - $1 Failed" >&2
+      SOMETHING_FAILED=$1
+  fi
+  return $status
+}
+
+setup()
+{
+  rm -rf ./testgrounds
+
+  echo '~~~🌟 NPM install'
+  test_command npm install
+
+  echo '~~~🌟 Linking local for Testing'
+  test_command npm link
+}
+
+verify_code()
+{
+  echo '~~~🌟 Checking Code'
+  npm install -g standard
+  npm install -g ava
+  npm i -g react-native-cli
+  test_command standard ./src
+  test_command npm test
+  test_command npm run integration
+}
+
+check_builds()
+{
+  mkdir testgrounds
+  cd ./testgrounds
+  echo '~~~🌟 Generating Project'
+  test_command ignite new TestProj --min --skip-git
+
+  echo '~~~🌟 Checking Builds'
+  cd ./TestProj
+
+  if [ ! -d "android" ]; then
+    echo 'Android folder did not generate'
+    SOMETHING_FAILED=1
+  fi
+
+  if [ ! -d "ios" ]; then
+    echo 'ios folder did not generate'
+    SOMETHING_FAILED=1
+  fi
+
+  echo 'Testing Blessed Plugins'
+  echo '~ Test adding vector-icons plugin from npm'
+  test_command ignite add vector-icons
+  echo '~ Test adding animatable plugin from npm'
+  test_command ignite add animatable
+  echo '~ Test adding i18n plugin from npm'
+  test_command ignite add i18n
+  echo '~ Test adding maps plugin from npm'
+  test_command ignite add maps
+
+  echo '~ LINT ALL THE THINGS!'
+  test_command npm run lint
+
+  echo '~ Build ios'
+  test_command react-native bundle --entry-file index.ios.js --bundle-output test.ios.js --dev false --platform ios --assets-dest iosAssets
+  if [ ! -d "iosAssets" ]; then
+    echo 'iosAssets folder did not generate'
+    SOMETHING_FAILED=1
+  fi
+
+  echo '~ Build android'
+  test_command react-native bundle --entry-file index.android.js --bundle-output test.android.js --dev false --platform android --assets-dest androidAssets
+  if [ ! -d "androidAssets" ]; then
+    echo 'androidAssets folder did not generate'
+    SOMETHING_FAILED=1
+  fi
+  # A failed android build will not exit with a non-zero return!
+  # This makes it a bit trickier to test for - look for the fail message instead
+  # Temporary disable this until we separate CI needs from here
+  # cd ./android
+  # ./gradlew assembleRelease | grep -q 'BUILD FAILED'
+  # if [[ $? -eq 0 ]]; then
+  #   echo 'Android build failed'
+  #   SOMETHING_FAILED=1
+  # fi
+  # cd ..
+
+
+  # back to root
+  cd ../..
+
+  echo '~~~🌟 Cleanup'
+  rm -rf testgrounds
+}
+
+# This is where the magic happens
+setup;
+
+verify_code;
+
+check_builds;
+
+# Done
+if [ "$SOMETHING_FAILED" != "0" ]; then
+  echo "~~~👎 Done with errors";
+  echo "$SOMETHING_FAILED";
+  exit 1;
+else
+  echo "~~~👍 Everything looks good!";
+  # depends on $SECONDS being part of sh
+  printf '%dh:%dm:%ds\n' $(($SECONDS/3600)) $(($SECONDS%3600/60)) $(($SECONDS%60));
+  exit 0;
+fi

--- a/bin/ci
+++ b/bin/ci
@@ -2,7 +2,7 @@
 
 #################### Running this Script #######################
 # Verify Git status is clean
-# Run this with `./bin/testRelease`
+# Run this with `./bin/ci`
 ################################################################
 
 SOMETHING_FAILED=0


### PR DESCRIPTION
Simplifies Semaphore to run `./bin/ci` and that takes care of setup, linting, tests, and integration tests.