### PR TITLE
Adds Sibbell config file for monitoring dependencies

### DIFF
--- a/.sibbell.yml
+++ b/.sibbell.yml
@@ -1,0 +1,17 @@
+projects:
+  - facebook/react-native
+  - sindresorhus/execa
+  - infinitered/gluegun
+  - substack/minimist
+  - AriaMinaei/pretty-error
+  - ramda/ramda
+  - skellock/ramdasauce
+  - npm/node-semver
+  - shelljs/shelljs
+  - npm/node-which
+  - avajs/ava
+  - babel/babel-eslint
+  - tschaub/mock-fs
+  - vektra/mockery
+  - istanbuljs/nyc
+  - feross/standard


### PR DESCRIPTION
Per @kevinvangelder , this will help us keep on top of dependencies. I've already added the integration to `infinitered` org, so you can add your own .sibbell.yml file to any of the other repos to do the same.

Sibbell files Github issues whenever a new release happens on a monitored repo, and includes the release notes.