### PR TITLE
Adds error if you use --verbose instead of --debug

### DIFF
--- a/src/cli/cli.js
+++ b/src/cli/cli.js
@@ -54,6 +54,11 @@ module.exports = async function run (argv) {
     return
   }
 
+  if (commandLine.verbose && !commandLine.debug) {
+    print.error('Use --debug instead of --verbose.')
+    return
+  }
+
   // run the command
   let context
   try {


### PR DESCRIPTION
Because of the way Gluegun and Ignite CLI work together, it's a little messy to accept either `--debug` or `--verbose`. So, given the late hour and wanting to get another release out, I cheated a little -- we just error and tell the user to use `--debug` instead of `--verbose`.

I'm happy to review and accept pull requests if this is unacceptable to you. ;) ;) ;)

"Fixes" #786 .