### PR TITLE
Bumps gluegun to 0.18.2.

### DIFF
--- a/package.json
+++ b/package.json
@@ -33,7 +33,7 @@
   "dependencies": {
     "execa": "0.6.0",
     "fs-jetpack": "1.0.0",
-    "gluegun": "0.17.1",
+    "gluegun": "0.18.2",
     "gluegun-patching": "0.3.0",
     "minimist": "1.2.0",
     "pretty-error": "2.0.2",


### PR DESCRIPTION
Upgrades to the latest `gluegun`.

Various fixes, but one nice feature we can start using is:  all `context.*` extensions are now exported and available.

```js
import { system } from 'gluegun'

system.which('node')
```

🎉 

Sad side note:  `0.18.0` had some unwanted breaking changes that I patched up in `0.18.1`.  I also upgraded all the deps.  Which had 3 broken enquirer packages, which i rolled back in `0.18.2`.  😢 

I've tested this branch against `ir-next` and `ir-boilerplate-2016` and it's compatible.




