### PR TITLE
Adds overwrite project on ignite new

### DIFF
--- a/bin/ci
+++ b/bin/ci
@@ -57,7 +57,7 @@ check_builds()
   mkdir testgrounds
   cd ./testgrounds
   echo '~~~🌟 Generating Project'
-  test_command ignite new TestProj --min --skip-git
+  test_command ignite new TestProj --min --skip-git --overwrite
 
   echo '~~~🌟 Checking Builds'
   cd ./TestProj
@@ -113,7 +113,7 @@ check_builds()
   cd ..
 
   echo '~~~🌟 Generating ir-next Project'
-  test_command ignite new NextProj --min --skip-git -b ir-next
+  test_command ignite new NextProj --min --skip-git -b ir-next --overwrite
 
   echo '~~~🌟 Checking Builds'
   cd ./NextProj

--- a/docs/quick-start/ignite-commands.md
+++ b/docs/quick-start/ignite-commands.md
@@ -71,10 +71,12 @@ Generate a new React Native project with Ignite CLI.
 When you execute this command, Ignite CLI will give you a series of options for
 your new project regarding what libraries you would like to use.
 
-With `ignite new`, you have the option to pick your own boilerplate to install for your project.  The default is `ignite-ir-boilerplate`, however you can change this by providing your own boilerplate available on `npm`.
+With `ignite new`, you have the option to pick your own boilerplate to install for your project.  The default is `ignite-ir-boilerplate`, however you can change this by providing your own boilerplate available on `npm`. You can also point to a folder on your machine. `--boilerplate` can also be shortened to `-b`.
 
 ```
-ignite new MyAwesomeApp --boilerplate {some-boilerplate-package}
+ignite new MyAwesomeApp --boilerplate ir-next
+ignite new MyAwesomeApp -b boss-boilerplate
+ignite new MyAwesomeApp -b /path/to/my/ignite-cool-boilerplate
 ```
 
 If you would like to skip the boilerplate and use what is available out of the box with React Native, you can pass the `--no-boilerplate` option.
@@ -83,6 +85,9 @@ If you would like to skip the boilerplate and use what is available out of the b
 ignite new MyBareBonesApp --no-boilerplate
 ```
 
+You can (with most boilerplates) pass through a `--min` or `--max` flag to automatically choose maximum options or minimum options.
+
+If the new app's folder already exists, you can pass through `--overwrite` to overwrite the directory. If you don't, Ignite CLI will ask you if you want to overwrite it.
 
 ### Plugin
 

--- a/src/commands/new.js
+++ b/src/commands/new.js
@@ -14,7 +14,7 @@ const { forEach, keys, reduce, concat, trim, isEmpty, match, not, toLower } = re
  * @param {any} context - The gluegun context.
  */
 async function command (context) {
-  const { parameters, strings, print, system, filesystem, ignite } = context
+  const { parameters, strings, print, system, filesystem, ignite, prompt } = context
   const { isBlank, upperFirst, camelCase } = strings
   const { log } = ignite
 
@@ -49,7 +49,7 @@ async function command (context) {
 
   // Guard against `ignite new ignite`
   if (toLower(projectName) === 'ignite') {
-    context.print.error(`Hey...that's my name! Please name your project something other than '${projectName}'.`)
+    print.error(`Hey...that's my name! Please name your project something other than '${projectName}'.`)
     process.exit(exitCodes.PROJECT_NAME)
   }
 
@@ -62,7 +62,14 @@ async function command (context) {
   // verify the directory doesn't exist already
   if (filesystem.exists(projectName) === 'dir') {
     print.error(`Directory ${projectName} already exists.`)
-    process.exit(exitCodes.DIRECTORY_EXISTS)
+    const askOverwrite = async () => { return await prompt.confirm('Do you want to overwrite this directory?') }
+    
+    if (parameters.options.overwrite || await askOverwrite()) {
+      print.info(`Overwriting ${projectName}...`)
+      filesystem.remove(projectName)
+    } else {
+      process.exit(exitCodes.DIRECTORY_EXISTS)
+    }
   }
 
   // print a header

--- a/tests/integration/ignite-new/newInvalid.test.js
+++ b/tests/integration/ignite-new/newInvalid.test.js
@@ -36,15 +36,3 @@ test(`doesn't allow kebab-case`, async t => {
   }
 })
 
-test(`doesn't let you overwrite a folder`, async t => {
-  try {
-    jetpack.dir('Chicken')
-    await execa(IGNITE, ['new', 'Chicken'])
-    t.fail()
-  } catch (err) {
-    t.is(err.stdout, 'Directory Chicken already exists.\n')
-    t.is(err.code, 8)
-  } finally {
-    jetpack.remove('Chicken')
-  }
-})


### PR DESCRIPTION
Allows for `--overwrite` flag on `ignite new MyApp` to overwrite an existing folder. Useful for testing over and over. Will also ask (rather than just abort) if it encounters an existing folder without the flag.