### PR TITLE
Allows setting @ version on ignite add

### DIFF
--- a/src/commands/add.js
+++ b/src/commands/add.js
@@ -59,6 +59,12 @@ Examples:
     process.exit(exitCodes.OK)
   }
 
+  // we don't (yet) support scoped npm packages, so bail
+  if (parameters.second.startsWith('@')) {
+    print.error(`Error: Ignite CLI doesn't support prefixed npm packages yet, sorry about that. Try it without the prefix.`)
+    process.exit(1)
+  }
+
   // find out the type of install
   const specs = detectInstall(context)
   const { moduleName } = specs

--- a/src/lib/detectInstall.js
+++ b/src/lib/detectInstall.js
@@ -32,25 +32,27 @@ function detectInstall (context) {
 
   // the plugin we're trying to install
   let plugin = parameters.second
+  let packageName = plugin.split('@')[0]
+  let packageVersion = plugin.split('@')[1] || null
 
   // If a path, expand that path. If not, prepend with `ignite-*`.
-  if (plugin.includes('/')) {
-    plugin = filesystem.path(plugin)
+  if (packageName.includes('/')) {
+    packageName = filesystem.path(packageName)
   } else {
-    plugin = prependIgnite(plugin)
+    packageName = prependIgnite(packageName)
   }
 
   // do we have overrides?
   if (pluginOverrides.length > 0) {
     // look for the plugin into one of our override paths
     const foundPath = find(
-      overridePath => isValidIgnitePluginDirectory(`${overridePath}/${plugin}`),
+      overridePath => isValidIgnitePluginDirectory(`${overridePath}/${packageName}`),
       pluginOverrides
     )
 
     // did we find it?
     if (foundPath) {
-      const path = `${foundPath}/${plugin}`
+      const path = `${foundPath}/${packageName}`
       return {
         directory: path,
         override: true,
@@ -61,10 +63,10 @@ function detectInstall (context) {
   }
 
   // is this a directory?
-  if (isValidIgnitePluginDirectory(plugin)) {
-    const json = filesystem.read(`${plugin}/package.json`, 'json') || {}
+  if (isValidIgnitePluginDirectory(packageName)) {
+    const json = filesystem.read(`${packageName}/package.json`, 'json') || {}
     return {
-      directory: plugin,
+      directory: packageName,
       moduleName: json.name,
       type: 'directory'
     }
@@ -72,7 +74,8 @@ function detectInstall (context) {
 
   // the default is to assume that npm can figure out where to get this
   return {
-    moduleName: plugin,
+    moduleName: packageName,
+    version: packageVersion,
     type: 'npm'
   }
 }

--- a/src/lib/detectInstall.js
+++ b/src/lib/detectInstall.js
@@ -32,6 +32,8 @@ function detectInstall (context) {
 
   // the plugin we're trying to install
   let plugin = parameters.second
+
+  // extract the package name and (optionally) version
   let packageName = plugin.split('@')[0]
   let packageVersion = plugin.split('@')[1] || null
 

--- a/tests/fast/lib/detectInstall.test.js
+++ b/tests/fast/lib/detectInstall.test.js
@@ -12,7 +12,7 @@ test('detects npm modules', async t => {
     filesystem,
     parameters: { second: 'something' }
   })
-  const expected = { moduleName: 'ignite-something', type: 'npm' }
+  const expected = { moduleName: 'ignite-something', type: 'npm', version: null }
   t.deepEqual(actual, expected)
 })
 
@@ -21,7 +21,16 @@ test("won't double prefix", async t => {
     filesystem,
     parameters: { second: 'ignite-something' }
   })
-  const expected = { moduleName: 'ignite-something', type: 'npm' }
+  const expected = { moduleName: 'ignite-something', type: 'npm', version: null }
+  t.deepEqual(actual, expected)
+})
+
+test("removes @ version", async t => {
+  const actual = detectInstall({
+    filesystem,
+    parameters: { second: 'ignite-something@">=2.0.0"' }
+  })
+  const expected = { moduleName: 'ignite-something', type: 'npm', version: '">=2.0.0"' }
   t.deepEqual(actual, expected)
 })
 
@@ -53,7 +62,7 @@ test('detects invalid plugin directories', async t => {
     filesystem,
     parameters: { second: moduleName }
   })
-  const expected = { type: 'npm', moduleName }
+  const expected = { type: 'npm', moduleName, version: null }
   t.deepEqual(actual, expected)
 })
 


### PR DESCRIPTION
Prior to this change, doing `ignite add i18n@0.1.2` would result in an error.

Related to https://github.com/infinitered/ignite-ir-next/issues/57.