### PR TITLE
Fixes bug where .ejs was left on plugin examples

### DIFF
--- a/src/extensions/ignite/addPluginComponentExample.js
+++ b/src/extensions/ignite/addPluginComponentExample.js
@@ -18,6 +18,8 @@ module.exports = (plugin, command, context) => {
       templateFile = `${fileName}.ejs`
     }
 
+    const fileNameNoExt = templateFile.slice(0, -4)
+
     // do we want to use examples in the classic format?
     if (config.examples === 'classic') {
       const spinner = print.spin(`▸ adding component example`)
@@ -29,7 +31,7 @@ module.exports = (plugin, command, context) => {
       template.generate({
         directory: templatePath,
         template: templateFile,
-        target: `ignite/Examples/Components/${fileName}`,
+        target: `ignite/Examples/Components/${fileNameNoExt}`,
         props
       })
 
@@ -38,7 +40,7 @@ module.exports = (plugin, command, context) => {
       if (filesystem.exists(destinationPath)) {
         ignite.patchInFile(destinationPath, {
           after: 'import ExamplesRegistry',
-          insert: `import '../Examples/Components/${fileName}'`
+          insert: `import '../Examples/Components/${fileNameNoExt}'`
         })
       }
       spinner.stop()

--- a/src/extensions/ignite/addPluginScreenExamples.js
+++ b/src/extensions/ignite/addPluginScreenExamples.js
@@ -52,10 +52,12 @@ module.exports = (plugin, command, context) => {
             templateFile = `${fileName}.ejs`
           }
 
+          const filenameNoEjs = templateFile.slice(0, -4)
+
           template.generate({
             directory: templatePath,
             template: templateFile,
-            target: `ignite/Examples/Containers/${pluginName}/${fileName}`,
+            target: `ignite/Examples/Containers/${pluginName}/${filenameNoEjs}`,
             props
           })
         },

--- a/src/templates/plugin/plugin.js.ejs
+++ b/src/templates/plugin/plugin.js.ejs
@@ -6,7 +6,7 @@ const NPM_MODULE_VERSION = '0.0.1'
 
 // const PLUGIN_PATH = __dirname
 // const APP_PATH = process.cwd()
-<% if (props.answers.template === 'Yes') { %>const EXAMPLE_FILE = '<%= props.name %>Example.js'<% } %>
+<% if (props.answers.template === 'Yes') { %>const EXAMPLE_FILE = '<%= props.name %>Example.js.ejs'<% } %>
 
 const add = async function (context) {
   // Learn more about context: https://infinitered.github.io/gluegun/#/context-api.md


### PR DESCRIPTION
Plugin examples retained their `.js.ejs` extension, causing a crash. This fixes that.