### PR TITLE
Fixes sporking issue, adds better tests

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,5 +14,3 @@ node_modules
 !.vscode/extensions.json
 testgrounds
 generated
-tests/out
-out

--- a/src/extensions/ignite/copyBatch.js
+++ b/src/extensions/ignite/copyBatch.js
@@ -1,4 +1,13 @@
 module.exports = (plugin, command, context) => {
+  
+  function findSpork(context, template) {
+    // console.dir(context, {colors: true, depth: 1})
+    const { filesystem } = context
+    const sporkDirectory = `${filesystem.cwd()}/ignite/Spork/${context.plugin.name}`
+
+    return filesystem.exists(`${sporkDirectory}/${template}`) ? sporkDirectory : false
+  }
+
   /**
    * Runs a series of jobs through the templating system.
    *
@@ -38,8 +47,11 @@ module.exports = (plugin, command, context) => {
       // generate the React component
       if (await shouldGenerate(job.target)) {
         const currentPluginPath = ignitePluginPath()
+
+        const sporkDirectory = findSpork(context, job.template)
+
         await template.generate({
-          directory: directory || (currentPluginPath && `${currentPluginPath}/templates`),
+          directory: directory || sporkDirectory || (currentPluginPath && `${currentPluginPath}/templates`),
           template: job.template,
           target: job.target,
           props

--- a/tests/integration/ignite-new/new.test.js
+++ b/tests/integration/ignite-new/new.test.js
@@ -1,0 +1,41 @@
+const test = require('ava')
+const execa = require('execa')
+const tempy = require('tempy')
+const jetpack = require('fs-jetpack')
+
+const IGNITE = `${process.cwd()}/bin/ignite`
+const APP_DIR = 'Foo'
+
+test.before(t => {
+  const tempDir = tempy.directory()
+  process.chdir(tempDir)
+})
+
+test('spins up a min app and performs various checks', async t => {
+  await execa(IGNITE, ['new', APP_DIR, '--min'])
+  process.chdir(APP_DIR)
+
+  // check the contents of ignite/ignite.json
+  const igniteJSON = jetpack.read('ignite/ignite.json')
+  t.is(typeof igniteJSON, 'string')
+  t.regex(igniteJSON, /"generators": {/)
+
+  // check the Containers/App.js file
+  const appJS = jetpack.read('App/Containers/App.js')
+  t.regex(appJS, /class App extends Component {/)
+  
+  // run ignite g component
+  await execa(IGNITE, ['g', 'component', 'Test'])
+  t.is(jetpack.inspect('App/Components/Test.js').type, 'file')
+
+  // spork a screen and edit it
+  await execa(IGNITE, ['spork', 'component.ejs'])
+  const sporkedFile = 'ignite/Spork/ignite-ir-boilerplate-2016/component.ejs'
+  t.is(jetpack.inspect(sporkedFile).type, 'file')
+  await jetpack.write(sporkedFile, 'SPORKED!')
+  await execa(IGNITE, ['generate', 'component', 'Sporkified'])
+  t.is(jetpack.read('App/Components/Sporkified.js'), 'SPORKED!')
+
+  // TODO: add more end-to-end tests here
+})
+

--- a/tests/integration/ignite-new/newInvalid.test.js
+++ b/tests/integration/ignite-new/newInvalid.test.js
@@ -2,18 +2,11 @@ const test = require('ava')
 const execa = require('execa')
 const jetpack = require('fs-jetpack')
 
-const RUN_DIR = 'out/new'
-const BACK_DIR = '../..'
-const IGNITE = '../../bin/ignite'
+const IGNITE = `${process.cwd()}/bin/ignite`
 
-test.before(() => {
-  jetpack.dir(RUN_DIR)
-  process.chdir(RUN_DIR)
-})
-
-test.after.always(() => {
-  process.chdir(BACK_DIR)
-  jetpack.remove(RUN_DIR)
+test.before(t => {
+  const tempDir = tempy.directory()
+  process.chdir(tempDir)
 })
 
 test('requires a name', async t => {

--- a/tests/integration/ignite-new/newInvalid.test.js
+++ b/tests/integration/ignite-new/newInvalid.test.js
@@ -1,6 +1,6 @@
 const test = require('ava')
 const execa = require('execa')
-const jetpack = require('fs-jetpack')
+const tempy = require('tempy')
 
 const IGNITE = `${process.cwd()}/bin/ignite`
 


### PR DESCRIPTION
Spork was broken in `copyBatch` generators. This fixes issue #1043.

I also added an end-to-end test. The assertions can be filled out much more, but I'm happy to have what we have here. Should be very useful to catch `ignite new` issues, and it also tests a generator and of course sporking. This fixes #1050.

I also had to add the ability to specify a spork file from the initial command. Example: `ignite spork component.ejs` should spork just that file and not wait for input. Truthfully, that's how I thought it worked already!
