### PR TITLE
Switches default boilerplate from ir-boilerplate-2016 to ir-boilerplate

### DIFF
--- a/BOILERPLATES.md
+++ b/BOILERPLATES.md
@@ -4,7 +4,7 @@
 
 | Name | Description |
 |------|-------------|
-| [ignite-ir-next](https://github.com/infinitered/ignite-ir-next) | The latest and greatest of Infinite Red opinions |
+| [ignite-ir-boilerplate](https://github.com/infinitered/ignite-ir-next) | The latest and greatest of Infinite Red opinions |
 | [ignite-ir-boilerplate-2016](https://github.com/infinitered/ignite-ir-boilerplate-2016) | InfiniteRed's 2016 tech stack |
 
 ## 3rd Party

--- a/BOILERPLATES.md
+++ b/BOILERPLATES.md
@@ -4,7 +4,7 @@
 
 | Name | Description |
 |------|-------------|
-| [ignite-ir-boilerplate](https://github.com/infinitered/ignite-ir-next) | The latest and greatest of Infinite Red opinions |
+| [ignite-ir-boilerplate](https://github.com/infinitered/ignite-ir-boilerplate) | The latest and greatest of Infinite Red opinions |
 | [ignite-ir-boilerplate-2016](https://github.com/infinitered/ignite-ir-boilerplate-2016) | InfiniteRed's 2016 tech stack |
 
 ## 3rd Party

--- a/README.md
+++ b/README.md
@@ -53,7 +53,7 @@ $ ignite i love you
 * Powerful but well-defined behavior
 * Battle tested and used every day by the developers at Infinite Red
 
-And you also get (by default) all of the sweet, sweet goodness of [our default boilerplate](https://github.com/infinitered/ignite-ir-boilerplate-2016), or choose [one of many others](./BOILERPLATES.md).
+And you also get (by default) all of the sweet, sweet goodness of [our default boilerplate](https://github.com/infinitered/ignite-ir-boilerplate), or choose [one of many others](./BOILERPLATES.md).
 
 ## :arrow_down: Install
 

--- a/README.md
+++ b/README.md
@@ -95,7 +95,7 @@ Check out the list of [Plugins](./PLUGINS.md)
 
 Check out the list of [Boilerplates](./BOILERPLATES.md)
 ```
-$ ignite new MyNewAppName -b ir-next
+$ ignite new MyNewAppName -b ir-boilerplate
 ```
 
 ## :poop: Troubleshooting :poop:

--- a/bin/ci
+++ b/bin/ci
@@ -112,8 +112,8 @@ check_builds()
   # back to playground
   cd ..
 
-  echo '~~~🌟 Generating ir-next Project'
-  test_command ignite new NextProj --min --skip-git -b ir-next --overwrite
+  echo '~~~🌟 Generating ir-boilerplate Project'
+  test_command ignite new NextProj --min --skip-git -b ir-boilerplate --overwrite
 
   echo '~~~🌟 Checking Builds'
   cd ./NextProj

--- a/docs/advanced-guides/creating-boilerplates.md
+++ b/docs/advanced-guides/creating-boilerplates.md
@@ -2,7 +2,7 @@
 
 A boilerplate is an Ignite CLI plugin which runs only once: the moment you create a new project.  Its purpose is to bootstrap your brand new React Native project with files, directories, libraries, images, fonts, other ignite plugins, or whatever you need on every project you create.
 
-Like we do in [ignite-ir-boilerplate-2016](https://github.com/infinitered/ignite-ir-boilerplate-2016), it's helpful to make parts of your boilerplate optional.  For example, if you know you're not wanting to want animations, you might not want to install that library.
+Like we do in [ignite-ir-boilerplate](https://github.com/infinitered/ignite-ir-boilerplate), it's helpful to make parts of your boilerplate optional.  For example, if you know you're not wanting to want animations, you might not want to install that library.
 
 Please read the [creating plugins](./creating-plugins.md) guide before continuing.  It explains the shared concepts over there.  A boilerplate is a plugin, only with super powers.
 

--- a/docs/quick-start/ignite-commands.md
+++ b/docs/quick-start/ignite-commands.md
@@ -74,7 +74,7 @@ your new project regarding what libraries you would like to use.
 With `ignite new`, you have the option to pick your own boilerplate to install for your project.  The default is `ignite-ir-boilerplate`, however you can change this by providing your own boilerplate available on `npm`. You can also point to a folder on your machine. `--boilerplate` can also be shortened to `-b`.
 
 ```
-ignite new MyAwesomeApp --boilerplate ir-next
+ignite new MyAwesomeApp --boilerplate ir-boilerplate
 ignite new MyAwesomeApp -b boss-boilerplate
 ignite new MyAwesomeApp -b /path/to/my/ignite-cool-boilerplate
 ```

--- a/docs/quick-start/using-boilerplates.md
+++ b/docs/quick-start/using-boilerplates.md
@@ -13,5 +13,5 @@ It creates your app with a host of opinions and options. This boilerplate reflec
 
 You can opt out of a boilerplate entirely by passing the option `--no-boilerplate`.  This will skip installing a boilerplate and only create a `ignite/ignite.json` file in your project; the bare minimum needed to become Ignite CLI sentient.
 
-We intend to release new boilerplates as best practices change. For example, [React Navigation](https://reactnavigation.org) is a great new navigation library that we intend to support as soon as we feel it's ready. It will likely be released as a new boilerplate package, which in a future release of Ignite will be set to default once it's stable. You can view an unstable version in our [`ignite-ir-next` boilerplate](https://github.com/infinitered/ignite-ir-next).
+We intend to release new boilerplates as best practices change. For example, [React Navigation](https://reactnavigation.org) is a great new navigation library that we recently released in our brand new [`ignite-ir-boilerplate` boilerplate](https://github.com/infinitered/ignite-ir-boilerplate).
 

--- a/src/commands/new.js
+++ b/src/commands/new.js
@@ -86,7 +86,7 @@ async function command (context) {
   }
 
   // grab the right boilerplate
-  let boilerplateName = parameters.options.boilerplate || parameters.options.b || 'ir-boilerplate-2016'
+  let boilerplateName = parameters.options.boilerplate || parameters.options.b || 'ir-boilerplate'
   
   // If the name includes a slash, it's probably a path. Expand it so it's the full real path here.
   if (boilerplateName.includes('/')) {

--- a/src/templates/plugin/boilerplate.js.ejs
+++ b/src/templates/plugin/boilerplate.js.ejs
@@ -2,7 +2,7 @@
  * This file provides an `install` function that should install React Native,
  * copy over any folders and template files, and install any desired plugins.
  * 
- * It's a simpler version of the one found in https://github.com/infinitered/ignite-ir-boilerplate-2016.
+ * It's a simpler version of the one found in https://github.com/infinitered/ignite-ir-boilerplate.
  * Refer to that one to see a more full featured example of what you can do.
  * 
  */


### PR DESCRIPTION
Moving from the venerable `ignite-ir-boilerplate-2016` to the fresh, hot `ignite-ir-boilerplate` version 2.0.0 (Andross), which is currently released as `2.0.0-rc.1`.