### PR TITLE
Add json-server to plugins list

### DIFF
--- a/PLUGINS.md
+++ b/PLUGINS.md
@@ -22,3 +22,4 @@ name | supporting | author
 [video](https://github.com/ryanlntn/ignite-video) | [react-native-video](https://github.com/react-native-community/react-native-video) | [Ryan Linton](https://github.com/ryanlntn)
 [push-notification](https://github.com/ryanlntn/ignite-push-notification) | [react-native-push-notification](https://github.com/zo0r/react-native-push-notification) | [Ryan Linton](https://github.com/ryanlntn)
 [radio-buttons](https://github.com/robinheinze/ignite-radio-buttons) | [react-native-radio-buttons](https://github.com/ArnaudRinquin/react-native-radio-buttons) | [Robin Heinze](https://github.com/robinheinze)
+[json-server](https://github.com/infinitered/ignite-json-server) | [json-server](https://github.com/typicode/json-server) | [Derek Greenberg](https://github.com/derekgreenberg)


### PR DESCRIPTION
## Please verify the following:
- [ ] Everything works on iOS/Android
- [ ] `npm test` **ava** tests pass with new tests, if relevant
- [ ] `./docs/` has been updated with your changes, if relevant

## Describe your PR
This adds the json-server plugin to PLUGINS.md.

NOTE: do not merge until someone -anyone - has tested this plugin in their own environment: `https://github.com/infinitered/ignite-json-server`

