### PR TITLE
Adds missing `tempy` dependency from package.json.

### DIFF
--- a/package.json
+++ b/package.json
@@ -48,9 +48,10 @@
     "babel-eslint": "7.1.1",
     "mock-fs": "git://github.com/not-an-aardvark/mock-fs/#06868bbd7724707f9324b237bdde28f05f7a01d5",
     "mockery": "2.0.0",
+    "np": "2.12.0",
     "nyc": "10.3.2",
     "standard": "10.0.2",
-    "np": "2.12.0"
+    "tempy": "^0.1.0"
   },
   "ava": {},
   "standard": {


### PR DESCRIPTION
This dependency was missing causing the integration tests to fail.