### PR TITLE
replace `index.android.js` and `index.ios.js` with `index.js`

### DIFF
--- a/docs/quick-start/project-structure.md
+++ b/docs/quick-start/project-structure.md
@@ -19,8 +19,7 @@ Your new React Native project should have a file structure similar to the follow
 ```
 VanillaProject
 ├── __tests__
-│   ├── index.android.js
-│   └── index.ios.js
+│   ├── index.js
 ├── android
 │   ├── app
 │   ├── build.gradle
@@ -31,8 +30,7 @@ VanillaProject
 │   ├── keystores
 │   └── settings.gradle
 ├── app.json
-├── index.android.js
-├── index.ios.js
+├── index.js
 ├── ios
 │   ├── VanillaProject
 │   ├── VanillaProject-tvOS
@@ -72,8 +70,7 @@ IgniteProject
 │   └── Transforms
 ├── README.md
 ├── __tests__
-│   ├── index.android.js
-│   └── index.ios.js
+│   ├── index.js
 ├── android
 │   ├── app
 │   ├── build.gradle
@@ -86,8 +83,7 @@ IgniteProject
 ├── ignite
 │   ├── ignite.json
 │   └── plugins
-├── index.android.js
-├── index.ios.js
+├── index.js
 ├── ios
 │   ├── IgniteProject
 │   ├── IgniteProject-tvOS


### PR DESCRIPTION
## Please verify the following:
- [ ] Everything works on iOS/Android
- [ ] `npm test` **ava** tests pass with new tests, if relevant
- [ ] `./docs/` has been updated with your changes, if relevant

## Describe your PR
react-native no longer has two platform specific entry files, but instead has consolidated them into one `index.js`
