### PR TITLE
Fix precedence error for file existence check in isIgniteDirectory

### DIFF
--- a/src/lib/isIgniteDirectory.js
+++ b/src/lib/isIgniteDirectory.js
@@ -10,7 +10,7 @@ function isIgniteDirectory (directory) {
   const igniteConfigPath = `${directory}/ignite/ignite.json`
 
   // it must be a file
-  if (!jetpack.exists(igniteConfigPath) === 'file') return false
+  if (jetpack.exists(igniteConfigPath) !== 'file') return false
 
   // let's read it as a JSON file
   try {


### PR DESCRIPTION
## Please verify the following:
- [ ] Everything works on iOS/Android <<**not tested**>>
- [x] `npm test` **ava** tests pass with new tests, if relevant
- [ ] ./docs/` has been updated with your changes, if relevant <<**not relevant**>>

## Describe your PR

This PR fixes #1206 by moving the negation into the expression.
This does not change semantics, it just makes use of `return false` on line 13 immediately in some cases instead of waiting for an error to cause `return false` on line 21 to be used.

Since this does not change semantics, a test can not easily be written for it (we could monitor for exceptions within the fs-mock, but that seems excessive).

