### PR TITLE
A little linting cleanup

### DIFF
--- a/bin/ci
+++ b/bin/ci
@@ -60,7 +60,7 @@ check_builds()
   cd $(mktemp -d)
 
   echo '~~~🌟 Generating Project'
-  test_command ignite new TestProj --min --skip-git --overwrite
+  test_command ignite new TestProj --min --skip-git --overwrite -b ignite-ir-boilerplate-andross
 
   echo '~~~🌟 Checking Builds'
   cd ./TestProj

--- a/src/cli/check.js
+++ b/src/cli/check.js
@@ -34,7 +34,7 @@ try {
   process.exit(3)
 }
 
-// Only check full dependencies if we're running in `--debug` or `--wtf` mode 
+// Only check full dependencies if we're running in `--debug` or `--wtf` mode
 var debugMode = (process.argv.indexOf('--debug') !== -1 || process.argv.indexOf('--wtf') !== -1)
 
 if (debugMode) {
@@ -87,4 +87,3 @@ if (debugMode) {
     process.exit(exitCodes.INVALID_GLOBAL_DEPENDENCY)
   }
 }
-

--- a/src/commands/new.js
+++ b/src/commands/new.js
@@ -184,4 +184,3 @@ async function command (context) {
 }
 
 module.exports = command
-

--- a/src/commands/new.js
+++ b/src/commands/new.js
@@ -71,7 +71,7 @@ async function command (context) {
   // verify the directory doesn't exist already
   if (filesystem.exists(projectName) === 'dir') {
     print.error(`Directory ${projectName} already exists.`)
-    const askOverwrite = async () => { return await prompt.confirm('Do you want to overwrite this directory?') }
+    const askOverwrite = async () => { return prompt.confirm('Do you want to overwrite this directory?') }
 
     if (parameters.options.overwrite || await askOverwrite()) {
       print.info(`Overwriting ${projectName}...`)

--- a/src/commands/plugin.js
+++ b/src/commands/plugin.js
@@ -18,7 +18,7 @@ const walkthrough = async (context) => {
   if (context.parameters.options.max) { return maxOptions }
 
   // Okay, we'll ask one by one, fine
-  return await context.prompt.ask([
+  return context.prompt.ask([
     {
       name: 'boilerplate',
       message: 'Is this an app boilerplate plugin?',

--- a/src/extensions/ignite.js
+++ b/src/extensions/ignite.js
@@ -33,7 +33,7 @@ const pluginOverridesExt = require('./ignite/pluginOverrides')
  * @return {Function} A function to attach to the context.
  */
 function attach (plugin, command, context) {
-  const { parameters, system } = context
+  const { parameters } = context
 
   // determine which package manager to use
   const forceNpm = parameters.options.npm

--- a/src/extensions/ignite/copyBatch.js
+++ b/src/extensions/ignite/copyBatch.js
@@ -1,6 +1,5 @@
 module.exports = (plugin, command, context) => {
-  
-  function findSpork(context, template) {
+  function findSpork (context, template) {
     // console.dir(context, {colors: true, depth: 1})
     const { filesystem } = context
     const sporkDirectory = `${filesystem.cwd()}/ignite/Spork/${context.plugin.name}`

--- a/src/extensions/ignite/copyBatch.js
+++ b/src/extensions/ignite/copyBatch.js
@@ -33,7 +33,7 @@ module.exports = (plugin, command, context) => {
     const shouldGenerate = async target => {
       if (!askToOverwrite) return true
       if (!filesystem.exists(target)) return true
-      return await confirm(`overwrite ${target}`)
+      return confirm(`overwrite ${target}`)
     }
 
     // old school loop because of async stuff

--- a/src/extensions/ignite/generate.js
+++ b/src/extensions/ignite/generate.js
@@ -18,7 +18,7 @@ module.exports = (plugin, command, context) => {
     const overrides = isSporked ? { directory: sporkDirectory } : {}
 
     // now make the call to the gluegun generate
-    return await template.generate(merge(opts, overrides))
+    return template.generate(merge(opts, overrides))
   }
 
   return generate

--- a/src/lib/importPlugin.js
+++ b/src/lib/importPlugin.js
@@ -55,7 +55,7 @@ async function importPlugin (context, opts) {
         )
       }
     }
-    
+
     const cmd = isDirectory
       ? `yarn add file:${target} --force --dev`
       : `yarn add ${target} --dev`

--- a/tests/fast/lib/detectInstall.test.js
+++ b/tests/fast/lib/detectInstall.test.js
@@ -25,7 +25,7 @@ test("won't double prefix", async t => {
   t.deepEqual(actual, expected)
 })
 
-test("removes @ version", async t => {
+test('removes @ version', async t => {
   const actual = detectInstall({
     filesystem,
     parameters: { second: 'ignite-something@">=2.0.0"' }

--- a/tests/integration/ignite-new/new.test.js
+++ b/tests/integration/ignite-new/new.test.js
@@ -23,7 +23,7 @@ test('spins up a min app and performs various checks', async t => {
   // check the Containers/App.js file
   const appJS = jetpack.read('App/Containers/App.js')
   t.regex(appJS, /class App extends Component {/)
-  
+
   // run ignite g component
   await execa(IGNITE, ['g', 'component', 'Test'])
   t.is(jetpack.inspect('App/Components/Test.js').type, 'file')
@@ -38,4 +38,3 @@ test('spins up a min app and performs various checks', async t => {
 
   // TODO: add more end-to-end tests here
 })
-

--- a/tests/integration/ignite-new/new.test.js
+++ b/tests/integration/ignite-new/new.test.js
@@ -12,7 +12,7 @@ test.before(t => {
 })
 
 test('spins up a min app and performs various checks', async t => {
-  await execa(IGNITE, ['new', APP_DIR, '--min'])
+  await execa(IGNITE, ['new', APP_DIR, '--min', '-b', 'ignite-ir-boilerplate-andross'])
   process.chdir(APP_DIR)
 
   // check the contents of ignite/ignite.json
@@ -30,7 +30,7 @@ test('spins up a min app and performs various checks', async t => {
 
   // spork a screen and edit it
   await execa(IGNITE, ['spork', 'component.ejs'])
-  const sporkedFile = 'ignite/Spork/ignite-ir-boilerplate/component.ejs'
+  const sporkedFile = 'ignite/Spork/ignite-ir-boilerplate-andross/component.ejs'
   t.is(jetpack.inspect(sporkedFile).type, 'file')
   await jetpack.write(sporkedFile, 'SPORKED!')
   await execa(IGNITE, ['generate', 'component', 'Sporkified'])


### PR DESCRIPTION
Hey guys, 
I'm preparing to try to add support for `create-react-app` thru ignite, first though I thought I would lint things, and whaddya know.... found there were these errors:

```
  /home/justin/projects/node/ignite/src/cli/check.js:37:78: Trailing spaces not allowed.
  /home/justin/projects/node/ignite/src/cli/check.js:90:1: Too many blank lines at the end of file. Max of 0 allowed.
  /home/justin/projects/node/ignite/src/commands/new.js:74:47: Redundant use of `await` on a return value.
  /home/justin/projects/node/ignite/src/commands/new.js:187:1: Too many blank lines at the end of file. Max of 0 allowed.
  /home/justin/projects/node/ignite/src/commands/plugin.js:21:10: Redundant use of `await` on a return value.
  /home/justin/projects/node/ignite/src/extensions/ignite.js:36:23: 'system' is assigned a value but never used.
  /home/justin/projects/node/ignite/src/extensions/ignite/copyBatch.js:1:48: Block must not be padded by blank lines.
  /home/justin/projects/node/ignite/src/extensions/ignite/copyBatch.js:2:1: Trailing spaces not allowed.
  /home/justin/projects/node/ignite/src/extensions/ignite/copyBatch.js:3:21: Missing space before function parentheses.
  /home/justin/projects/node/ignite/src/extensions/ignite/copyBatch.js:37:14: Redundant use of `await` on a return value.
  /home/justin/projects/node/ignite/src/extensions/ignite/generate.js:21:12: Redundant use of `await` on a return value.
  /home/justin/projects/node/ignite/src/lib/importPlugin.js:58:1: Trailing spaces not allowed.
  /home/justin/projects/node/ignite/tests/fast/lib/detectInstall.test.js:28:6: Strings must use singlequote.
  /home/justin/projects/node/ignite/tests/integration/ignite-new/new.test.js:26:1: Trailing spaces not allowed.
  /home/justin/projects/node/ignite/tests/integration/ignite-new/new.test.js:41:1: Too many blank lines at the end of file. Max of 0 allowed.
```
so thought I would fix so everything is nice and clean. :rotating_light: 
