### PR TITLE
Upgraded crashlytics plugin and changed name

### DIFF
--- a/PLUGINS.md
+++ b/PLUGINS.md
@@ -30,5 +30,6 @@ name | supporting | author
 [tab-view](https://github.com/dabit3/ignite-tab-view) | [react-native-tab-view](https://github.com/react-native-community/react-native-tab-view) | [Nadir Dabit](https://github.com/dabit3)
 [video](https://github.com/ryanlntn/ignite-video) | [react-native-video](https://github.com/react-native-community/react-native-video) | [Ryan Linton](https://github.com/ryanlntn)
 [camera](https://github.com/thisisjaiswal/ignite-camera) | [react-native-camera](https://github.com/lwansbrough/react-native-camera) | [Sandeep Jaiswal](https://github.com/thisisjaiswal)
-[fabric / crashlytics](https://github.com/Osedea/ignite-fabric) | [react-native-fabric](https://github.com/corymsmith/react-native-fabric) | [Adrien Thiery](https://github.com/adrienthiery)
-[onesignal](https://github.com/LighthouseIT/ignite-onesignal) | [react-native-onesignal](https://github.com/OneSignal/react-native-onesignal/) | [Donald Silveira](https://github.com/donnes) 
+[fabric](https://github.com/Osedea/ignite-fabric) (to be deprecated) | [react-native-fabric](https://github.com/corymsmith/react-native-fabric) | [Adrien Thiery](https://github.com/adrienthiery)
+[crashlytics](https://github.com/Osedea/ignite-crashlytics) | [react-native-fabric](https://github.com/corymsmith/react-native-fabric) | [Adrien Thiery](https://github.com/adrienthiery)
+[onesignal](https://github.com/LighthouseIT/ignite-onesignal) | [react-native-onesignal](https://github.com/OneSignal/react-native-onesignal/) | [Donald Silveira](https://github.com/donnes)


### PR DESCRIPTION
## Please verify the following:
- [ ] ~Everything works on iOS/Android~
- [ ] ~`npm test` **ava** tests pass with new tests, if relevant~
- [x] `./docs/` has been updated with your changes, if relevant

## Describe your PR

I had made `ignite-fabric` a while back, but since Fabric has been bought by Google (Firebase), the instructions to get started have changed, and now Crashlytics is replacing Crash detection on Firebase, so I revamped the plugin with the new setup instructions and renamed it to `ignite-crashlytics` (because that's actually the only thing it sets up).

Right now, the other plugin is still working, though, so I marked it as `(to be deprecated)`.

Is that good for you guys?