### PR TITLE
Add ignite-kryptonite web boilerplate

### DIFF
--- a/BOILERPLATES.md
+++ b/BOILERPLATES.md
@@ -17,3 +17,4 @@
 | [ignite-appclon-mobx](https://github.com/Appclon/ignite-appclon-mobx) | Appclon + Ignite Boilerplate | [Appclon](https://github.com/Appclon) |
 | [ignite-typescript-boilerplate](https://github.com/aerian-studios/ignite-typescript-boilerplate/) | A boilerplate for TypeScript apps, based on ignite-ir-boilerplate  | [Matt Kane](https://github.com/ascorbic) |
 | [ignite-expo-boilerplate](https://github.com/jbosse/ignite-expo-boilerplate) | Fork of ignite-ir-boilerplate modified to work with Expo.io  | [Jimmy Bosse](https://github.com/jbosse) |
+| [ignite-kryptonite](https://github.com/juddey/ignite-kryptonite) | Your react web thing, ignitified.  | [Justin Lane](https://github.com/juddey) |


### PR DESCRIPTION
Hello! Adding a link to a boilerplate I've developed for react single page apps, based on`andross`. Uses `create-react-app` under the hood to create the initial skeleton and then writes the boilerplate from there.

Designed to answer the question: _Is there an ignite boilerplate for web?_

:smile: 