### PR TITLE
[WIP] Feature/add boilerplatize command

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -4171,10 +4171,9 @@
       }
     },
     "ignore": {
-      "version": "3.3.3",
-      "resolved": "https://registry.npmjs.org/ignore/-/ignore-3.3.3.tgz",
-      "integrity": "sha1-QyNS5XrM2HqzEQ6C0/6g5HgSFW0=",
-      "dev": true
+      "version": "3.3.8",
+      "resolved": "https://registry.npmjs.org/ignore/-/ignore-3.3.8.tgz",
+      "integrity": "sha512-pUh+xUQQhQzevjRHHFqqcTy0/dP/kS9I8HSrUydhihjuD09W6ldVWFtIrwhXdUJHis3i2rZNqEHpZH/cbinFbg=="
     },
     "ignore-by-default": {
       "version": "1.0.1",

--- a/package.json
+++ b/package.json
@@ -10,7 +10,6 @@
     "test": "nyc ava tests/fast",
     "watch": "ava tests/fast --watch",
     "coverage": "nyc report --reporter=text-lcov | coveralls",
-    "start": "node src/index.js",
     "lint": "standard",
     "integration": "ava -s tests/integration",
     "shipit": "np"
@@ -35,6 +34,7 @@
     "fs-jetpack": "1.2.0",
     "gluegun": "0.20.0",
     "gluegun-patching": "0.3.0",
+    "ignore": "^3.3.8",
     "minimist": "1.2.0",
     "pretty-error": "2.0.2",
     "ramda": "0.24.1",

--- a/src/cli/cli.js
+++ b/src/cli/cli.js
@@ -15,7 +15,6 @@ const buildIgnite = () => {
     .token('commandName', 'cliCommand')
     .token('commandHidden', 'cliHidden')
     .token('commandAlias', 'cliAlias')
-    .token('commandName', 'cliCommand')
     .token('commandDescription', 'cliDescription')
     .token('extensionName', 'contextExtension')
     .createRuntime()

--- a/src/commands/boilerplatize.js
+++ b/src/commands/boilerplatize.js
@@ -2,25 +2,25 @@
 // @cliAlias bz
 // ----------------------------------------------------------------------------
 
-const ignore = require('ignore');
+const ignore = require('ignore')
 
-const targetFolder = 'boilerplate/';
-let projectName;
+const targetFolder = 'boilerplate/'
+let projectName
 let ignoredFiles = ignore().add([
   '.DS_Store',
   'boilerplate',
-  '.git',
-]);
+  '.git'
+])
 
 /**
  * @param {string} fileName - Name of the file we want to copy
  * @param {GluegunContext} context - the Gluegun context
  */
-async function generateFile(relativePath, context) {
-  const { filesystem, print: { info, colors }, patching, ignite } = context;
-  const absolutePath = `${filesystem.cwd()}/${relativePath}`;
+async function generateFile (relativePath, context) {
+  const { filesystem, ignite } = context
+  const absolutePath = `${filesystem.cwd()}/${relativePath}`
 
-  const fileContent = filesystem.read(absolutePath);
+  const fileContent = filesystem.read(absolutePath)
 
   // Checking if file contains imports from the project
   const fileIncludesProjectName =
@@ -28,21 +28,21 @@ async function generateFile(relativePath, context) {
     fileContent.includes(`require("${projectName}`) ||
     fileContent.includes(`from '${projectName}/`) ||
     fileContent.includes(`from "${projectName}/`) ||
-    fileContent.includes(`"${projectName}"`);
+    fileContent.includes(`"${projectName}"`)
 
   if (fileIncludesProjectName) {
     if (relativePath === 'package.json') {
-      const packageJSON = filesystem.read(absolutePath, 'json');
-      delete packageJSON.dependencies.react;
-      delete packageJSON.dependencies['react-native'];
+      const packageJSON = filesystem.read(absolutePath, 'json')
+      delete packageJSON.dependencies.react
+      delete packageJSON.dependencies['react-native']
       filesystem.write(`${targetFolder}${relativePath}.ejs`, packageJSON, { atomic: true })
     } else {
-      filesystem.copy(absolutePath, `${targetFolder}${relativePath}.ejs`);
+      filesystem.copy(absolutePath, `${targetFolder}${relativePath}.ejs`)
     }
-    console.log(`Patching ${targetFolder}${relativePath}.ejs`);
-    await ignite.patchInFile(`${targetFolder}${relativePath}.ejs`, { replace: new RegExp(projectName, 'g'), insert: '<% props.name %>' });
+    console.log(`Patching ${targetFolder}${relativePath}.ejs`)
+    await ignite.patchInFile(`${targetFolder}${relativePath}.ejs`, { replace: new RegExp(projectName, 'g'), insert: '<% props.name %>' })
   } else {
-    filesystem.copy(absolutePath, `${targetFolder}${relativePath}`);
+    filesystem.copy(absolutePath, `${targetFolder}${relativePath}`)
   }
 };
 
@@ -50,30 +50,29 @@ async function generateFile(relativePath, context) {
  * @param {string} folderName - Name of the folder we want to list and copy
  * @param {GluegunContext} context - the Gluegun context
  */
-async function listAndCopy(folderName, context, acceptedForSubdirectories = false) {
-  const isFirstLoop = !folderName;
-  const { ignite, filesystem, print: { colors, info } } = context;
-  const relativeFolderPathExceptForRoot = isFirstLoop ? filesystem.cwd() : `${folderName}/`;
-  const absoluteFolderPath = !isFirstLoop ? `${filesystem.cwd()}/${relativeFolderPathExceptForRoot}` : relativeFolderPathExceptForRoot;
+async function listAndCopy (folderName, context, acceptedForSubdirectories = false) {
+  const isFirstLoop = !folderName
+  const { ignite, filesystem, print: { colors, info } } = context
+  const relativeFolderPathExceptForRoot = isFirstLoop ? filesystem.cwd() : `${folderName}/`
 
   if (ignoredFiles.ignores(relativeFolderPathExceptForRoot)) {
-    ignite.log(`Ignoring ${relativeFolderPathExceptForRoot}`);
-    return;
+    ignite.log(`Ignoring ${relativeFolderPathExceptForRoot}`)
+    return
   }
 
   // handleiOSAndAndroidFolders()
-  const files = await filesystem.list(relativeFolderPathExceptForRoot);
+  const files = await filesystem.list(relativeFolderPathExceptForRoot)
 
   for (let index = 0; index < files.length; index++) {
-    const item = files[index];
-    const srcItemRelativePath = `${folderName ? `${folderName}/` : ''}${item}`;
-    ignite.log(`Checking: ${srcItemRelativePath}`);
+    const item = files[index]
+    const srcItemRelativePath = `${folderName ? `${folderName}/` : ''}${item}`
+    ignite.log(`Checking: ${srcItemRelativePath}`)
 
     if (ignoredFiles.ignores(srcItemRelativePath)) {
-      ignite.log(`Ignoring ${srcItemRelativePath}`);
+      ignite.log(`Ignoring ${srcItemRelativePath}`)
     } else {
-      if (filesystem.exists(srcItemRelativePath) === "dir") {
-        let answer;
+      if (filesystem.exists(srcItemRelativePath) === 'dir') {
+        let answer
 
         if (!acceptedForSubdirectories) {
           answer = await context.prompt.ask([
@@ -82,21 +81,21 @@ async function listAndCopy(folderName, context, acceptedForSubdirectories = fals
               message: `Do you want to include the '${srcItemRelativePath}' folder in your boilerplate?`,
               type: 'radio',
               choices: ['Yes', 'Yes and all the subdirectories', 'No']
-            },
-          ]);
+            }
+          ])
         } else {
-          answer = { includeFolder: 'Yes and all the subdirectories' };
+          answer = { includeFolder: 'Yes and all the subdirectories' }
         }
 
         if (answer.includeFolder.includes('Yes')) {
-          filesystem.dir(`${targetFolder}${srcItemRelativePath}`);
-          info(colors.green(`Creating directory: ${targetFolder}${srcItemRelativePath}`));
-          await listAndCopy(srcItemRelativePath, context, answer.includeFolder === 'Yes and all the subdirectories');
+          filesystem.dir(`${targetFolder}${srcItemRelativePath}`)
+          info(colors.green(`Creating directory: ${targetFolder}${srcItemRelativePath}`))
+          await listAndCopy(srcItemRelativePath, context, answer.includeFolder === 'Yes and all the subdirectories')
         } else {
-          info(colors.yellow(`Skipping directory: ${srcItemRelativePath}`));
+          info(colors.yellow(`Skipping directory: ${srcItemRelativePath}`))
         }
       } else {
-        await generateFile(srcItemRelativePath, context);
+        await generateFile(srcItemRelativePath, context)
       }
     }
   }
@@ -105,29 +104,29 @@ async function listAndCopy(folderName, context, acceptedForSubdirectories = fals
 /**
  * @param {GluegunContext} context - the Gluegun context
  */
-async function boilerplatize(context) {
-  const { print: { colors, info }, ignite, filesystem } = context;
+async function boilerplatize (context) {
+  const { print: { colors, info }, ignite, filesystem } = context
 
-  ignite.log('running boilerplatize command');
+  ignite.log('running boilerplatize command')
 
   // Get the project name out of package.json
-  const packageJSON = filesystem.read(`${filesystem.cwd()}/package.json`, 'json');
-  projectName = packageJSON.name;
+  const packageJSON = filesystem.read(`${filesystem.cwd()}/package.json`, 'json')
+  projectName = packageJSON.name
 
   // Read gitignore and filter comments and empty lines
-  const gitignore = filesystem.read(`${filesystem.cwd()}/.gitignore`).split(filesystem.eol).filter((item) => item[0] !== '#' && item !== '');
+  const gitignore = filesystem.read(`${filesystem.cwd()}/.gitignore`).split(filesystem.eol).filter((item) => item[0] !== '#' && item !== '')
 
-  ignoredFiles.add(gitignore);
+  ignoredFiles.add(gitignore)
 
   if (filesystem.exists(`${targetFolder}`)) {
-    info(colors.green(`Removing ${targetFolder}`));
-    filesystem.remove(`${targetFolder}`);
+    info(colors.green(`Removing ${targetFolder}`))
+    filesystem.remove(`${targetFolder}`)
   }
 
-  info(colors.green(`Creating ${targetFolder}`));
-  filesystem.dir(`${targetFolder}`);
+  info(colors.green(`Creating ${targetFolder}`))
+  filesystem.dir(`${targetFolder}`)
 
-  await listAndCopy(null, context);
+  await listAndCopy(null, context)
 }
 
-module.exports = boilerplatize;
+module.exports = boilerplatize

--- a/src/commands/boilerplatize.js
+++ b/src/commands/boilerplatize.js
@@ -78,11 +78,15 @@ async function listAndCopy (folderName, context, acceptedForSubdirectories = fal
           answer = await context.prompt.ask([
             {
               name: 'includeFolder',
-              message: `Do you want to include the '${srcItemRelativePath}' folder in your boilerplate?`,
+              message: `Do you want to include the '${srcItemRelativePath}' folder in your boilerplate? (defaults to YES)`,
               type: 'radio',
               choices: ['Yes', 'Yes and all the subdirectories', 'No']
             }
           ])
+
+          if (!answer.includeFolder) {
+            answer = { includeFolder: 'Yes' }
+          }
         } else {
           answer = { includeFolder: 'Yes and all the subdirectories' }
         }

--- a/src/commands/boilerplatize.js
+++ b/src/commands/boilerplatize.js
@@ -1,0 +1,133 @@
+// @cliDescription Turns a valid react-native project into a boilerplatize.
+// @cliAlias bz
+// ----------------------------------------------------------------------------
+
+const ignore = require('ignore');
+
+const targetFolder = 'boilerplate/';
+let projectName;
+let ignoredFiles = ignore().add([
+  '.DS_Store',
+  'boilerplate',
+  '.git',
+]);
+
+/**
+ * @param {string} fileName - Name of the file we want to copy
+ * @param {GluegunContext} context - the Gluegun context
+ */
+async function generateFile(relativePath, context) {
+  const { filesystem, print: { info, colors }, patching, ignite } = context;
+  const absolutePath = `${filesystem.cwd()}/${relativePath}`;
+
+  const fileContent = filesystem.read(absolutePath);
+
+  // Checking if file contains imports from the project
+  const fileIncludesProjectName =
+    fileContent.includes(`require('${projectName}`) ||
+    fileContent.includes(`require("${projectName}`) ||
+    fileContent.includes(`from '${projectName}/`) ||
+    fileContent.includes(`from "${projectName}/`) ||
+    fileContent.includes(`"${projectName}"`);
+
+  if (fileIncludesProjectName) {
+    if (relativePath === 'package.json') {
+      const packageJSON = filesystem.read(absolutePath, 'json');
+      delete packageJSON.dependencies.react;
+      delete packageJSON.dependencies['react-native'];
+      filesystem.write(`${targetFolder}${relativePath}.ejs`, packageJSON, { atomic: true })
+    } else {
+      filesystem.copy(absolutePath, `${targetFolder}${relativePath}.ejs`);
+    }
+    console.log(`Patching ${targetFolder}${relativePath}.ejs`);
+    await ignite.patchInFile(`${targetFolder}${relativePath}.ejs`, { replace: new RegExp(projectName, 'g'), insert: '<% props.name %>' });
+  } else {
+    filesystem.copy(absolutePath, `${targetFolder}${relativePath}`);
+  }
+};
+
+/**
+ * @param {string} folderName - Name of the folder we want to list and copy
+ * @param {GluegunContext} context - the Gluegun context
+ */
+async function listAndCopy(folderName, context, acceptedForSubdirectories = false) {
+  const isFirstLoop = !folderName;
+  const { ignite, filesystem, print: { colors, info } } = context;
+  const relativeFolderPathExceptForRoot = isFirstLoop ? filesystem.cwd() : `${folderName}/`;
+  const absoluteFolderPath = !isFirstLoop ? `${filesystem.cwd()}/${relativeFolderPathExceptForRoot}` : relativeFolderPathExceptForRoot;
+
+  if (ignoredFiles.ignores(relativeFolderPathExceptForRoot)) {
+    ignite.log(`Ignoring ${relativeFolderPathExceptForRoot}`);
+    return;
+  }
+
+  // handleiOSAndAndroidFolders()
+  const files = await filesystem.list(relativeFolderPathExceptForRoot);
+
+  for (let index = 0; index < files.length; index++) {
+    const item = files[index];
+    const srcItemRelativePath = `${folderName ? `${folderName}/` : ''}${item}`;
+    ignite.log(`Checking: ${srcItemRelativePath}`);
+
+    if (ignoredFiles.ignores(srcItemRelativePath)) {
+      ignite.log(`Ignoring ${srcItemRelativePath}`);
+    } else {
+      if (filesystem.exists(srcItemRelativePath) === "dir") {
+        let answer;
+
+        if (!acceptedForSubdirectories) {
+          answer = await context.prompt.ask([
+            {
+              name: 'includeFolder',
+              message: `Do you want to include the '${srcItemRelativePath}' folder in your boilerplate?`,
+              type: 'radio',
+              choices: ['Yes', 'Yes and all the subdirectories', 'No']
+            },
+          ]);
+        } else {
+          answer = { includeFolder: 'Yes and all the subdirectories' };
+        }
+
+        if (answer.includeFolder.includes('Yes')) {
+          filesystem.dir(`${targetFolder}${srcItemRelativePath}`);
+          info(colors.green(`Creating directory: ${targetFolder}${srcItemRelativePath}`));
+          await listAndCopy(srcItemRelativePath, context, answer.includeFolder === 'Yes and all the subdirectories');
+        } else {
+          info(colors.yellow(`Skipping directory: ${srcItemRelativePath}`));
+        }
+      } else {
+        await generateFile(srcItemRelativePath, context);
+      }
+    }
+  }
+};
+
+/**
+ * @param {GluegunContext} context - the Gluegun context
+ */
+async function boilerplatize(context) {
+  const { print: { colors, info }, ignite, filesystem } = context;
+
+  ignite.log('running boilerplatize command');
+
+  // Get the project name out of package.json
+  const packageJSON = filesystem.read(`${filesystem.cwd()}/package.json`, 'json');
+  projectName = packageJSON.name;
+
+  // Read gitignore and filter comments and empty lines
+  const gitignore = filesystem.read(`${filesystem.cwd()}/.gitignore`).split(filesystem.eol).filter((item) => item[0] !== '#' && item !== '');
+
+  ignoredFiles.add(gitignore);
+
+  if (filesystem.exists(`${targetFolder}`)) {
+    info(colors.green(`Removing ${targetFolder}`));
+    filesystem.remove(`${targetFolder}`);
+  }
+
+  info(colors.green(`Creating ${targetFolder}`));
+  filesystem.dir(`${targetFolder}`);
+
+  await listAndCopy(null, context);
+}
+
+module.exports = boilerplatize;

--- a/src/extensions/ignite/patchInFile.js
+++ b/src/extensions/ignite/patchInFile.js
@@ -32,12 +32,23 @@ module.exports = (plugin, command, context) => {
     const newString = opts.insert || ''
 
     if (replaceString) {
-      if (data.includes(replaceString)) {
-        // Replace matching string with new string
-        const newContents = data.replace(replaceString, `${newString}`)
-        jetpack.write(file, newContents, { atomic: true })
+      if (typeof replaceString === 'string') {
+        if (data.includes(replaceString)) {
+          // Replace matching string with new string
+          const newContents = data.replace(replaceString, `${newString}`)
+          jetpack.write(file, newContents, { atomic: true })
+        } else {
+          console.warn(`${replaceString} not found`)
+        }
+      } else if (replaceString instanceof RegExp) {
+        if (data.match(replaceString)) {
+          const newContents = data.replace(replaceString, `${newString}`)
+          jetpack.write(file, newContents, { atomic: true })
+        } else {
+          console.warn(`${replaceString} not found`)
+        }
       } else {
-        console.warn(`${replaceString} not found`)
+        console.warn(`${replaceString} is neither a String or a RegExp?`)
       }
     } else {
       // Insert before/after a particular string


### PR DESCRIPTION
## Please verify the following:

- [ ] Everything works on iOS/Android
- [x] `npm test` **ava** tests pass with new tests, if relevant
- [ ] `./docs/` has been updated with your changes, if relevant

## Describe your PR

This is the first attempt to add a `boilerplatize` command.

This PR is mostly asking for feedback from @kevinvangelder and/or @GantMan and other inifinitered people 🙂(or anyone really).

What would you need from a `boilerplatize` command? (See #1282 )

Concept of the command right now:

* Ask if you want to include a folder and all subfiles, or some files in the folder, or non
   * if none, skip
   * if some, ask which ones
   * if all, add all
* For each file selected, if the file contains the project name (`package.json` > `name`), transform it into an `.ejs` template replacing all occurences of `name` by `props.name`

The command should theoretically ignore all files specified in `.gitignore` (To be fixed 'cause `node_modules` seem to be asked for...)

Example of use:
<img width="427" alt="screen shot 2018-07-09 at 10 07 59 pm" src="https://user-images.githubusercontent.com/2392118/42485195-9c766532-83c4-11e8-8c9a-b61a547dec54.png">
