### PR TITLE
enable using specific version of a boilerplate

### DIFF
--- a/docs/quick-start/ignite-commands.md
+++ b/docs/quick-start/ignite-commands.md
@@ -89,6 +89,8 @@ You can (with most boilerplates) pass through a `--min` or `--max` flag to autom
 
 If the new app's folder already exists, you can pass through `--overwrite` to overwrite the directory. If you don't, Ignite CLI will ask you if you want to overwrite it.
 
+If you want to use a specific version of a boilerplate, you can add the version to the boilerplate name.  For example, use `ignite new BetaApp -b ir-boilerplate-bowser@1.0.0-beta.1` to use the `1.0.0-beta.1` release of the Bowser boilerplate.
+
 ### Plugin
 
 ```

--- a/src/lib/importPlugin.js
+++ b/src/lib/importPlugin.js
@@ -9,16 +9,17 @@ const exitCodes = require('../lib/exitCodes')
  * @param {string} opts.moduleName The module to install
  */
 async function importPlugin (context, opts) {
-  const { moduleName, type, directory } = opts
+  const { moduleName, version, type, directory } = opts
   const { ignite, system, filesystem } = context
   const { log } = ignite
   const isDirectory = type === 'directory'
   const target = isDirectory ? directory : moduleName
+  const packageVersion = `${(version && !isDirectory) ? `@${version}` : ''}`
 
   // check to see if it exists first
   if (type === 'npm') {
     try {
-      const json = JSON.parse(await system.run(`npm info ${target} --json`))
+      const json = JSON.parse(await system.run(`npm info ${target}${packageVersion} --json`))
       log(`${json.name} ${json.version} on npm.`)
     } catch (e) {
       log(`unable to find ${target} on npm`)
@@ -55,16 +56,15 @@ async function importPlugin (context, opts) {
         )
       }
     }
-
     const cmd = isDirectory
       ? `yarn add file:${target} --force --dev`
-      : `yarn add ${target} --dev`
+      : `yarn add ${target}${packageVersion} --dev`
     log(cmd)
     await system.run(cmd)
     log('finished yarn command')
   } else {
     const cacheBusting = isDirectory ? '--cache-min=0' : ''
-    const cmd = trim(`npm i ${target} --save-dev ${cacheBusting}`)
+    const cmd = trim(`npm i ${target}${packageVersion} --save-dev ${cacheBusting}`)
     log(cmd)
     await system.run(cmd)
     log('finished npm command')

--- a/src/lib/importPlugin.js
+++ b/src/lib/importPlugin.js
@@ -14,7 +14,7 @@ async function importPlugin (context, opts) {
   const { log } = ignite
   const isDirectory = type === 'directory'
   const target = isDirectory ? directory : moduleName
-  const packageVersion = `${(version && !isDirectory) ? `@${version}` : ''}`
+  const packageVersion = (version && !isDirectory) ? `@${version}` : ''
 
   // check to see if it exists first
   if (type === 'npm') {


### PR DESCRIPTION
## Please verify the following:
- [x] Everything works on iOS/Android
- [x] `npm test` **ava** tests pass with new tests, if relevant
- [x] `./docs/` has been updated with your changes, if relevant

## Describe your PR
This allows developers to generate an app using a specific version of a boilerplate, such as a past release or a beta release.

I plan on releasing some big breaking changes to my boilerplate and it would be nice to allow users to generate using an older version if they wish.
