### PR TITLE
Install library globally, run from global dir

### DIFF
--- a/src/commands/add.js
+++ b/src/commands/add.js
@@ -30,7 +30,7 @@ const removeIgnitePlugin = async (moduleName, context) => {
 
 module.exports = async function (context) {
   // grab a fist-full of features...
-  const { print, filesystem, prompt, ignite, parameters, strings } = context
+  const { print, filesystem, prompt, ignite, parameters, strings, system } = context
   const { log } = ignite
 
   const perfStart = (new Date()).getTime()
@@ -67,8 +67,24 @@ Examples:
 
   // find out the type of install
   const specs = detectInstall(context)
-  const { moduleName } = specs
-  const modulePath = `${process.cwd()}/node_modules/${moduleName}`
+  const { moduleName, global } = specs
+  let modulePath
+  if (global) {
+    try {
+      cmd = ignite.useYarn
+        ? `yarn global dir` 
+        : `npm root -g`
+      print.info(`running ${cmd}`)
+      const res = await system.run(cmd)
+      modulePath = `${res}/node_modules/${moduleName}`
+      modulePath = modulePath.replace(/\s/g, '')
+    } catch (e) {
+      print.error(`${moduleName} not found in global modules. Exiting.`)
+      process.exit(-1)
+    }
+  } else {
+    modulePath = `${process.cwd()}/node_modules/${moduleName}`
+  }
 
   log(`installing ${modulePath} from source ${specs.type}`)
 

--- a/src/lib/detectInstall.js
+++ b/src/lib/detectInstall.js
@@ -38,6 +38,12 @@ function detectInstall (context) {
   let packageName = plugin.split('@')[0]
   let packageVersion = plugin.split('@')[1] || null
 
+  let global = false
+  const basePackageName = plugin.split(path.sep).slice(-1)[0]
+  if (basePackageName=='ignite-library') {
+    global = true
+  }
+
   // If a path, expand that path. If not, prepend with `ignite-*`.
   if (packageName.includes(path.sep)) {
     packageName = filesystem.path(packageName)
@@ -60,7 +66,8 @@ function detectInstall (context) {
         directory: path,
         override: true,
         moduleName: filesystem.read(`${path}/package.json`, 'json').name,
-        type: 'directory'
+        type: 'directory',
+        global: global
       }
     }
   }
@@ -71,7 +78,8 @@ function detectInstall (context) {
     return {
       directory: packageName,
       moduleName: json.name,
-      type: 'directory'
+      type: 'directory',
+      global: global
     }
   }
 
@@ -79,7 +87,8 @@ function detectInstall (context) {
   return {
     moduleName: packageName,
     version: packageVersion,
-    type: 'npm'
+    type: 'npm',
+    global: global
   }
 }
 

--- a/src/lib/importPlugin.js
+++ b/src/lib/importPlugin.js
@@ -9,11 +9,18 @@ const exitCodes = require('../lib/exitCodes')
  * @param {string} opts.moduleName The module to install
  */
 async function importPlugin (context, opts) {
-  const { moduleName, type, directory } = opts
+  const { moduleName, type, directory, global } = opts
   const { ignite, system, filesystem } = context
   const { log } = ignite
   const isDirectory = type === 'directory'
   const target = isDirectory ? directory : moduleName
+
+  const globalMod =
+    global
+      ? ignite.useYarn
+        ? 'global'
+        : '-g'
+      : ''
 
   // check to see if it exists first
   if (type === 'npm') {
@@ -57,14 +64,14 @@ async function importPlugin (context, opts) {
     }
 
     const cmd = isDirectory
-      ? `yarn add file:${target} --force --dev`
+      ? `yarn ${globalMod} add file:${target} --force --dev`
       : `yarn add ${target} --dev`
     log(cmd)
     await system.run(cmd)
     log('finished yarn command')
   } else {
     const cacheBusting = isDirectory ? '--cache-min=0' : ''
-    const cmd = trim(`npm i ${target} --save-dev ${cacheBusting}`)
+    const cmd = trim(`npm i ${globalMod} ${target} --save-dev ${cacheBusting}`)
     log(cmd)
     await system.run(cmd)
     log('finished npm command')


### PR DESCRIPTION
## Please verify the following:
- [ ] Everything works on iOS/Android
- [ ] `npm test` **ava** tests pass with new tests, if relevant
- [ ] `./docs/` has been updated with your changes, if relevant

Untested presently

## Describe your PR
@jamonholmgren and I discussed the possibility of making `ignite-library` a plugin and installing it globally. This PR allows that. Ignite will recognize `ignite-library` specifically and do so. It will then locate the appropriate package manager's global installation location and run the plugin from there.

