### PR TITLE
Pass npm option to react-native cli

### DIFF
--- a/src/extensions/reactNative.js
+++ b/src/extensions/reactNative.js
@@ -64,6 +64,9 @@ function attach (plugin, command, context) {
     if (opts.skipJest) {
       rnOptions.push('--skip-jest')
     }
+    if (opts.useNpm) {
+      rnOptions.push('--npm')
+    }
 
     // react-native init
     const cmd = trim(`react-native init ${name} ${rnOptions.join(' ')}`)


### PR DESCRIPTION
Fixes https://github.com/infinitered/ignite/issues/1142
with https://github.com/infinitered/ignite-andross/pull/241

## Please verify the following:
- [x] Everything works on iOS/Android
- [x] `npm test` **ava** tests pass with new tests, if relevant
- [x] `./docs/` has been updated with your changes, if relevant

## Describe your PR
Ensures that running `boilerplate-install` with `--npm` uses npm


