### PR TITLE
Remove trailing period from 'Initial commit'

### DIFF
--- a/src/templates/plugin/boilerplate.js.ejs
+++ b/src/templates/plugin/boilerplate.js.ejs
@@ -95,7 +95,7 @@ async function install (context) {
   if (!gitExists && !parameters.options['skip-git'] && system.which('git')) {
     spinner.text = 'setting up git'
     spinner.start()
-    await system.run('git init . && git add . && git commit -m "Initial commit."')
+    await system.run('git init && git add . && git commit -m"Initial commit"')
     spinner.succeed()
   }
 


### PR DESCRIPTION
## Please verify the following:

- [x] Everything works on iOS/Android
- [x] `npm test` **ava** tests pass with new tests, if relevant
- [x] `./docs/` has been updated with your changes, if relevant

## Describe your PR

Just a minor update to the way the Git repository is initialized. A Git commit message subject line should _not_ end with a period.

This changes

    Initial commit.

to

    Initial commit

Also see: [Rule 4 "How to Write a Git Commit Message"](https://chris.beams.io/posts/git-commit/#end)