### PR TITLE
Warns the user if multiple arguments are provided as part of new command

### DIFF
--- a/src/commands/new.js
+++ b/src/commands/new.js
@@ -35,8 +35,8 @@ async function command (context) {
 
   // Ensure not more than one argument is provided for <projectName>
   if (process.argv.slice(3).length > 1) {
-   context.print.error('\n Kindly provide only one argument as the <projectName>');
-   process.exit(exitCodes.GENERIC);
+    context.print.error('\n Kindly provide only one argument as the <projectName>')
+    process.exit(exitCodes.GENERIC)
   }
 
   // ensure we're in a supported directory

--- a/src/commands/new.js
+++ b/src/commands/new.js
@@ -33,6 +33,12 @@ async function command (context) {
   // check for alphanumeric name, beginning with a letter
   const isValidName = /^[a-z_][a-z0-9_]+$/i.test(projectName)
 
+  // Ensure not more than one argument is provided for <projectName>
+  if (process.argv.slice(3).length > 1) {
+   context.print.error('\n Kindly provide only one argument as the <projectName>');
+   process.exit(exitCodes.GENERIC);
+  }
+
   // ensure we're in a supported directory
   if (isIgniteDirectory(process.cwd())) {
     context.print.error('The `ignite new` command cannot be run within an already ignited project.')

--- a/src/commands/new.js
+++ b/src/commands/new.js
@@ -35,8 +35,7 @@ async function command (context) {
 
   // Ensure not more than one argument is provided for <projectName>
   if (process.argv.slice(3).length > 1) {
-    context.print.error('\n Kindly provide only one argument as the <projectName>')
-    process.exit(exitCodes.GENERIC)
+    context.print.info('\n Info: You provided more than one argument for <projectName>. The first one will be used and the rest are ignored.')
   }
 
   // ensure we're in a supported directory


### PR DESCRIPTION
Closes #1389 

Warns the user appropriately in case more than one arguments were provided for `<projectName>`
> `ignite new <projectName> arg` shows up suitable warnings 