### PR TITLE
Updates ignite doctor to show boilerplate version

### DIFF
--- a/src/commands/attach.ts
+++ b/src/commands/attach.ts
@@ -1,10 +1,11 @@
 import isIgniteDirectory from '../lib/is-ignite-directory'
+import attachIgnite from '../lib/attach-ignite'
 import { IgniteToolbox } from '../types'
 
 module.exports = {
   description: 'Attaches Ignite CLI to an existing project.',
   run: async function(toolbox: IgniteToolbox) {
-    const { filesystem, print, meta } = toolbox
+    const { print, meta } = toolbox
 
     // ensure we're in a supported directory
     if (isIgniteDirectory(process.cwd())) {
@@ -12,16 +13,7 @@ module.exports = {
       return
     }
 
-    // ignite/ignite.json
-    const igniteJson = {
-      createdWith: meta.version(),
-      boilerplate: 'empty',
-      examples: 'none',
-    }
-    filesystem.write('ignite/ignite.json', igniteJson)
-
-    // the plugins folder
-    filesystem.write('ignite/plugins/.gitkeep', '')
+    await attachIgnite(toolbox, { createdWith: meta.version(), boilerplate: 'empty', boilerplateVersion: '' })
 
     toolbox.print.info(`🔥  Good to go! Type ${print.colors.bold('ignite')} to get started.`)
   },

--- a/src/commands/doctor.ts
+++ b/src/commands/doctor.ts
@@ -14,6 +14,7 @@ module.exports = {
       system: { run, which },
       print: { colors, info, table },
       strings: { padEnd },
+      ignite,
     } = toolbox
 
     // display helpers
@@ -73,16 +74,19 @@ module.exports = {
     // -=-=-=- ignite -=-=-=-
     const ignitePath = which('ignite')
     const igniteVersion = await run('ignite version', { trim: true })
-    const igniteJson = read(`${process.cwd()}/ignite/ignite.json`, 'json')
-    const igniteBoilerplate = igniteJson && igniteJson.boilerplate
+    const igniteJson = ignite.loadIgniteConfig()
 
     info('')
     info(colors.cyan('Ignite'))
     const igniteTable = []
-    igniteTable.push([column1('ignite'), column2(igniteVersion), column3(ignitePath)])
-    if (igniteBoilerplate) {
-      igniteTable.push([column1('boilerplate'), column2(igniteBoilerplate)])
+    igniteTable.push([column1('ignite-cli'), column2(igniteVersion), column3(ignitePath)])
+    if (igniteJson) {
+      Object.keys(igniteJson).forEach(k => {
+        const v = typeof igniteJson[k] === 'object' ? JSON.stringify(igniteJson[k]) : igniteJson[k]
+        igniteTable.push([column1(k), column2(v), column3('')])
+      })
     }
+
     table(igniteTable)
 
     // -=-=-=- android -=-=-=-

--- a/src/extensions/ignite.ts
+++ b/src/extensions/ignite.ts
@@ -66,5 +66,7 @@ module.exports = (toolbox: IgniteToolbox) => {
     log: logExt(toolbox),
     pluginOverrides: pluginOverridesExt(toolbox),
     patching: patchingExt(toolbox),
+    boilerplateName: () => loadIgniteConfig().boilerplate,
+    boilerplateVersion: () => loadIgniteConfig().boilerplateVersion,
   }
 }

--- a/src/extensions/ignite/ignite-config.ts
+++ b/src/extensions/ignite/ignite-config.ts
@@ -1,7 +1,7 @@
 import { dissoc } from 'ramda'
-import { IgniteToolbox } from '../../types'
+import { IgniteToolbox, IgniteProjectConfig } from '../../types'
 
-const igniteConfigFilename = `${process.cwd()}/ignite/ignite.json`
+const igniteConfigFilename = `./ignite/ignite.json`
 
 export default (toolbox: IgniteToolbox) => {
   const { filesystem } = toolbox
@@ -9,23 +9,27 @@ export default (toolbox: IgniteToolbox) => {
   /**
    * Reads the contents of the ignite/ignite.json configuration.
    */
-  function loadIgniteConfig(): Object {
+  function loadIgniteConfig(): IgniteProjectConfig {
     return filesystem.exists(igniteConfigFilename) ? filesystem.read(igniteConfigFilename, 'json') || {} : {}
   }
 
   /**
    * Saves a new ignite config file.
    */
-  function saveIgniteConfig(config: Object = {}) {
+  function saveIgniteConfig(config: IgniteProjectConfig = {}) {
     filesystem.write(igniteConfigFilename, config, { jsonIndent: 2 })
   }
 
   /**
-   * Sets an ignite config setting
+   * Sets an ignite config setting. Takes an object or a key/value pair.
    */
-  function setIgniteConfig(key: string, value: string) {
+  function setIgniteConfig(keyOrObject: string | object, value?: string) {
     const igniteConfig = loadIgniteConfig()
-    igniteConfig[key] = value
+    if (typeof keyOrObject === 'string') {
+      igniteConfig[keyOrObject] = value
+    } else {
+      Object.assign(igniteConfig, keyOrObject)
+    }
     saveIgniteConfig(igniteConfig)
   }
 

--- a/src/lib/add-empty-boilerplate.ts
+++ b/src/lib/add-empty-boilerplate.ts
@@ -1,7 +1,8 @@
 import { IgniteToolbox, IgniteRNInstallResult } from '../types'
+import attachIgnite from './attach-ignite'
 
 export default async function(toolbox: IgniteToolbox) {
-  const { filesystem, parameters, meta, print, reactNative } = toolbox
+  const { parameters, print, reactNative } = toolbox
   const name = parameters.first
   const spinner = print.spin(`skipping boilerplate`).succeed()
 
@@ -9,13 +10,8 @@ export default async function(toolbox: IgniteToolbox) {
   const rnInstall: IgniteRNInstallResult = await reactNative.install({ name })
   if (rnInstall.exitCode > 0) process.exit(rnInstall.exitCode)
 
-  // ignite/ignite.json
-  const igniteJson = {
-    createdWith: meta.version(),
-    boilerplate: 'empty',
-    examples: 'none',
-  }
-  filesystem.write(`ignite/ignite.json`, igniteJson)
+  await attachIgnite(toolbox, { createdWith: 'empty', boilerplateVersion: '' })
+
   spinner.stop()
 
   // Wrap it up with our success message.

--- a/src/lib/attach-ignite.ts
+++ b/src/lib/attach-ignite.ts
@@ -1,0 +1,11 @@
+import { IgniteToolbox, IgniteProjectConfig } from '../types'
+
+export default async function attachIgnite(toolbox: IgniteToolbox, projectConfig: IgniteProjectConfig) {
+  const { ignite, filesystem } = toolbox
+
+  // save ignite config
+  ignite.setIgniteConfig(projectConfig)
+
+  // the plugins folder
+  filesystem.write('ignite/plugins/.gitkeep', '')
+}

--- a/src/templates/plugin/boilerplate/ignite/ignite.json
+++ b/src/templates/plugin/boilerplate/ignite/ignite.json
@@ -1,4 +1,0 @@
-{
-  "createdWith": "<%= props.igniteVersion %>",
-  "boilerplate": "<%= props.name %>"
-}

--- a/src/types.ts
+++ b/src/types.ts
@@ -23,6 +23,8 @@ export type IgniteTools = {
   patchInFile: Function
   log: Function
   pluginOverrides: string[]
+  boilerplateName: () => string | void
+  boilerplateVersion: () => string | void
   patching: {
     prependToFile
     insertInFile
@@ -31,8 +33,19 @@ export type IgniteTools = {
   }
 }
 
+export type ReactNativeTools = {
+  install(opts: {
+    name?: string
+    version?: string
+    template?: string
+    skipJest?: boolean
+    useNpm?: boolean
+  }): Promise<IgniteRNInstallResult>
+}
+
 export interface IgniteToolbox extends GluegunToolbox {
   ignite: IgniteTools
+  reactNative: ReactNativeTools
 }
 
 export interface IgnitePlugin {
@@ -84,4 +97,11 @@ export type IgnitePluginScreenFile = {
 export type IgniteCopyJob = {
   target: string
   template: string
+}
+
+export type IgniteProjectConfig = {
+  createdWith?: string
+  boilerplate?: string
+  boilerplateVersion?: string
+  examples?: string[]
 }


### PR DESCRIPTION
This updates Ignite CLI to do the following:

1. Adds the boilerplate version into the `./ignite/ignite.json` project config file
2. Ensures `ignite attach` is run after every boilerplate to remove requirement to have `ignite/ignite.json` in boilerplates
4. Adds git initialization to Ignite CLI, to remove requirement to handle git in boilerplates
5. Updates `ignite doctor` to show everything in the `ignite/ignite.json` project config file

Fixes #1406. 

![image](https://user-images.githubusercontent.com/1479215/57186466-d9373580-6e94-11e9-9159-fff3b4350d84.png)

