### PR TITLE
Removes requirement to have Ignite attached to add a plugin

### DIFF
--- a/src/commands/add.ts
+++ b/src/commands/add.ts
@@ -3,7 +3,6 @@ import * as R from 'ramda'
 import detectedChanges from '../lib/detected-changes'
 import detectInstall from '../lib/detect-install'
 import importPlugin from '../lib/import-plugin'
-import isIgniteDirectory from '../lib/is-ignite-directory'
 import findPluginFile from '../lib/find-plugin-file'
 import exitCodes from '../lib/exit-codes'
 
@@ -35,14 +34,6 @@ module.exports = {
     log('running add command')
     const config = ignite.loadIgniteConfig()
     const currentGenerators = config.generators || {}
-
-    // ensure we're in a supported directory
-    if (!isIgniteDirectory(process.cwd())) {
-      toolbox.print.error(
-        'The `ignite add` command must be run in an ignite-compatible directory.\nUse `ignite attach` to make compatible.',
-      )
-      process.exit(exitCodes.NOT_IGNITE_PROJECT)
-    }
 
     // the thing we're trying to install
     if (strings.isBlank(parameters.first)) {

--- a/src/commands/remove.ts
+++ b/src/commands/remove.ts
@@ -1,6 +1,5 @@
 import Shell from 'shelljs'
 import { concat, pathOr, join, map, assoc } from 'ramda'
-import isIgniteDirectory from '../lib/is-ignite-directory'
 import prependIgnite from '../lib/prepend-ignite'
 import findPluginFile from '../lib/find-plugin-file'
 import exitCodes from '../lib/exit-codes'
@@ -39,14 +38,6 @@ module.exports = {
   alias: ['r'],
   description: 'Removes an Ignite CLI plugin.',
   run: async function(toolbox: IgniteToolbox) {
-    // ensure we're in a supported directory
-    if (!isIgniteDirectory(process.cwd())) {
-      toolbox.print.error(
-        'The `ignite remove` command must be run in an ignite-compatible directory.\nUse `ignite attach` to make compatible.',
-      )
-      process.exit(exitCodes.NOT_IGNITE_PROJECT)
-    }
-
     // grab a fist-full of features...
     const { print, parameters, prompt, ignite } = toolbox
     const { info, warning, xmark, error, success } = print


### PR DESCRIPTION
There's no compelling reason to error when you're not in an Ignited project. This removes that requirement. If plugins want to write to a non-existent Ignite config, it'll be created for them (as long as they use `setIgniteConfig`).

This also fixes an issue I'm having with Ignite CLI 3.1.0.