### PR TITLE
1418 - Use parameter second instead of third for plugin name

### DIFF
--- a/src/commands/plugin.ts
+++ b/src/commands/plugin.ts
@@ -48,7 +48,7 @@ const walkthrough = async (toolbox: IgniteToolbox) => {
  */
 const createNewPlugin = async (toolbox: IgniteToolbox) => {
   const { parameters, print, ignite, strings, meta } = toolbox
-  const pluginName = validateName(parameters.third, toolbox)
+  const pluginName = validateName(parameters.second, toolbox)
   const name = strings.pascalCase(pluginName.replace(/^ignite-/, ''))
 
   // Plugin generation walkthrough


### PR DESCRIPTION
## Please verify the following:

- [x] Everything works on iOS/Android
- [x] `yarn ci:test` **jest** tests pass with new tests, if relevant
- [x] `./docs/` has been updated with your changes, if relevant

## Describe your PR

The goal of this PR is to fix issue 1418. It seems that, according to the parameters list, second should be used for the plugin name instead of third:

```
{ plugin: 'ignite',
  command: 'plugin',
  array: [ 'new', 'toto' ],
  options: {},
  raw:
   [ '/Users/ghemmen/.nvm/versions/node/v10.15.3/bin/node',
     '/usr/local/bin/ignite',
     'plugin',
     'new',
     'toto' ],
  argv:
   [ '/Users/ghemmen/.nvm/versions/node/v10.15.3/bin/node',
     '/usr/local/bin/ignite',
     'plugin',
     'new',
     'toto' ],
  first: 'new',
  second: 'toto',
  third: undefined,
  string: 'new toto' }
```