### PR TITLE
fix(types): Updates GluegunCommand type for Ignite plugins

### DIFF
--- a/package.json
+++ b/package.json
@@ -44,7 +44,7 @@
     "cryptiles": ">=4.1.2",
     "execa": "0.8.0",
     "fs-jetpack": "1.2.0",
-    "gluegun": "^3.2.0",
+    "gluegun": "^3.2.3",
     "lodash": ">=4.17.5",
     "minimist": "1.2.0",
     "mixin-deep": ">=1.3.1",

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,4 +1,4 @@
-import { GluegunToolbox } from 'gluegun'
+import { GluegunToolbox, GluegunCommand } from 'gluegun'
 
 export type IgniteTools = {
   ignitePluginPath: Function
@@ -51,7 +51,7 @@ export interface IgniteToolbox extends GluegunToolbox {
 export interface IgnitePlugin {
   name: string
   directory: string
-  commands: any[]
+  commands: GluegunCommand<IgniteToolbox>[]
 }
 
 export type IgniteConfig = {

--- a/yarn.lock
+++ b/yarn.lock
@@ -2531,10 +2531,10 @@ globby@^9.0.0:
     pify "^4.0.1"
     slash "^2.0.0"
 
-gluegun@^3.2.0:
-  version "3.2.1"
-  resolved "https://registry.yarnpkg.com/gluegun/-/gluegun-3.2.1.tgz#c141332af1baa9f4476f72aabeb88609947cc5ea"
-  integrity sha512-XrsVkiS9Nm2iZBW8G+tM/qG/wDtRi4I8ec5OgvoepKqlR65gcbU/h47YXX7pBcVgyJkdwNdupNyx6t5aZ2kRWg==
+gluegun@^3.2.3:
+  version "3.2.3"
+  resolved "https://registry.yarnpkg.com/gluegun/-/gluegun-3.2.3.tgz#4b855e3dfd6721660328a318d16873899bca448f"
+  integrity sha512-JUywcK6I2TFwDJYvKVt5Ck9lC/0qcip5MAEsC4d5HZTUfh8h1CKjgQyqAoj+Or/1jjNGvb78kcfEMz/j8XGx5g==
   dependencies:
     apisauce "^1.0.1"
     app-module-path "^2.2.0"


### PR DESCRIPTION
This upgrades Gluegun and updates IgnitePlugin `commands` to use `GluegunCommand<IgniteToolbox>[]` generic.