### PR TITLE
fix prompt type for spork command

### DIFF
--- a/src/commands/spork.ts
+++ b/src/commands/spork.ts
@@ -59,7 +59,7 @@ module.exports = {
       copyFiles = await context.prompt.ask({
         name: 'selectedTemplates',
         message: 'Which templates would you like to spork?',
-        type: 'checkbox',
+        type: 'multiselect',
         choices,
       })
     }


### PR DESCRIPTION
Fix #1433

## Please verify the following:

- [x] Everything works on iOS/Android
- [x] `yarn ci:test` **jest** tests pass with new tests, if relevant
- [x] `./docs/` has been updated with your changes, if relevant

## Describe your PR

[This section of code](https://github.com/infinitered/gluegun/blob/b158829a991fe33fc48d7da4a35387bed874620a/src/toolbox/prompt-tools.ts#L37-L48) would normally handle old enquirer prompt types, but we are passing a single object instead of an array so the `map` doesn't happen.  

Replacing `checkbox` with `multiselect` fixes it.  The other option is to make the prompt pass an array instead of a single object but this fix seems better.
