### PR TITLE
Added "naive" check for cocoapods.

### DIFF
--- a/src/commands/doctor.ts
+++ b/src/commands/doctor.ts
@@ -111,9 +111,8 @@ module.exports = {
       info(colors.cyan('iOS'))
       table([[column1('xcode'), column2(xcodeVersion)]])
 
-      const cocoaPodsPath = which('pod')
-      const cocoaPodsVersion = await run('pod --version', { trim: true })
-
+      const cocoaPodsPath = which('pod') || ''
+      const cocoaPodsVersion = cocoaPodsPath ? await run('pod --version', { trim: true }) : 'Not installed'
       table([[column1('cocoapods'), column2(cocoaPodsVersion), column3(cocoaPodsPath)]])
     }
 

--- a/src/commands/doctor.ts
+++ b/src/commands/doctor.ts
@@ -110,6 +110,11 @@ module.exports = {
       info('')
       info(colors.cyan('iOS'))
       table([[column1('xcode'), column2(xcodeVersion)]])
+
+      const cocoaPodsPath = which('pod')
+      const cocoaPodsVersion = await run('pod --version', { trim: true })
+
+      table([[column1('cocoapods'), column2(cocoaPodsVersion), column3(cocoaPodsPath)]])
     }
 
     // -=-=-=- windows -=-=-=-


### PR DESCRIPTION
## Please verify the following:

- [x] Everything works on iOS/Android
- [x] `yarn ci:test` **jest** tests pass with new tests, if relevant
- [x] `./docs/` has been updated with your changes, if relevant

## Describe your PR
Added a "naive" check for CocoaPods if user is on mac, since it is now a RN core "prerequisite".
