### PR TITLE
Do not print import-plugin error, log instead

### DIFF
--- a/src/lib/import-plugin.ts
+++ b/src/lib/import-plugin.ts
@@ -68,6 +68,7 @@ async function importPlugin(toolbox: IgniteToolbox, opts: IgniteDetectInstall) {
 export default async (toolbox: IgniteToolbox, specs: IgniteDetectInstall): Promise<number | void> => {
   const { moduleName } = specs
   const { print, ignite } = toolbox
+  const { log } = ignite
   const spinner = print.spin(`adding ${print.colors.cyan(moduleName)}`)
 
   if (specs.type) {
@@ -75,7 +76,7 @@ export default async (toolbox: IgniteToolbox, specs: IgniteDetectInstall): Promi
       await importPlugin(toolbox, specs)
     } catch (e) {
       if (e.unavailable) {
-        print.info(e)
+        log(e.message)
         spinner.fail(`${print.colors.bold(moduleName)} is not available on npm.`)
         print.info('')
         print.info(print.colors.muted('-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-'))


### PR DESCRIPTION
## Please verify the following:

- [ not sure if applicable ] Everything works on iOS/Android
- [ ] `yarn ci:test` **jest** tests pass with new tests, if relevant
- [ ] `./docs/` has been updated with your changes, if relevant

## Describe your PR

In response to #1474 i stopped printing the error message, logging it instead. This will hide it from everyday output while still making it easily available via the --debug flag