### PR TITLE
Fix initial commit message

### DIFF
--- a/src/commands/new.ts
+++ b/src/commands/new.ts
@@ -205,7 +205,7 @@ module.exports = {
     if (!parameters.options['skip-git'] && !filesystem.exists('./.git') && system.which('git')) {
       spinner = print.spin('setting up source control with git')
       await system.run(
-        `git init . && git add -A && git commit -m "Initial commit\nIgnite CLI version ${meta.version()}"`,
+        `git init . && git add -A && git commit -m "Initial commit\n\nIgnite CLI version ${meta.version()}"`,
       )
       spinner.succeed(`configured git`)
     }


### PR DESCRIPTION
This fixes the commit message format used for the initial commit.
The second line in a Git commit message **must be empty**, since it separates the subject line from the body.

References:

https://chris.beams.io/posts/git-commit/#separate
https://tbaggery.com/2008/04/19/a-note-about-git-commit-messages.html