### PR TITLE
feat: use npx for react-native-cli

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -47,8 +47,6 @@ To get familiarized with Ignite CLI's source code, read the [Tour of Ignite CLI'
 
 ## How to Build and Run App
 
-Note that if you do not already have the React Native command line tools installed, you should run `yarn global add react-native-cli`. For additional information and troubleshooting go to the [React Native Getting Started Guide](https://facebook.github.io/react-native/docs/getting-started.html#content).
-
 ```sh
 $ cd ~/your/apps/directory
 $ ignite new HackingOnIgnite

--- a/src/cli/check.js
+++ b/src/cli/check.js
@@ -2,17 +2,6 @@
 // NOTE:  this file is intentionally written with es3
 
 var shell = require('shelljs')
-var which = require('which')
-
-// Quick n dirty dependency checking
-// Saves us 0.350s on startup over full dependency checking
-// cost: 0.010s
-try {
-  which.sync('react-native')
-} catch (e) {
-  console.log('Missing react-native-cli. Install with `npm i -g react-native-cli` and try again.')
-  process.exit(3)
-}
 
 // Only check full dependencies if we're running in `--debug` or `--wtf` mode
 var debugMode = process.argv.indexOf('--debug') !== -1 || process.argv.indexOf('--wtf') !== -1
@@ -21,38 +10,6 @@ if (debugMode) {
   // lets check our global dependencies
   var enforceGlobalDependency = require('./enforce-global')
   var exitCodes = require('../lib/exit-codes').default
-
-  // react-native-cli
-  // cost: 0.173s
-  var rnCli = enforceGlobalDependency({
-    optional: false,
-    range: '>=2.0.0',
-    which: 'react-native',
-    packageName: 'react-native-cli',
-    versionCommand: '--version',
-    installMessage: 'To install: npm i -g react-native-cli',
-  })
-
-  if (!rnCli) {
-    // If `react-native` is installed, it can cause problems with `react-native-cli`
-    // and cause this to fail. Let's check for that potential issue.
-    // This is very costly, so avoid it if possible!
-    console.log("\nChecking for 'react-native' npm package conflict...")
-    var badRN = shell.exec(`npm list -g react-native`, { silent: true })
-    if (badRN.code === 0) {
-      console.log(
-        '\n' +
-          "It appears you have the global npm package 'react-native' installed. This causes problems\n" +
-          'with Ignite CLI. You may have installed this by mistake. Instead, you probably want the\n' +
-          'react-native-cli npm package.\n' +
-          '\n' +
-          'npm uninstall -g react-native\n' +
-          'npm install -g react-native-cli\n',
-      )
-    }
-
-    process.exit(exitCodes.INVALID_GLOBAL_DEPENDENCY)
-  }
 
   // yarn
   // cost: 0.175s

--- a/src/commands/doctor.ts
+++ b/src/commands/doctor.ts
@@ -57,21 +57,6 @@ module.exports = {
       [column1('yarn'), column2(yarnVersion), column3(yarnPath)],
     ])
 
-    // -=-=-=- react native -=-=-=-
-    const rnPath = which('react-native')
-    const rnCli = rnPath && split(/\s/, await run('react-native --version', { trim: true }))[1] // lulz
-    const rnPkg = read(`${process.cwd()}/node_modules/react-native/package.json`, 'json')
-    const appReactNativeVersion = rnPkg && rnPkg.version
-
-    info('')
-    info(colors.cyan('React Native'))
-    const rnTable = []
-    rnTable.push([column1('react-native-cli'), column2(rnCli)])
-    if (appReactNativeVersion) {
-      rnTable.push([column1('app rn version'), column2(appReactNativeVersion)])
-    }
-    table(rnTable)
-
     // -=-=-=- ignite -=-=-=-
     const ignitePath = which('ignite')
     const igniteVersion = await run('ignite version', { trim: true })

--- a/src/commands/doctor.ts
+++ b/src/commands/doctor.ts
@@ -10,7 +10,6 @@ module.exports = {
   run: async function(toolbox: IgniteToolbox) {
     // fistful of features
     const {
-      filesystem: { read },
       system: { run, which },
       print: { colors, info, table },
       strings: { padEnd },

--- a/src/extensions/reactNative.ts
+++ b/src/extensions/reactNative.ts
@@ -1,4 +1,4 @@
-import { test, trim } from 'ramda'
+import { trim } from 'ramda'
 import exitCodes from '../lib/exit-codes'
 import { IgniteToolbox, IgniteRNInstallResult } from '../types'
 
@@ -33,23 +33,6 @@ function attach(toolbox: IgniteToolbox) {
 
     const perfStart = new Date().getTime()
 
-    // jet if the version isn't available
-    // note that npm and yarn don't differ significantly in perf here, so use npm
-    const versionCheck = await system.run(`npm info react-native@${reactNativeVersion}`)
-    const versionAvailable = test(new RegExp(reactNativeVersion, ''), versionCheck || '')
-    if (!versionAvailable) {
-      print.error(
-        `💩  react native version ${print.colors.yellow(reactNativeVersion)} not found on NPM -- ${print.colors.yellow(
-          REACT_NATIVE_VERSION,
-        )} recommended`,
-      )
-      return {
-        exitCode: exitCodes.REACT_NATIVE_VERSION,
-        version: reactNativeVersion,
-        template: reactNativeTemplate,
-      }
-    }
-
     // craft the additional options to pass to the react-native cli
     const rnOptions = ['--version', reactNativeVersion]
     if (!strings.isBlank(reactNativeTemplate)) {
@@ -64,7 +47,7 @@ function attach(toolbox: IgniteToolbox) {
     }
 
     // react-native init
-    const cmd = trim(`react-native init ${name} ${rnOptions.join(' ')}`)
+    const cmd = trim(`npx react-native init ${name} ${rnOptions.join(' ')}`)
     log('initializing react native')
     log(cmd)
     const withTemplate = reactNativeTemplate ? ` with ${print.colors.cyan(reactNativeTemplate)} template` : ''


### PR DESCRIPTION
## Please verify the following:

- [x] Everything works on iOS/Android
- [x] `yarn ci:test` **jest** tests pass with new tests, if relevant
- [x] `./docs/` has been updated with your changes, if relevant

## Describe your PR
Hi there 👋

I notice that this cli still forces having `react-native-cli` to be installed, while it is no longer recommended by its maintainers ( [React Native CLI](https://github.com/react-native-community/cli#using-npx-recommended)).

So i have update the code to use `npx react-native init` instead of `react-native init` and update the checker and doctor scripts to not check for `react-native-cli`.

Thanks