### PR TITLE
Upgrade all deps -- mainly Gluegun

### DIFF
--- a/package.json
+++ b/package.json
@@ -44,7 +44,7 @@
     "@types/ramda": "^0.26.18",
     "execa": "2.0.3",
     "fs-jetpack": "2.2.2",
-    "gluegun": "^4.0.2",
+    "gluegun": "^4.1.0",
     "lodash": ">=4.17.15",
     "minimist": "1.2.0",
     "mixin-deep": ">=2.0.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2666,10 +2666,10 @@ globby@^10.0.0:
     merge2 "^1.2.3"
     slash "^3.0.0"
 
-gluegun@^4.0.2:
-  version "4.0.2"
-  resolved "https://registry.yarnpkg.com/gluegun/-/gluegun-4.0.2.tgz#9a5a80d6892da8abb881b0604d2750065d808550"
-  integrity sha512-OCuQijKMgMtteH8/y/L4Br11i5DdqYOc132KOYNAIdoZB3mwPcNgbrs7KyAZHDo7w58llqYpIQI/ujmayz3FhQ==
+gluegun@^4.1.0:
+  version "4.1.0"
+  resolved "https://registry.yarnpkg.com/gluegun/-/gluegun-4.1.0.tgz#73b29f4d6de1ecc037ad2bba64e2f60c94bde710"
+  integrity sha512-+Tk6jXJox/us1JOl40SlBZzziVS7nkLJOixGP+oHK7b1kDoCwmhYN6CTh+orwdAmh/NSXQsULbB0+az9HnPW/A==
   dependencies:
     apisauce "^1.0.1"
     app-module-path "^2.2.0"
@@ -2701,7 +2701,7 @@ gluegun@^4.0.2:
     ramdasauce "^2.1.0"
     semver "^6.1.1"
     which "^2.0.0"
-    yargs-parser "^15.0.0"
+    yargs-parser "^16.0.0"
 
 got@^6.7.1:
   version "6.7.1"
@@ -7676,10 +7676,10 @@ yargs-parser@^13.1.1:
     camelcase "^5.0.0"
     decamelize "^1.2.0"
 
-yargs-parser@^15.0.0:
-  version "15.0.0"
-  resolved "https://registry.yarnpkg.com/yargs-parser/-/yargs-parser-15.0.0.tgz#cdd7a97490ec836195f59f3f4dbe5ea9e8f75f08"
-  integrity sha512-xLTUnCMc4JhxrPEPUYD5IBR1mWCK/aT6+RJ/K29JY2y1vD+FhtgKK0AXRWvI262q3QSffAQuTouFIKUuHX89wQ==
+yargs-parser@^16.0.0:
+  version "16.0.0"
+  resolved "https://registry.yarnpkg.com/yargs-parser/-/yargs-parser-16.0.0.tgz#534baab6f1c1c0c80adc2f57d1bcd55117a56bb2"
+  integrity sha512-WyNdFYED0penIaLqLSDSeFksC5lVjrjp9vNkG7IKfgQNiAYa6FfHuJXjuaQgt0eOVN2z+gJhHJSX7uRhJKPc7Q==
   dependencies:
     camelcase "^5.0.0"
     decamelize "^1.2.0"


### PR DESCRIPTION
Upgrades all deps to latest.

Gluegun 4.1.0 will support plugins in a `./build` folder, which we will need for converting [boilerplates to TypeScript](https://github.com/infinitered/ignite-bowser/pull/284).