### PR TITLE
chore: add install cocoapods extension

### DIFF
--- a/src/commands/new.ts
+++ b/src/commands/new.ts
@@ -6,6 +6,8 @@ import addEmptyBoilerplate from '../lib/add-empty-boilerplate'
 import boilerplateInstall from '../lib/boilerplate-install'
 import { IgniteToolbox } from '../types'
 
+const isMac = process.platform === 'darwin'
+
 /**
  * Creates a new ignite project based on an optional boilerplate.
  */
@@ -15,7 +17,7 @@ module.exports = {
   run: async function command(toolbox: IgniteToolbox) {
     const { parameters, strings, print, filesystem, system, ignite, prompt, runtime, meta } = toolbox
     const { isBlank, upperFirst, camelCase } = strings
-    const { log } = ignite
+    const { log, installCocoapods } = ignite
 
     // grab the project name
     const projectName = (parameters.first || '').toString()
@@ -202,6 +204,11 @@ module.exports = {
     let spinner = print.spin(`running ${yarnOrNPM} one last time...`)
     await system.run(yarnOrNPM)
     spinner.succeed(`${yarnOrNPM} complete`)
+
+    // run install cocoapods
+    if (isMac === true) {
+      await installCocoapods()
+    }
 
     // initialize git if it isn't already initialized
     if (!parameters.options['skip-git'] && !filesystem.exists('./.git') && system.which('git')) {

--- a/src/extensions/ignite.ts
+++ b/src/extensions/ignite.ts
@@ -8,6 +8,7 @@ import igniteConfigExt from './ignite/ignite-config'
 import findIgnitePluginsExt from './ignite/find-ignite-plugins'
 import addModuleExt from './ignite/add-module'
 import addAndroidPermissionExt from './ignite/add-android-permission'
+import installCocoapodsExt from './ignite/install-cocoapods'
 import removeModuleExt from './ignite/remove-module'
 import addPluginScreenExamplesExt from './ignite/add-plugin-screen-examples'
 import removePluginScreenExamplesExt from './ignite/remove-plugin-screen-examples'
@@ -53,6 +54,7 @@ module.exports = (toolbox: IgniteToolbox) => {
     findIgnitePlugins: findIgnitePluginsExt(toolbox),
     addModule: addModuleExt(toolbox),
     addAndroidPermission: addAndroidPermissionExt(toolbox),
+    installCocoapods: installCocoapodsExt(toolbox),
     removeModule: removeModuleExt(toolbox),
     copyBatch: copyBatchExt(toolbox),
     addPluginComponentExample: addPluginComponentExampleExt(toolbox),

--- a/src/extensions/ignite/install-cocoapods.ts
+++ b/src/extensions/ignite/install-cocoapods.ts
@@ -1,0 +1,15 @@
+import { IgniteToolbox } from '../../types'
+
+export default (toolbox: IgniteToolbox) => {
+  const installCocoapods = async () => {
+    const { system, print, ignite } = toolbox
+    const { log } = ignite
+
+    log(`installing cocoapods ...`)
+    let spinner = print.spin(`installing cocoapods ...`)
+    await system.run(`cd ios/ && pod install`)
+    spinner.succeed(`installing cocoapods complete`)
+  }
+
+  return installCocoapods
+}

--- a/src/types.ts
+++ b/src/types.ts
@@ -11,6 +11,7 @@ export type IgniteTools = {
   findIgnitePlugins: Function
   addModule: Function
   addAndroidPermission: Function
+  installCocoapods: Function
   removeModule: Function
   copyBatch: Function
   addPluginComponentExample: Function


### PR DESCRIPTION
## Please verify the following:

- [x] Everything works on iOS/Android
- [x] `yarn ci:test` **jest** tests pass with new tests, if relevant
- [x] `./docs/` has been updated with your changes, if relevant

## Describe your PR
Hi there ✋,

While building a boilerplate, i notice that `ignite` won't run `pod install`  before the initialise git commit. 

So i added a new extension `installCocoapods` to `ignite tools`, it runs `pod install` on the iOS project folder. Currently it triggered on the `new` command before initialise git. However, we could let the boilerplate trigger it.

Thanks :) 