### PR TITLE
Adding ability to add a plugin from a repository name or url

### DIFF
--- a/src/lib/boilerplate-install.ts
+++ b/src/lib/boilerplate-install.ts
@@ -31,14 +31,17 @@ export default async (toolbox: IgniteToolbox): Promise<boolean> => {
   }
 
   const { moduleName } = installSource
-  const modulePath = `${process.cwd()}/node_modules/${moduleName}`
-  const boilerplateJs = modulePath + '/boilerplate.js'
-  const boilerplatePackage = modulePath + '/package.json'
 
   // install the plugin
-  ignite.log(`installing plugin ${moduleName} from ${installSource.type}`)
-  const exitCode = await importPlugin(toolbox, installSource)
-  if (exitCode) return false
+  ignite.log(`installing plugin ${installSource.moduleName} from ${installSource.type}`)
+  const importReturn = await importPlugin(toolbox, installSource)
+  if (typeof importReturn === 'number' || !importReturn) return false
+
+  print.debug(importReturn)
+  const installedModuleName = importReturn ? `${importReturn}` : moduleName
+  const modulePath = `${process.cwd()}/node_modules/${installedModuleName}`
+  const boilerplateJs = modulePath + '/boilerplate.js'
+  const boilerplatePackage = modulePath + '/package.json'
 
   // start the spinner
   const spinner = print.spin('installing boilerplate')

--- a/tests/integration/ignite-new/new-bowser.test.js
+++ b/tests/integration/ignite-new/new-bowser.test.js
@@ -64,9 +64,23 @@ test('spins up a Bowser app and performs various checks', async done => {
 
   await system.run(`${IGNITE} g screen bowser`, opts)
   expect(filesystem.list(`${process.cwd()}/app/screens`)).toContain('bowser-screen.tsx')
-  expect(filesystem.read(`${process.cwd()}/app/screens/bowser-screen.tsx`)).toContain(
-    'export const BowserScreen',
-  )
+  expect(filesystem.read(`${process.cwd()}/app/screens/bowser-screen.tsx`)).toContain('export const BowserScreen')
+
+  // Testing adding a plugin
+  await system.run(`${IGNITE} add webview`, opts)
+  expect(filesystem.read(`${process.cwd()}/package.json`)).toContain('react-native-webview')
+
+  // Testing removing a plugin
+  await system.run(`${IGNITE} remove webview`, opts)
+  expect(filesystem.read(`${process.cwd()}/package.json`)).not.toContain('react-native-webview')
+
+  // Testing adding a non-npm plugin
+  await system.run(`${IGNITE} add infinitered/ignite-webview`, opts)
+  expect(filesystem.read(`${process.cwd()}/package.json`)).toContain('react-native-webview')
+
+  // Testing adding a plugin from url
+  await system.run(`${IGNITE} add https://github.com/infinitered/ignite-vector-icons`, opts)
+  expect(filesystem.read(`${process.cwd()}/package.json`)).toContain('react-native-vector-icons')
 
   done()
 })


### PR DESCRIPTION
## Please verify the following:

- [x] Everything works on iOS/Android
- [x] `yarn ci:test` **jest** tests pass with new tests, if relevant
- [x] `./docs/` has been updated with your changes, if relevant

## Describe your PR

Adding support for adding plugins with repo name or url :
```
ignite add infinitered/ignite-maps
ignite add https://github.com/infinitered/ignite-maps
```

should now work, in addition to the normal way, that check on npm:
```
ignite add maps
```