### PR TITLE
Fix shelljs warnings & test failures

### DIFF
--- a/package.json
+++ b/package.json
@@ -52,7 +52,7 @@
     "ramda": "0.26.1",
     "ramdasauce": "2.1.3",
     "semver": "6.3.0",
-    "shelljs": "0.8.3",
+    "shelljs": "0.8.4",
     "which": "1.3.1"
   },
   "devDependencies": {

--- a/tests/integration/ignite-new/new-bowser.test.js
+++ b/tests/integration/ignite-new/new-bowser.test.js
@@ -55,10 +55,10 @@ test('spins up a Bowser app and performs various checks', async done => {
   expect(appJS).toContain('export default App')
 
   // run generators
-  await system.run(`${IGNITE} g component test --function-component`, opts)
+  await system.run(`${IGNITE} g component test --no-observer`, opts)
   expect(filesystem.list(`${process.cwd()}/app/components`)).toContain('test')
   expect(filesystem.read(`${process.cwd()}/app/components/test/test.tsx`)).toContain(
-    'export const Test: React.FunctionComponent<TestProps> = props => {',
+    'export function Test(props: TestProps) {',
   )
 
   await system.run(`${IGNITE} g model mtest`, opts)
@@ -66,8 +66,10 @@ test('spins up a Bowser app and performs various checks', async done => {
   expect(filesystem.read(`${process.cwd()}/app/models/mtest/mtest.ts`)).toContain('export const MtestModel')
 
   await system.run(`${IGNITE} g screen bowser`, opts)
-  expect(filesystem.list(`${process.cwd()}/app/screens`)).toContain('bowser-screen.tsx')
-  expect(filesystem.read(`${process.cwd()}/app/screens/bowser-screen.tsx`)).toContain('export const BowserScreen')
+  expect(filesystem.list(`${process.cwd()}/app/screens/bowser-screen`)).toContain('bowser-screen.tsx')
+  expect(filesystem.read(`${process.cwd()}/app/screens/bowser-screen/bowser-screen.tsx`)).toContain(
+    'export const BowserScreen',
+  )
 
   done()
 })

--- a/yarn.lock
+++ b/yarn.lock
@@ -6396,10 +6396,10 @@ shebang-regex@^3.0.0:
   resolved "https://registry.yarnpkg.com/shebang-regex/-/shebang-regex-3.0.0.tgz#ae16f1644d873ecad843b0307b143362d4c42172"
   integrity sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==
 
-shelljs@0.8.3:
-  version "0.8.3"
-  resolved "https://registry.yarnpkg.com/shelljs/-/shelljs-0.8.3.tgz#a7f3319520ebf09ee81275b2368adb286659b097"
-  integrity sha512-fc0BKlAWiLpwZljmOvAOTE/gXawtCoNrP5oaY7KIaQbbyHeQVg01pSEuEGvGh3HEdBU4baCD7wQBwADmM/7f7A==
+shelljs@0.8.4:
+  version "0.8.4"
+  resolved "https://registry.yarnpkg.com/shelljs/-/shelljs-0.8.4.tgz#de7684feeb767f8716b326078a8a00875890e3c2"
+  integrity sha512-7gk3UZ9kOfPLIAbslLzyWeGiEqx9e3rxwZM0KE6EL8GlGwjym9Mrlx5/p33bWTu9YG6vcS4MBxYZDHYr5lr8BQ==
   dependencies:
     glob "^7.0.0"
     interpret "^1.0.0"


### PR DESCRIPTION
## Please verify the following:

- [x] Everything works on iOS/Android
- [x] `yarn ci:test` **jest** tests pass with new tests, if relevant
- [x] `./docs/` has been updated with your changes, if relevant

## Describe your PR
When I run commands like `ignite generate` in a Bowser app, I was getting a screenful of warnings:
```
$ ignite g
(node:44309) Warning: Accessing non-existent property 'cat' of module exports inside circular dependency
(Use `node --trace-warnings ...` to show where the warning was created)
(node:44309) Warning: Accessing non-existent property 'cd' of module exports inside circular dependency
(node:44309) Warning: Accessing non-existent property 'chmod' of module exports inside circular dependency
(node:44309) Warning: Accessing non-existent property 'cp' of module exports inside circular dependency
[...]
```

Traced this to [this issue](https://github.com/nodejs/node/issues/32987#issuecomment-635726114) - turns out our problem was also a need to upgrade to a newer `shelljs`, which fixed the warnings.

The ignite new-bowser test was also failing because of (my) recent changes to ignite-bowser (5.3.0), so I fixed those tests.
