### PR TITLE
Fixes for `ignite new --expo` in Flame

### DIFF
--- a/boilerplate/package.expo.json
+++ b/boilerplate/package.expo.json
@@ -5,8 +5,7 @@
     "android": "expo start --android",
     "ios": "expo start --ios",
     "web": "expo start --web",
-    "eject": "expo eject",
-    "prepare": "npm-run-all patch hack:*"
+    "eject": "expo eject"
   },
   "dependencies": {
     "expo": "~39.0.2",

--- a/boilerplate/package.expo.json
+++ b/boilerplate/package.expo.json
@@ -5,7 +5,8 @@
     "android": "expo start --android",
     "ios": "expo start --ios",
     "web": "expo start --web",
-    "eject": "expo eject"
+    "eject": "expo eject",
+    "prepare": "npm-run-all patch hack:*"
   },
   "dependencies": {
     "expo": "~39.0.2",

--- a/boilerplate/package.json
+++ b/boilerplate/package.json
@@ -18,7 +18,6 @@
     "hack:types-react-test-renderer": "rimraf node_modules/@types/react-test-renderer/node_modules/@types",
     "lint": "eslint index.js app storybook test --fix --ext .js,.ts,.tsx",
     "patch": "patch-package",
-    "prepare": "npm-run-all patch hack:*",
     "storybook": "start-storybook -p 9001 -c ./storybook",
     "test": "jest",
     "adb": "adb reverse tcp:9090 tcp:9090 && adb reverse tcp:3000 tcp:3000 && adb reverse tcp:9001 tcp:9001 && adb reverse tcp:8081 tcp:8081"

--- a/src/commands/new.ts
+++ b/src/commands/new.ts
@@ -1,4 +1,3 @@
-import * as tempy from "tempy"
 import { GluegunToolbox } from "../types"
 import { spawnProgress } from "../tools/spawn"
 import { isAndroidInstalled } from "../tools/react-native"
@@ -31,20 +30,11 @@ export default {
     const cli = expo ? "expo-cli" : "react-native-cli"
     const bowserPath = path(`${meta.src}`, "..")
     const boilerplatePath = path(bowserPath, "boilerplate")
-    const boilerplateCopy = path(tempy.directory(), "boilerplate")
-    if (expo) {
-      filesystem.copy(boilerplatePath, boilerplateCopy)
-      const packageJsonPath = path(boilerplateCopy, "package.json")
-      const packageJson = filesystem.read(packageJsonPath, "json")
-      delete packageJson.scripts.prepare
-      filesystem.write(packageJsonPath, packageJson)
-    }
-
     const cliString = expo
-      ? `npx expo-cli init ${projectName} --template ${boilerplateCopy}`
+      ? `npx expo-cli init ${projectName} --template ${boilerplatePath}`
       : `npx react-native init ${projectName} --template ${bowserPath}`
 
-    log({ expo, cli, bowserPath, boilerplatePath, boilerplateCopy, cliString })
+    log({ expo, cli, bowserPath, boilerplatePath, cliString })
 
     // welcome everybody!
     p("\n")
@@ -82,23 +72,24 @@ export default {
       filesystem.copy(path(boilerplatePath, ".gitignore"), gitPath)
     }
 
-    // expo-specific changes
+    // Update package.json. Having a "prepare" script in package.json
+    // messes up expo-cli init above (it fails because npm-run-all hasn't been
+    // installed yet), so we're adding it here; we also need to merge in our
+    // extra expo stuff.
+    let packageJson = filesystem.read("package.json", "json")
+    packageJson.scripts.prepare = "npm-run-all patch hack:*"
     if (expo) {
-      // merge package.json with Expo's (if Expo)
       const merge = require("deepmerge-json")
-      const dst = filesystem.read("package.json", "json")
-      const src = filesystem.read("package.expo.json", "json")
-      const pkgJob = filesystem.writeAsync("package.json", merge(dst, src))
+      const expoJson = filesystem.read("package.expo.json", "json")
+      packageJson = merge(expoJson, packageJson)
+    }
+    filesystem.write("package.json", packageJson)
 
-      // remove the ios and android folders if we're spinning up an Expo app
-      const iosJob = filesystem.removeAsync("ios")
-      const androidJob = filesystem.removeAsync("android")
-
-      // do all this concurrently for speed
-      await Promise.all([iosJob, androidJob, pkgJob])
-
-      // remove the expo-only package.json
-      filesystem.remove("package.expo.json")
+    // More Expo-specific changes
+    if (expo) {
+      // remove the ios and android folders
+      filesystem.remove("ios")
+      filesystem.remove("android")
 
       // rename the index.js to App.js, which expo expects
       filesystem.rename("index.js", "App.js")
@@ -110,6 +101,9 @@ export default {
       // see https://github.com/th3rdwave/react-native-safe-area-context/issues/110#issuecomment-668864576
       // await packager.add("react-native-safe-area-context", { expo: true })
     }
+
+    // remove the expo-only package.json
+    filesystem.remove("package.expo.json")
 
     // TODO: copy over generators
 

--- a/src/commands/new.ts
+++ b/src/commands/new.ts
@@ -1,3 +1,4 @@
+import * as tempy from "tempy"
 import { GluegunToolbox } from "../types"
 import { spawnProgress } from "../tools/spawn"
 import { isAndroidInstalled } from "../tools/react-native"
@@ -30,11 +31,20 @@ export default {
     const cli = expo ? "expo-cli" : "react-native-cli"
     const bowserPath = path(`${meta.src}`, "..")
     const boilerplatePath = path(bowserPath, "boilerplate")
+    const boilerplateCopy = path(tempy.directory(), "boilerplate")
+    if (expo) {
+      filesystem.copy(boilerplatePath, boilerplateCopy)
+      const packageJsonPath = path(boilerplateCopy, "package.json")
+      const packageJson = filesystem.read(packageJsonPath, "json")
+      delete packageJson.scripts.prepare
+      filesystem.write(packageJsonPath, packageJson)
+    }
+
     const cliString = expo
-      ? `npx expo-cli init ${projectName} --template ${boilerplatePath}`
+      ? `npx expo-cli init ${projectName} --template ${boilerplateCopy}`
       : `npx react-native init ${projectName} --template ${bowserPath}`
 
-    log({ expo, cli, bowserPath, boilerplatePath, cliString })
+    log({ expo, cli, bowserPath, boilerplatePath, boilerplateCopy, cliString })
 
     // welcome everybody!
     p("\n")

--- a/src/tools/generators.ts
+++ b/src/tools/generators.ts
@@ -2,6 +2,7 @@ import { filesystem, GluegunToolbox, strings } from "gluegun"
 import * as ejs from "ejs"
 import { command, heading, igniteHeading, p, warning } from "./pretty"
 
+// eslint-disable-next-line @typescript-eslint/no-unused-vars
 export function showGeneratorHelp(toolbox: GluegunToolbox) {
   const inIgnite = isIgniteProject()
   const generators = inIgnite ? installedGenerators() : []

--- a/src/tools/spawn.ts
+++ b/src/tools/spawn.ts
@@ -5,9 +5,11 @@ export function spawnProgress(commandLine: string, options: SpawnOptions): Promi
   return new Promise((resolve, reject) => {
     const args = commandLine.split(" ")
     const spawned = require("cross-spawn")(args.shift(), args, options)
+    const errorOut = []
 
     spawned.stdout.on("data", (data) => options.onProgress && options.onProgress(data.toString()))
-    spawned.on("close", () => resolve())
+    spawned.stderr.on("data", (data) => errorOut.push(data))
+    spawned.on("close", (code) => (code === 0 ? resolve() : reject(errorOut.join())))
     spawned.on("error", (err) => reject(err))
   })
 }

--- a/test/ignite-new.test.ts
+++ b/test/ignite-new.test.ts
@@ -3,6 +3,7 @@ import * as tempy from "tempy"
 import { run, runError } from "./_test-helpers"
 
 const APP_NAME = "Foo"
+const EXPO_APP_NAME = "Bar"
 
 const originalDir = process.cwd()
 let tempDir: string
@@ -35,6 +36,63 @@ test(`ignite new ${APP_NAME}`, async (done) => {
   const dirs = filesystem.list(`.`)
   expect(dirs).toContain("ios")
   expect(dirs).toContain("android")
+  expect(dirs).toContain("app")
+
+  // check the contents of ignite/templates
+  const templates = filesystem.list(`./ignite/templates`)
+  expect(templates).toContain("component")
+  expect(templates).toContain("model")
+  expect(templates).toContain("screen")
+
+  // check the basic contents of package.json
+  const igniteJSON = filesystem.read(`./package.json`, "json")
+  expect(igniteJSON).toHaveProperty("scripts")
+  expect(igniteJSON).toHaveProperty("dependencies")
+  expect(igniteJSON).toHaveProperty("detox.configurations")
+
+  // check the app.tsx file
+  const appJS = filesystem.read(`./app/app.tsx`)
+  expect(appJS).toContain("export default App")
+  expect(appJS).toContain("RootStore")
+
+  // now lets test generators too, since we have a properly spun-up app!
+  // components
+  const componentGen = await run(`generate component WompBomp`)
+  expect(componentGen).toContain(`app/components/womp-bomp/womp-bomp.tsx`)
+  expect(filesystem.list(`${process.cwd()}/app/components`)).toContain("womp-bomp")
+  expect(filesystem.read(`${process.cwd()}/app/components/womp-bomp/womp-bomp.tsx`)).toContain("export const WompBomp")
+
+  // models
+  const modelGen = await run(`generate model mod-test`)
+  expect(modelGen).toContain(`app/models/mod-test/mod-test.ts`)
+  expect(modelGen).toContain(`app/models/mod-test/mod-test.test.ts`)
+  expect(filesystem.list(`${process.cwd()}/app/models`)).toContain("mod-test")
+  expect(filesystem.read(`${process.cwd()}/app/models/mod-test/mod-test.ts`)).toContain("export const ModTestModel")
+
+  // screens
+  const screenGen = await run(`generate screen bowser-screen`)
+  expect(screenGen).toContain(`Stripping Screen from end of name`)
+  expect(screenGen).toContain(`app/screens/bowser/bowser-screen.tsx`)
+  expect(filesystem.list(`${process.cwd()}/app/screens/bowser`)).toContain("bowser-screen.tsx")
+  expect(filesystem.read(`${process.cwd()}/app/screens/bowser/bowser-screen.tsx`)).toContain(
+    "export const BowserScreen",
+  )
+
+  // we're done!
+  process.chdir("..")
+  done()
+})
+
+test(`ignite new ${EXPO_APP_NAME} --expo`, async (done) => {
+  const result = await run(`new ${EXPO_APP_NAME} --expo`)
+
+  expect(result).toContain(`Using expo-cli`)
+  expect(result).toContain(`Ignite CLI ignited ${EXPO_APP_NAME}`)
+
+  // now let's examine the spun-up app
+  process.chdir(EXPO_APP_NAME)
+
+  const dirs = filesystem.list(`.`)
   expect(dirs).toContain("app")
 
   // check the contents of ignite/templates


### PR DESCRIPTION
Fix `ignite new AppName --expo` in Flame, which was failing because it tries to run `npm prepare` (in the context of the boilerplate's package.json) at some point before it's actually copied the boilerplate to the new app's directory... and since we have a "prepare" script in the boilerplate's package.json that runs `npm-run-all patch hack:*`, it tried to run that -- but since it hadn't installed dependencies yet, `npm-run-all` isn't available.

I fixed this by (in the --expo case) ~~copying the boilerplate to a temp directory and removing the "prepare" script from the copy's package.json before passing that temp path to `expo-cli`. I added the "prepare" script to the boilerplate's `package.expo.json` so it gets added back when we merge that in later.~~ removing the "prepare" script from the boilerplate's package.json, and manually adding it back after initial app creation.

Also:
- That prepare problem initially showed up as a failure when trying to merge the package.json files later in run -- because spawnProgress didn't notice that `expo-cli init` was failing - to make this more obvious in the future, I've modified it here to reject its promise (with the collected error output) when the command fails with non-zero status; gluegun's unhandled promise rejection handler will display that output, which is better than nothing, but we could make the `new.ts` `run` function be more proactive about it...

- To ensure that --expo app generation continues to work, I duplicated most of the existing app-generation test and made it exercise --expo app generation

- eslint (`yarn lint`) was complaining about an unused parameter in `generators.ts` - I shut it up.