### PR TITLE
Toggle storybook from the Dev menu

### DIFF
--- a/boilerplate/README.md
+++ b/boilerplate/README.md
@@ -35,6 +35,7 @@ ignite-project
 │   ├── index.ts
 │   ├── storybook-registry.ts
 │   ├── storybook.ts
+│   ├── toggle-storybook.tsx
 ├── test
 │   ├── __snapshots__
 │   ├── storyshots.test.ts.snap
@@ -110,7 +111,7 @@ Here lives the theme for your application, including spacing, colors, and typogr
 **utils**
 This is a great place to put miscellaneous helpers and utilities. Things like date helpers, formatters, etc. are often found here. However, it should only be used for things that are truely shared across your application. If a helper or utility is only used by a specific component or model, consider co-locating your helper with that component or model.
 
-**app.tsx** This is the entry point to your app. This is where you will find the main App component which renders the rest of the application. This is also where you will specify whether you want to run the app in storybook mode.
+**app.tsx** This is the entry point to your app. This is where you will find the main App component which renders the rest of the application.
 
 ### ./ignite directory
 
@@ -118,7 +119,7 @@ The `ignite` directory stores all things Ignite, including CLI and boilerplate i
 
 ### ./storybook directory
 
-This is where your stories will be registered and where the Storybook configs will live
+This is where your stories will be registered and where the Storybook configs will live.
 
 ### ./test directory
 
@@ -127,9 +128,9 @@ This directory will hold your Jest configs and mocks, as well as your [storyshot
 ## Running Storybook
 
 From the command line in your generated app's root directory, enter `yarn run storybook`
-This starts up the storybook server.
-
-In `index.js`, change `SHOW_STORYBOOK` to `true` and reload the app.
+This starts up the storybook server and opens a story navigator in your browser. With your app
+running, choose Toggle Storybook from the developer menu to switch to Storybook; you can then
+use the story navigator in your browser to change stories.
 
 For Visual Studio Code users, there is a handy extension that makes it easy to load Storybook use cases into a running emulator via tapping on items in the editor sidebar. Install the `React Native Storybook` extension by `Orta`, hit `cmd + shift + P` and select "Reconnect Storybook to VSCode". Expand the STORYBOOK section in the sidebar to see all use cases for components that have `.story.tsx` files in their directories.
 

--- a/boilerplate/app/app.tsx
+++ b/boilerplate/app/app.tsx
@@ -1,6 +1,6 @@
 /**
  * Welcome to the main entry point of the app. In this file, we'll
- * be kicking off our app or storybook.
+ * be kicking off our app.
  *
  * Most of this file is boilerplate and you shouldn't need to modify
  * it very often. But take some time to look through and understand
@@ -24,6 +24,7 @@ import {
   useNavigationPersistence,
 } from "./navigation"
 import { RootStore, RootStoreProvider, setupRootStore } from "./models"
+import { ToggleStorybook } from "../storybook/toggle-storybook"
 
 // This puts screens in a native ViewController or Activity. If you want fully native
 // stack navigation, use `createNativeStackNavigator` in place of `createStackNavigator`:
@@ -63,15 +64,17 @@ function App() {
 
   // otherwise, we're ready to render the app
   return (
-    <RootStoreProvider value={rootStore}>
-      <SafeAreaProvider initialMetrics={initialWindowMetrics}>
-        <RootNavigator
-          ref={navigationRef}
-          initialState={initialNavigationState}
-          onStateChange={onNavigationStateChange}
-        />
-      </SafeAreaProvider>
-    </RootStoreProvider>
+    <ToggleStorybook>
+      <RootStoreProvider value={rootStore}>
+        <SafeAreaProvider initialMetrics={initialWindowMetrics}>
+          <RootNavigator
+            ref={navigationRef}
+            initialState={initialNavigationState}
+            onStateChange={onNavigationStateChange}
+          />
+        </SafeAreaProvider>
+      </RootStoreProvider>
+    </ToggleStorybook>
   )
 }
 

--- a/boilerplate/index.js
+++ b/boilerplate/index.js
@@ -8,22 +8,6 @@
 //
 // It's easier just to leave it here.
 import App from "./app/app.tsx"
-
-// Should we show storybook instead of our app?
-//
-// ⚠️ Leave this as `false` when checking into git.
-const SHOW_STORYBOOK = false
-
-let RootComponent = App
-if (__DEV__) {
-  if (SHOW_STORYBOOK) {
-    // Only include Storybook if we're in dev mode
-    const { StorybookUIRoot } = require("./storybook")
-    RootComponent = StorybookUIRoot
-  }
-}
-
 import { AppRegistry } from "react-native"
-AppRegistry.registerComponent("HelloWorld", () => RootComponent)
 
-export default RootComponent
+AppRegistry.registerComponent("HelloWorld", () => App)

--- a/boilerplate/storybook/toggle-storybook.tsx
+++ b/boilerplate/storybook/toggle-storybook.tsx
@@ -1,0 +1,51 @@
+import React, { useState, useEffect } from "react"
+import { DevSettings } from "react-native"
+import { loadString, saveString } from "../app/utils/storage"
+
+/**
+ * Toggle Storybook mode, in __DEV__ mode only.
+ *
+ * In non-__DEV__ mode, or when Storybook isn't toggled on,
+ * renders its children.
+ *
+ * The mode flag is persisted in async storage, which means it
+ * persists across reloads/restarts - this is handy when developing
+ * new components in Storybook.
+ */
+export function ToggleStorybook(props) {
+  const [showStorybook, setShowStorybook] = useState(false)
+  const [StorybookUIRoot, setStorybookUIRoot] = useState(null)
+
+  useEffect(() => {
+    if (__DEV__) {
+      // Load the setting from storage if it's there
+      loadString("devStorybook").then((storedSetting) => {
+        // Set the initial value
+        setShowStorybook(storedSetting === "on")
+
+        // Add our toggle command to the menu
+        DevSettings.addMenuItem("Toggle Storybook", () => {
+          setShowStorybook((show) => {
+            // On toggle, flip the current value
+            show = !show
+
+            // Write it back to storage
+            saveString("devStorybook", show ? "on" : "off")
+
+            // Return it to change the local state
+            return show
+          })
+        })
+
+        // Load the storybook UI once
+        setStorybookUIRoot(() => require("./storybook").StorybookUIRoot)
+      })
+    }
+  }, [])
+
+  if (showStorybook) {
+    return StorybookUIRoot ? <StorybookUIRoot /> : null
+  } else {
+    return props.children
+  }
+}


### PR DESCRIPTION
Wraps the whole app in a new component that (in `__DEV__` mode only) adds an item to the shake menu to toggle Storybook mode; this replaces the `SHOW_STORYBOOK` constant in `index.js`.

(@fvonhoven and I did this together. FYI, Frank - I also did a few doc updates for it, and ended up renaming the new component and moving it into the /storybook directory since it's such a special-purpose component.)