### PR TITLE
Flame test fixes

### DIFF
--- a/boilerplate/ignite/templates/model/NAME.test.ts.ejs
+++ b/boilerplate/ignite/templates/model/NAME.test.ts.ejs
@@ -1,7 +1,7 @@
-import { <%= props.pascalCaseName %>Mod<%= props.pascalCaseName %> } from "./<%= props.kebabCaseName %>"
+import { <%= props.pascalCaseName %>Model } from "./<%= props.kebabCaseName %>"
 
 test("can be created", () => {
-  const instance: <%= props.pascalCaseName %><%= props.pascalCaseName %>Model.create({})
+  const instance = <%= props.pascalCaseName %>Model.create({})
 
   expect(instance).toBeTruthy()
 })

--- a/src/commands/new.ts
+++ b/src/commands/new.ts
@@ -42,8 +42,9 @@ export default {
     const cli = expo ? "expo-cli" : "react-native-cli"
     const ignitePath = path(`${meta.src}`, "..")
     const boilerplatePath = path(ignitePath, "boilerplate")
+    const cliEnv = expo && debug ? { ...process.env, EXPO_DEBUG: 1 } : process.env
     const cliString = expo
-      ? `${debug ? "EXPO_DEBUG=1 " : ""}npx expo-cli init ${projectName} --template ${boilerplatePath}`
+      ? `npx expo-cli init ${projectName} --template ${boilerplatePath}`
       : `npx react-native init ${projectName} --template ${ignitePath}${debug ? " --verbose" : ""}`
 
     log({ expo, cli, ignitePath, boilerplatePath, cliString })
@@ -59,6 +60,7 @@ export default {
 
     // generate the project
     await spawnProgress(log(cliString), {
+      env: cliEnv,
       onProgress: (out: string) => {
         out = log(out.toString())
 

--- a/src/commands/new.ts
+++ b/src/commands/new.ts
@@ -43,8 +43,8 @@ export default {
     const ignitePath = path(`${meta.src}`, "..")
     const boilerplatePath = path(ignitePath, "boilerplate")
     const cliString = expo
-      ? `npx expo-cli init ${projectName} --template ${boilerplatePath}`
-      : `npx react-native init ${projectName} --template ${ignitePath}`
+      ? `${debug ? "EXPO_DEBUG=1 " : ""}npx expo-cli init ${projectName} --template ${boilerplatePath}`
+      : `npx react-native init ${projectName} --template ${ignitePath}${debug ? " --verbose" : ""}`
 
     log({ expo, cli, ignitePath, boilerplatePath, cliString })
 

--- a/src/commands/new.ts
+++ b/src/commands/new.ts
@@ -160,12 +160,6 @@ export default {
 
     // we're done! round performance stats to .xx digits
     const perfDuration = Math.round((new Date().getTime() - perfStart) / 10) / 100
-    const androidInfo = isAndroidInstalled(toolbox)
-      ? ""
-      : `\n\nTo run in Android, make sure you've followed the latest react-native setup instructions at https://facebook.github.io/react-native/docs/getting-started.html before using ignite.\nYou won't be able to run Android successfully until you have.`
-
-    const runIos = process.platform === "darwin" ? "npx react-native run-ios\n     " : ""
-    const runInfo = expo ? "yarn start" : `${runIos}npx react-native run-android${androidInfo}`
 
     p()
     p()
@@ -173,7 +167,20 @@ export default {
     p()
     direction(`To get started:`)
     command(`  cd ${projectName}`)
-    command(`  ${runInfo}`)
+    if (expo) {
+      command(`  yarn start`)
+    } else {
+      if (process.platform === "darwin") {
+        command(`  npx react-native run-ios`)
+      }
+      command(`  npx react-native run-android`)
+      if (isAndroidInstalled(toolbox)) {
+        p()
+        direction("To run in Android, make sure you've followed the latest react-native setup")
+        direction("instructions at https://facebook.github.io/react-native/docs/getting-started.html")
+        direction("before using ignite. You won't be able to run Android successfully until you have.")
+      }
+    }
     p()
     p("Need additional help?")
     p()

--- a/src/tools/spawn.ts
+++ b/src/tools/spawn.ts
@@ -1,5 +1,6 @@
 export type SpawnOptions = {
   onProgress?: (data: string) => void
+  env?: Record<string, unknown>
 }
 export function spawnProgress(commandLine: string, options: SpawnOptions): Promise<string> {
   return new Promise((resolve, reject) => {

--- a/src/tools/spawn.ts
+++ b/src/tools/spawn.ts
@@ -5,11 +5,14 @@ export function spawnProgress(commandLine: string, options: SpawnOptions): Promi
   return new Promise((resolve, reject) => {
     const args = commandLine.split(" ")
     const spawned = require("cross-spawn")(args.shift(), args, options)
-    const errorOut = []
+    const output = []
 
-    spawned.stdout.on("data", (data) => options.onProgress && options.onProgress(data.toString()))
-    spawned.stderr.on("data", (data) => errorOut.push(data))
-    spawned.on("close", (code) => (code === 0 ? resolve("") : reject(errorOut.join())))
+    spawned.stdout.on("data", (data) => {
+      data = data.toString()
+      return options.onProgress ? options.onProgress(data) : output.push(data)
+    })
+    spawned.stderr.on("data", (data) => output.push(data))
+    spawned.on("close", (code) => (code === 0 ? resolve("") : reject(output.join())))
     spawned.on("error", (err) => reject(err))
   })
 }

--- a/test/_test-helpers.ts
+++ b/test/_test-helpers.ts
@@ -1,7 +1,7 @@
 import { system, filesystem } from "gluegun"
 const stripANSI = require("strip-ansi") // why...
 
-const IGNITE = "node " + filesystem.path(`${__dirname}/../bin/ignite`)
+const IGNITE = "node " + filesystem.path(__dirname, "..", "bin", "ignite")
 const shellOpts = { stdio: "inherit" }
 
 jest.setTimeout(5 * 60 * 1000)

--- a/test/_test-helpers.ts
+++ b/test/_test-helpers.ts
@@ -4,7 +4,7 @@ const stripANSI = require("strip-ansi") // why...
 const IGNITE = "node " + filesystem.path(__dirname, "..", "bin", "ignite")
 const shellOpts = { stdio: "inherit" }
 
-jest.setTimeout(5 * 60 * 1000)
+jest.setTimeout(8 * 60 * 1000)
 
 export async function runIgnite(cmd: string): Promise<string> {
   return run(`${IGNITE} ${cmd}`)

--- a/test/ignite-new.test.ts
+++ b/test/ignite-new.test.ts
@@ -116,5 +116,5 @@ async function testSpunUpApp() {
   )
 
   // run the tests; if they fail, run will raise and this test will fail
-  await run(`yarn test`)
+  await run(`yarn test --updateSnapshot`)
 }

--- a/test/ignite-new.test.ts
+++ b/test/ignite-new.test.ts
@@ -38,6 +38,33 @@ test(`ignite new ${APP_NAME}`, async (done) => {
   expect(dirs).toContain("android")
   expect(dirs).toContain("app")
 
+  await testSpunUpApp()
+
+  // we're done!
+  process.chdir("..")
+  done()
+})
+
+test(`ignite new ${EXPO_APP_NAME} --expo`, async (done) => {
+  const result = await runIgnite(`new ${EXPO_APP_NAME} --expo`)
+
+  expect(result).toContain(`Using expo-cli`)
+  expect(result).toContain(`Ignite CLI ignited ${EXPO_APP_NAME}`)
+
+  // now let's examine the spun-up app
+  process.chdir(EXPO_APP_NAME)
+
+  const dirs = filesystem.list(`.`)
+  expect(dirs).toContain("app")
+
+  await testSpunUpApp()
+
+  // we're done!
+  process.chdir("..")
+  done()
+})
+
+async function testSpunUpApp() {
   // run typescript
   let resultTS
   try {
@@ -88,72 +115,6 @@ test(`ignite new ${APP_NAME}`, async (done) => {
     "export const BowserScreen",
   )
 
-  // run the tests
-  const testOutput = await run(`yarn test`)
-  expect(testOutput).toContain("WHAT HERE?")
-
-  // we're done!
-  process.chdir("..")
-  done()
-})
-
-test(`ignite new ${EXPO_APP_NAME} --expo`, async (done) => {
-  const result = await runIgnite(`new ${EXPO_APP_NAME} --expo`)
-
-  expect(result).toContain(`Using expo-cli`)
-  expect(result).toContain(`Ignite CLI ignited ${EXPO_APP_NAME}`)
-
-  // now let's examine the spun-up app
-  process.chdir(EXPO_APP_NAME)
-
-  const dirs = filesystem.list(`.`)
-  expect(dirs).toContain("app")
-
-  // check the contents of ignite/templates
-  const templates = filesystem.list(`./ignite/templates`)
-  expect(templates).toContain("component")
-  expect(templates).toContain("model")
-  expect(templates).toContain("screen")
-
-  // check the basic contents of package.json
-  const igniteJSON = filesystem.read(`./package.json`, "json")
-  expect(igniteJSON).toHaveProperty("scripts")
-  expect(igniteJSON).toHaveProperty("dependencies")
-  expect(igniteJSON).toHaveProperty("detox.configurations")
-
-  // check the app.tsx file
-  const appJS = filesystem.read(`./app/app.tsx`)
-  expect(appJS).toContain("export default App")
-  expect(appJS).toContain("RootStore")
-
-  // now lets test generators too, since we have a properly spun-up app!
-  // components
-  const componentGen = await runIgnite(`generate component WompBomp`)
-  expect(componentGen).toContain(`app/components/womp-bomp/womp-bomp.tsx`)
-  expect(filesystem.list(`${process.cwd()}/app/components`)).toContain("womp-bomp")
-  expect(filesystem.read(`${process.cwd()}/app/components/womp-bomp/womp-bomp.tsx`)).toContain("export const WompBomp")
-
-  // models
-  const modelGen = await runIgnite(`generate model mod-test`)
-  expect(modelGen).toContain(`app/models/mod-test/mod-test.ts`)
-  expect(modelGen).toContain(`app/models/mod-test/mod-test.test.ts`)
-  expect(filesystem.list(`${process.cwd()}/app/models`)).toContain("mod-test")
-  expect(filesystem.read(`${process.cwd()}/app/models/mod-test/mod-test.ts`)).toContain("export const ModTestModel")
-
-  // screens
-  const screenGen = await runIgnite(`generate screen bowser-screen`)
-  expect(screenGen).toContain(`Stripping Screen from end of name`)
-  expect(screenGen).toContain(`app/screens/bowser/bowser-screen.tsx`)
-  expect(filesystem.list(`${process.cwd()}/app/screens/bowser`)).toContain("bowser-screen.tsx")
-  expect(filesystem.read(`${process.cwd()}/app/screens/bowser/bowser-screen.tsx`)).toContain(
-    "export const BowserScreen",
-  )
-
-  // run the tests
-  const testOutput = await run(`yarn test`)
-  expect(testOutput).toContain("WHAT HERE?")
-
-  // we're done!
-  process.chdir("..")
-  done()
-})
+  // run the tests; if they fail, run will raise and this test will fail
+  await run(`yarn test`)
+}


### PR DESCRIPTION
A few things:

- Fixed the generated model test template - it was wacky.

- Improved the formatting of to-get-started message output.

- Made spawnProgress produce more error output when running a command that exits with non-zero status.

- If we're generating a new app with `--debug`, run the CLI commands more verbosely.

- De-duplicated much of the code in the generated-app tests.

- Fixed a lint complaint (outside the boilerplate; our generated apps still have lots of lint complaints - might work on this next)

- Our generated apps don't have storyshots files; had to add `--updateSnapshots` to the ignite-new tests to get them to pass on CI; also, CI tests were exceeding the 5-minute timeout, so I extended it to 8 minutes.