### PR TITLE
Fix production `ignite new`'s failure to copy .gitignore

### DIFF
--- a/src/commands/new.ts
+++ b/src/commands/new.ts
@@ -83,9 +83,16 @@ export default {
     process.chdir(projectName)
 
     // copy the .gitignore if it wasn't copied over [expo...]
-    const gitPath = log(path(process.cwd(), ".gitignore"))
-    if (!filesystem.exists(gitPath)) {
-      filesystem.copy(path(boilerplatePath, ".gitignore"), gitPath)
+    // Release Ignite installs have the boilerplate's .gitignore in .npmignore
+    // (see https://github.com/npm/npm/issues/3763); development Ignite still
+    // has it in .gitignore. Copy it from one or the other.
+    const targetIgnorePath = log(path(process.cwd(), ".gitignore"))
+    if (!filesystem.exists(targetIgnorePath)) {
+      let sourceIgnorePath = log(path(boilerplatePath, ".npmignore"))
+      if (!filesystem.exists(sourceIgnorePath)) {
+        sourceIgnorePath = path(boilerplatePath, ".gitignore")
+      }
+      filesystem.copy(sourceIgnorePath, targetIgnorePath)
     }
 
     // Update package.json:


### PR DESCRIPTION
## Please verify the following:

- [x] `yarn ci:test` **jest** tests pass with new tests, if relevant
- [x] `README.md` has been updated with your changes, if relevant (n/a)

## Describe your PR
When a user installs `ignite-cli`, `npm` & `yarn` play games with `.gitignore` and `.npmignore` files: they're merged and the result is stored in `.npmignore`. Because we only have `.gitignore`, this means that when running a production-installed `ignite new`, our `.gitignore` can be found at `.npmignore`. Neither base installer (`expo-cli init` or `react-native init`) copies it; This leads to #1578.

This fixes that by checking for .gitignore after the base installer is done (as before), and copying either `.gitignore` or `.npmignore` from the boilerplate, whichever is present.