### PR TITLE
Add storybook info & instructions to demo screen

### DIFF
--- a/boilerplate/app/screens/demo/demo-screen.tsx
+++ b/boilerplate/app/screens/demo/demo-screen.tsx
@@ -77,6 +77,11 @@ const HINT: TextStyle = {
   marginVertical: spacing[2],
 }
 
+const platformCommand = Platform.select({
+  ios: "Cmd + D", 
+  android: "Cmd/Ctrl + M",
+})
+
 export const DemoScreen = observer(function DemoScreen() {
   const navigation = useNavigation()
   const goBack = () => navigation.goBack()
@@ -134,8 +139,9 @@ export const DemoScreen = observer(function DemoScreen() {
         />
         <Text style={TITLE} preset="header" tx="demoScreen.title" />
         <Text style={TAGLINE} tx="demoScreen.tagLine" />
-        <BulletItem text="Load up Reactotron!  You can inspect your app, view the events, interact, and so much more!" />
         <BulletItem text="Integrated here, Navigation with State, TypeScript, Storybook, Solidarity, and i18n." />
+        <BulletItem text={`To run Storybook, press ${platformCommand} or shake the device to show the developer menu, then select "Toggle Storybook"`} />
+        <BulletItem text="Load up Reactotron!  You can inspect your app, view the events, interact, and so much more!" />
         <View>
           <Button
             style={DEMO}


### PR DESCRIPTION
## Please verify the following:

- [x] `yarn ci:test` **jest** tests pass with new tests, if relevant

## Describe your PR
* Add verbiage about the storybook debugger menu option to the demo screen
* Also reordered the `<BulletItem/>`s on the `demo-screen.tsx` for better context and readability

### Screenshots
![Simulator Screen Shot - iPhone 11 - 2020-12-28 at 15 17 28](https://user-images.githubusercontent.com/10098988/103243983-26490480-4921-11eb-83bc-1769c020f37a.png)
![Simulator Screen Shot - iPhone 11 - 2020-12-28 at 15 17 23](https://user-images.githubusercontent.com/10098988/103243984-28ab5e80-4921-11eb-9294-d2778e06b970.png)
