### PR TITLE
Show globally-installed packages in `ignite doctor`

### DIFF
--- a/boilerplate/app/screens/demo/demo-screen.tsx
+++ b/boilerplate/app/screens/demo/demo-screen.tsx
@@ -78,7 +78,7 @@ const HINT: TextStyle = {
 }
 
 const platformCommand = Platform.select({
-  ios: "Cmd + D", 
+  ios: "Cmd + D",
   android: "Cmd/Ctrl + M",
 })
 
@@ -140,7 +140,9 @@ export const DemoScreen = observer(function DemoScreen() {
         <Text style={TITLE} preset="header" tx="demoScreen.title" />
         <Text style={TAGLINE} tx="demoScreen.tagLine" />
         <BulletItem text="Integrated here, Navigation with State, TypeScript, Storybook, Solidarity, and i18n." />
-        <BulletItem text={`To run Storybook, press ${platformCommand} or shake the device to show the developer menu, then select "Toggle Storybook"`} />
+        <BulletItem
+          text={`To run Storybook, press ${platformCommand} or shake the device to show the developer menu, then select "Toggle Storybook"`}
+        />
         <BulletItem text="Load up Reactotron!  You can inspect your app, view the events, interact, and so much more!" />
         <View>
           <Button

--- a/src/commands/doctor.ts
+++ b/src/commands/doctor.ts
@@ -64,23 +64,6 @@ module.exports = {
     const ignitePath = which("ignite")
     const igniteSrcPath = `${meta.src}`
     const igniteVersion = meta.version()
-    // const igniteJson = ignite.loadIgniteConfig()
-    // const installedGenerators = runtime.commands
-    //   .filter(cmd => cmd.name === "generate")
-    //   .sort((a, b) => (a.commandPath.join(" ") < b.commandPath.join(" ") ? -1 : 1))
-    //   .reduce((acc, k) => {
-    //     k.plugin.commands.map(c => {
-    //       if (c.plugin.name === k.plugin.name && k.plugin.name !== "ignite" && c.name !== "generate") {
-    //         if (!acc[c.name]) {
-    //           acc[c.name] = [k.plugin.name]
-    //         } else {
-    //           acc[c.name].push(k.plugin.name)
-    //         }
-    //       }
-    //     })
-    //     return acc
-    //   }, {})
-    // igniteJson.generators = Object.assign({}, installedGenerators, igniteJson.generators)
 
     info("")
     info(colors.cyan("Ignite"))
@@ -91,21 +74,6 @@ module.exports = {
       column2(igniteSrcPath.split(separator).pop()),
       column3(igniteSrcPath),
     ])
-    // if (igniteJson) {
-    //   Object.keys(igniteJson).forEach(k => {
-    //     const v = typeof igniteJson[k] === "object" ? JSON.stringify(igniteJson[k]) : igniteJson[k]
-    //     if (k === "generators") {
-    //       igniteTable.push([column1(k), column2(" "), column3("")])
-    //       Object.keys(igniteJson[k]).forEach(t => {
-    //         const l = Array.isArray(igniteJson[k][t]) ? igniteJson[k][t].join(", ") : igniteJson[k][t]
-    //         igniteTable.push([column1(""), column2(t), column3(l)])
-    //       })
-    //     } else {
-    //       igniteTable.push([column1(k), column2(v), column3("")])
-    //     }
-    //   })
-    // }
-
     table(igniteTable)
 
     // -=-=-=- android -=-=-=-

--- a/src/tools/packager.ts
+++ b/src/tools/packager.ts
@@ -4,15 +4,23 @@ import { spawnProgress } from "./spawn"
 // we really need a packager core extension on Gluegun
 // in the meantime, we'll use this hacked together version
 
-type PackageOptions = {
+type PackageInstallOptions = {
   dev?: boolean
   expo?: boolean
   onProgress?: (out: string) => void
 }
-const packageOptions: PackageOptions = {
+const packageInstallOptions: PackageInstallOptions = {
   dev: false,
   expo: false,
   onProgress: (out: string) => console.log(out),
+}
+
+type PackageListOptions = {
+  packager?: "npm" | "yarn"
+  global?: boolean
+}
+const packageListOptions: PackageListOptions = {
+  global: false,
 }
 
 let isYarn
@@ -22,7 +30,7 @@ function yarn() {
   return isYarn
 }
 
-function add(pkg: string, options: PackageOptions = packageOptions) {
+function add(pkg: string, options: PackageInstallOptions = packageInstallOptions) {
   if (options.expo) {
     return `npx expo-cli install ${pkg}`
   } else if (yarn()) {
@@ -34,7 +42,7 @@ function add(pkg: string, options: PackageOptions = packageOptions) {
   }
 }
 
-function remove(pkg: string, options: PackageOptions = packageOptions) {
+function remove(pkg: string, options: PackageInstallOptions = packageInstallOptions) {
   if (options.expo) {
     return `npx expo-cli uninstall ${pkg}`
   } else if (yarn()) {
@@ -52,24 +60,60 @@ function install() {
   }
 }
 
+function list(
+  options: PackageListOptions = packageListOptions,
+): [string, (string) => [string, string][]] {
+  if (options.packager === "yarn" || (options.packager === undefined && yarn())) {
+    return [
+      `yarn${options.global ? " global" : ""} list`,
+      (output: string): [string, string][] => {
+        // Parse yarn's human-readable output
+        return output.split("\n").reduce((acc: [string, string][], line: string): [
+          string,
+          string,
+        ][] => {
+          const match = line.match(/info "([^@]+)@([^"]+)" has binaries/)
+          return match ? [...acc, [match[1], match[2]]] : acc
+        }, [])
+      },
+    ]
+  } else {
+    return [
+      `npm list${options.global ? " --global" : ""} --depth=0 --json`,
+      (output: string): [string, string][] => {
+        // npm returns a single JSON blob with a "dependencies" key
+        const json = JSON.parse(output)
+        return Object.keys(json.dependencies || []).map((key: string): [string, string] => [
+          key,
+          json.dependencies[key].version,
+        ])
+      },
+    ]
+  }
+}
+
 export const packager = {
-  run: async (command: string, options: PackageOptions = packageOptions) => {
+  run: async (command: string, options: PackageInstallOptions = packageInstallOptions) => {
     if (yarn()) {
       return spawnProgress(`yarn ${command}`, { onProgress: options.onProgress })
     } else {
       return spawnProgress(`npm run ${command}`, { onProgress: options.onProgress })
     }
   },
-  add: async (pkg: string, options: PackageOptions = packageOptions) => {
+  add: async (pkg: string, options: PackageInstallOptions = packageInstallOptions) => {
     const cmd = add(pkg, options)
     return spawnProgress(cmd, { onProgress: options.onProgress })
   },
-  remove: async (pkg: string, options: PackageOptions = packageOptions) => {
+  remove: async (pkg: string, options: PackageInstallOptions = packageInstallOptions) => {
     const cmd = remove(pkg, options)
     return spawnProgress(cmd, { onProgress: options.onProgress })
   },
-  install: async (options: PackageOptions = packageOptions) => {
+  install: async (options: PackageInstallOptions = packageInstallOptions) => {
     const cmd = install()
     return spawnProgress(cmd, { onProgress: options.onProgress })
+  },
+  list: async (options: PackageListOptions = packageListOptions) => {
+    const [cmd, parseFn] = list(options)
+    return parseFn(await spawnProgress(cmd, {}))
   },
 }

--- a/src/tools/spawn.ts
+++ b/src/tools/spawn.ts
@@ -13,7 +13,7 @@ export function spawnProgress(commandLine: string, options: SpawnOptions): Promi
       return options.onProgress ? options.onProgress(data) : output.push(data)
     })
     spawned.stderr.on("data", (data) => output.push(data))
-    spawned.on("close", (code) => (code === 0 ? resolve("") : reject(output.join())))
+    spawned.on("close", (code) => (code === 0 ? resolve(output.join("")) : reject(output.join(""))))
     spawned.on("error", (err) => reject(err))
   })
 }


### PR DESCRIPTION
## Please verify the following:

- [x] `yarn ci:test` **jest** tests pass with new tests, if relevant

## Describe your PR

@nirre7 had a problem that was caused by an older version of react-native-cli being installed globally (which is no longer recommended); he suggested having Ignite warn when this happens. https://infiniteredcommunity.slack.com/archives/CD8UA5RJ4/p1609336353033800?thread_ts=1609248567.028100&cid=CD8UA5RJ4

I think that's a great idea, and I thought it'd be useful as a preliminary step to see _all_ the globally-installed packages in `ignite doctor`'s output, so that's what this PR adds. Because `npm` and `yarn` store global packages in different places, it lists them separately -- the Javascript section of its output now looks like this (I just have one package in each group):

```
JavaScript (and globally-installed packages)
  node                14.15.1      /Users/stearns/.asdf/installs/nodejs/14.15.1/bin/node
  npm                 6.14.8       /Users/stearns/.asdf/installs/nodejs/14.15.1/bin/npm
    expo-cli          4.0.17
  yarn                1.22.5       /Users/stearns/.yarn/bin/yarn
    create-next-app   10.0.4
```