### PR TITLE
Fix grep path in i18n test

### DIFF
--- a/boilerplate/test/i18n.test.ts
+++ b/boilerplate/test/i18n.test.ts
@@ -44,7 +44,7 @@ describe("i18n", () => {
   test("There are no missing keys", (done) => {
     // Actual command output:
     // grep "Tx=\"\S*\"\|tx=\"\S*\"\|translate(\"\S*\"" -ohr './app' | grep -o "\".*\""
-    const command = `grep "Tx=\\"\\S*\\"\\|tx=\\"\\S*\\"\\|translate(\\"\\S*\\"" -ohr '../app' | grep -o "\\".*\\""`
+    const command = `grep "Tx=\\"\\S*\\"\\|tx=\\"\\S*\\"\\|translate(\\"\\S*\\"" -ohr './app' | grep -o "\\".*\\""`
     exec(command, (_, stdout) => {
       const allTranslationsDefined = iterate(en, "", [])
       const allTranslationsUsed = stdout.replace(/"/g, "").split("\n")


### PR DESCRIPTION
## Please verify the following:

No updates to the README, no new tests added (`yarn ci:test` passes).

## Describe your PR
The current boilerplate test in `test/i18n.test.ts` named "There are no missing keys" is incorrect because the `grep` path is _ever-so-slightly_ off. The relative path should be `'./app'` and not `'../app'`, as child processes spawned in Jest tests using `exec` run in Jest's [root directory](https://jestjs.io/docs/en/configuration#rootdir-string), not the directory containing the test file ([original code commit](http://lab.cloudpresser.com/root/ignite-cloud-presser/commit/d0cae5484a96f4d686ab61c87428ec5749b194d6)).

I won't detail how I found this bug, but it involves creating an Ignite app named "app", i.e. running `npx ignite-cli new app`.


Here's some evidence of the problem:
- inserting `console.log(stdout);` into the start of `exec`'s callback function _when the app is not named "app"_ — note how `grep` fails to match anything, as it's unable to find a sibling of `<project-name>` named `app`
```
console.log

```

- changing the path to `'./app'` while logging `stdout` as above — note how all keys from files of `app` are correctly `grep`'d
```
console.log
    "demoScreen.howTo"
    "demoScreen.title"
    "demoScreen.tagLine"
    "demoScreen.reactotron"
    "welcomeScreen.poweredBy"
    "welcomeScreen.readyForLaunch"
    "welcomeScreen.continue"
    "storybook.placeholder"
    "storybook.field"
    "common.ok"
    "common.cancel"
    "demoScreen.howTo"
    "demoScreen.howTo"
    "demoScreen.howTo"
```

- replacing the entire test block with
```
describe("i18n", () => {
  test("There are no missing keys", (done) => {
    const pwdCmd = `pwd`
    exec(pwdCmd, (_, stdout) => {
      console.log(stdout);
      done();
    })
  }, 240000)
})
```
note how the child process' working directory is the project root, not the test directory `potato/test/`
```
console.log
    /Users/leonyjiang/prog/potato
```