### PR TITLE
Fix the "MobX-State-Tree [(Why not Redux?)]" Link

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ Ignite apps include the following rock-solid technical decisions out of the box:
 
 - React Native
 - React Navigation 5
-- MobX-State-Tree [(Why not Redux?)](#About-The-Stack)
+- MobX-State-Tree [(Why not Redux?)](https://github.com/infinitered/ignite/blob/master/docs/MobX-State-Tree.md)
 - MobX-React-Lite
 - TypeScript
 - AsyncStorage (integrated with MST for restoring state)


### PR DESCRIPTION
## Please verify the following:

- [x] `yarn ci:test` **jest** tests pass with new tests, if relevant : NOT RELEVANT
- [x] `README.md` has been updated with your changes, if relevant

## Describe your PR

The link was redirecting to an anchor which does not exist anymore on this page. I think you should redirect to the doc file MobX-State-Tree.md.

Best Regards,
Ruben