### PR TITLE
Fix issue #1579 -- ignite doctor on Windows -- adds optional chaining

### DIFF
--- a/src/commands/doctor.ts
+++ b/src/commands/doctor.ts
@@ -90,8 +90,8 @@ module.exports = {
     // -=-=-=- android -=-=-=-
     const androidPath = process.env.ANDROID_HOME
     const javaPath = which("java")
-    const javaVersionCmd = isWindows ? "java -version" : "java -version 2>&1"
-    const javaVersion = javaPath && (await run(javaVersionCmd)).match(/"(.*)"/).slice(-1)[0]
+    const javaVersionCmd = "java -version 2>&1"
+    const javaVersion = javaPath && (await run(javaVersionCmd))?.match(/"(.*)"/)?.slice(-1)[0]
 
     info("")
     info(colors.cyan("Android"))


### PR DESCRIPTION
This PR should fix #1579 by unifying the Java command with the macOS version, and also double protection by adding optional chaining.

![image](https://user-images.githubusercontent.com/1479215/104412471-2b14d780-5521-11eb-9535-6d6f655ebc71.png)
