### PR TITLE
Update package.json to fix error related to mobx

### DIFF
--- a/boilerplate/package.json
+++ b/boilerplate/package.json
@@ -37,7 +37,7 @@
     "i18n-js": "3.8.0",
     "mobx": "6.0.4",
     "mobx-react-lite": "3.1.6",
-    "mobx-state-tree": "4.0.2",
+    "mobx-state-tree": "^5.0.1",
     "ramda": "0.27.1",
     "react": "16.14.0",
     "react-native": "^0.63.4",


### PR DESCRIPTION
Adding fix for https://github.com/mobxjs/mobx-state-tree/issues/1653

![Screenshot_1613281315](https://user-images.githubusercontent.com/4496555/107869783-d6fe6980-6eb7-11eb-93e2-25b29d079ec9.png)

`mobx-state-tree` version 4.0.2 gave above error.

