### PR TITLE
Add an example list screen fetch api using mobx-state-tree flow

### DIFF
--- a/boilerplate/app/i18n/en.json
+++ b/boilerplate/app/i18n/en.json
@@ -10,7 +10,8 @@
   "welcomeScreen": {
     "poweredBy": "POWERED BY IGNITE",
     "readyForLaunch": "Ready for launch.",
-    "continue": "CONTINUE"
+    "continue": "CONTINUE",
+    "demoList": "DEMO LIST"
   },
   "demoScreen": {
     "howTo": "HOW TO",
@@ -19,6 +20,10 @@
     "reactotron": "Demo Reactotron",
     "androidReactotronHint": "If this doesn't work, ensure the Reactotron desktop app is running, run adb reverse tcp:9090 tcp:9090 from your terminal, and reload the app.",
     "iosReactotronHint": "If this doesn't work, ensure the Reactotron desktop app is running and reload app."
+  },
+  "listScreen": {
+    "title": "List Demo Screen: %{count}",
+    "delete": "Delete"
   },
   "storybook": {
     "placeholder": "Placeholder",

--- a/boilerplate/app/models/list-demo/list-demo.props.ts
+++ b/boilerplate/app/models/list-demo/list-demo.props.ts
@@ -1,0 +1,12 @@
+import { Instance, types } from "mobx-state-tree"
+
+// Define exactly response data what you need
+export const DataUser = types.model({
+  id: types.maybeNull(types.number),
+  name: types.maybeNull(types.string),
+  gender: types.maybeNull(types.string),
+  image: types.maybeNull(types.string),
+})
+
+type DataUserType = Instance<typeof DataUser>
+export interface DataUserProps extends DataUserType {}

--- a/boilerplate/app/models/list-demo/list-demo.test.ts
+++ b/boilerplate/app/models/list-demo/list-demo.test.ts
@@ -1,0 +1,7 @@
+import { ListDemoModel } from "./list-demo"
+
+test("can be created", () => {
+  const instance = ListDemoModel.create({})
+
+  expect(instance).toBeTruthy()
+})

--- a/boilerplate/app/models/list-demo/list-demo.ts
+++ b/boilerplate/app/models/list-demo/list-demo.ts
@@ -1,0 +1,66 @@
+import { applySnapshot, flow, Instance, SnapshotOut, types } from "mobx-state-tree"
+import { DataUser, DataUserProps } from "./list-demo.props"
+import { withEnvironment } from ".."
+import * as Types from "../../services/api/api.types"
+
+/**
+ * Model description here for TypeScript hints.
+ */
+export const ListDemoModel = types
+  .model("ListDemo")
+  .extend(withEnvironment)
+  .props({
+    data: types.optional(types.array(DataUser), []),
+    loading: false,
+    page: 1,
+    noMore: false,
+  })
+  .views((self) => ({
+    get countData() {
+      // Do the logic here, the data will auto notify to the view when changed
+      return self.data.length
+    },
+  })) // eslint-disable-line @typescript-eslint/no-unused-vars
+  .actions((self) => ({
+    getListUser: flow(function * () {
+      const result: Types.GetListResult = yield self.environment.api.getListUser(self.page)
+      if (result.kind === "ok") {
+        const arrays = [...self.data, ...result.data?.results]
+        self.data.replace(arrays)
+      } else {
+        self.noMore = true
+      }
+      self.loading = false
+    }),
+  })) // eslint-disable-line @typescript-eslint/no-unused-vars
+  .actions((self) => ({
+    loadData: () => {
+      applySnapshot(self.data, [])
+      self.loading = true
+      self.page = 1
+      self.noMore = false
+      self.getListUser()
+    },
+    onLoadmore: () => {
+      self.loading = true
+      self.page = self.page + 1
+      self.getListUser()
+    },
+    removeItemData: (item: DataUserProps) => {
+      self.data.remove(item)
+    },
+  }))
+
+/**
+  * Un-comment the following to omit model attributes from your snapshots (and from async storage).
+  * Useful for sensitive data like passwords, or transitive state like whether a modal is open.
+
+  * Note that you'll need to import `omit` from ramda, which is already included in the project!
+  *  .postProcessSnapshot(omit(["password", "socialSecurityNumber", "creditCardNumber"]))
+  */
+
+type ListDemoType = Instance<typeof ListDemoModel>
+export interface ListDemo extends ListDemoType {}
+type ListDemoSnapshotType = SnapshotOut<typeof ListDemoModel>
+export interface ListDemoSnapshot extends ListDemoSnapshotType {}
+export const createListDemoDefaultModel = () => types.optional(ListDemoModel, {})

--- a/boilerplate/app/models/root-store/root-store.ts
+++ b/boilerplate/app/models/root-store/root-store.ts
@@ -1,11 +1,12 @@
 import { Instance, SnapshotOut, types } from "mobx-state-tree"
+import { createListDemoDefaultModel } from "../list-demo/list-demo"
 
 /**
  * A RootStore model.
  */
 // prettier-ignore
 export const RootStoreModel = types.model("RootStore").props({
-
+    listDemo: createListDemoDefaultModel()
 })
 
 /**

--- a/boilerplate/app/navigation/main-navigator.tsx
+++ b/boilerplate/app/navigation/main-navigator.tsx
@@ -6,7 +6,7 @@
  */
 import React from "react"
 import { createStackNavigator } from "@react-navigation/stack"
-import { WelcomeScreen, DemoScreen } from "../screens"
+import { WelcomeScreen, DemoScreen, ListScreen } from "../screens"
 
 /**
  * This type allows TypeScript to know what routes are defined in this navigator
@@ -23,6 +23,7 @@ import { WelcomeScreen, DemoScreen } from "../screens"
 export type PrimaryParamList = {
   welcome: undefined
   demo: undefined
+  list: undefined
 }
 
 // Documentation: https://reactnavigation.org/docs/stack-navigator/
@@ -37,6 +38,7 @@ export function MainNavigator() {
     >
       <Stack.Screen name="welcome" component={WelcomeScreen} />
       <Stack.Screen name="demo" component={DemoScreen} />
+      <Stack.Screen name="list" component={ListScreen} />
     </Stack.Navigator>
   )
 }

--- a/boilerplate/app/navigation/navigation-utilities.tsx
+++ b/boilerplate/app/navigation/navigation-utilities.tsx
@@ -3,7 +3,7 @@ import { BackHandler } from "react-native"
 import { PartialState, NavigationState, NavigationContainerRef } from "@react-navigation/native"
 
 export const RootNavigation = {
-  navigate(name: string) {
+  navigate(name: string, params?: any) {
     name // eslint-disable-line no-unused-expressions
   },
   goBack() {}, // eslint-disable-line @typescript-eslint/no-empty-function

--- a/boilerplate/app/screens/index.ts
+++ b/boilerplate/app/screens/index.ts
@@ -1,3 +1,4 @@
 export * from "./welcome/welcome-screen"
 export * from "./demo/demo-screen"
+export * from "./list/list-screen"
 // export other screens here

--- a/boilerplate/app/screens/list/item-list.tsx
+++ b/boilerplate/app/screens/list/item-list.tsx
@@ -1,0 +1,51 @@
+import * as React from "react"
+import { Image, ImageStyle, TextStyle, View, ViewStyle } from "react-native"
+import { observer } from "mobx-react-lite"
+import { spacing } from "../../theme"
+import { Text, Button } from "../../components"
+import { DataUserProps } from "../../models/list-demo/list-demo.props"
+
+const CONTAINER: ViewStyle = {
+  padding: spacing[2],
+  flexDirection: "row",
+  alignItems: "center",
+}
+const AVATAR: ImageStyle = {
+  width: 60,
+  height: 60,
+  borderRadius: 30,
+}
+const INFO: ViewStyle = {
+  flex: 1,
+  marginLeft: spacing[3],
+}
+const NAME: TextStyle = {
+  fontWeight: "bold",
+}
+
+export interface ItemListProps {
+  item: DataUserProps
+  onDeleteItem(item: DataUserProps): void
+}
+
+/**
+ * Describe your component here
+ */
+export const ItemList = observer(function ItemList(props: ItemListProps) {
+  const { item, onDeleteItem } = props
+
+  const clickDelete = () => onDeleteItem(item)
+
+  return (
+    <View style={CONTAINER}>
+      <Image style={AVATAR} source={{ uri: item?.image }} />
+      <View style={INFO}>
+        <Text style={NAME} text={item?.name} />
+        <Text text={item?.gender} />
+      </View>
+      <Button onPress={clickDelete} preset="link">
+        <Text tx={"listScreen.delete"} />
+      </Button>
+    </View>
+  )
+})

--- a/boilerplate/app/screens/list/list-screen.tsx
+++ b/boilerplate/app/screens/list/list-screen.tsx
@@ -1,0 +1,94 @@
+import React from "react"
+import { observer } from "mobx-react-lite"
+import {
+  ActivityIndicator,
+  FlatList,
+  ListRenderItem,
+  RefreshControl,
+  TextStyle,
+  ViewStyle,
+} from "react-native"
+import { Header, Screen, Wallpaper } from "../../components"
+import { useNavigation } from "@react-navigation/native"
+import { color, spacing } from "../../theme"
+import { ItemList } from "./item-list"
+import { useStores } from "../../models"
+import { DataUserProps } from "../../models/list-demo/list-demo.props"
+import { translate } from "../../i18n"
+
+const ROOT: ViewStyle = {
+  flex: 1,
+  paddingHorizontal: spacing[4],
+}
+const HEADER: TextStyle = {
+  paddingTop: spacing[3],
+  paddingBottom: spacing[5] - 1,
+  paddingHorizontal: 0,
+}
+const BOLD: TextStyle = { fontWeight: "bold" }
+const HEADER_TITLE: TextStyle = {
+  ...BOLD,
+  fontSize: 12,
+  lineHeight: 15,
+  textAlign: "center",
+  letterSpacing: 1.5,
+}
+const LOADING: ViewStyle = {
+  padding: spacing[3],
+}
+const ON_THRESHOLD = 1
+
+export const ListScreen = observer(function ListScreen() {
+  const { listDemo } = useStores()
+  const navigation = useNavigation()
+
+  React.useEffect(() => {
+    listDemo.loadData()
+  }, [])
+
+  const onDeleteItem = (item: DataUserProps) => listDemo.removeItemData(item)
+
+  const renderItem: ListRenderItem<DataUserProps> = ({ item, index }) => (
+    <ItemList onDeleteItem={onDeleteItem} item={item} />
+  )
+
+  const onLoadmore = () => {
+    if (!listDemo.noMore && !listDemo.loading) {
+      listDemo.onLoadmore()
+    }
+  }
+
+  return (
+    <Screen style={ROOT} preset="fixed">
+      <Wallpaper />
+      <Header
+        headerText={translate("listScreen.title", { count: listDemo.countData })}
+        leftIcon="back"
+        onLeftPress={navigation.goBack}
+        style={HEADER}
+        titleStyle={HEADER_TITLE}
+      />
+      <FlatList
+        refreshControl={
+          <RefreshControl
+            tintColor={color.background}
+            refreshing={false}
+            onRefresh={listDemo.loadData}
+          />
+        }
+        data={listDemo.data}
+        extraData={listDemo.data.length}
+        keyExtractor={(item) => item.id + ""}
+        removeClippedSubviews
+        ListFooterComponent={
+          listDemo.loading && (
+            <ActivityIndicator style={LOADING} size="small" color={color.background} />
+          )
+        }
+        onEndReached={onLoadmore}
+        onEndReachedThreshold={ON_THRESHOLD}
+        renderItem={renderItem}
+      />
+    </Screen>
+  )
+})

--- a/boilerplate/app/screens/welcome/welcome-screen.tsx
+++ b/boilerplate/app/screens/welcome/welcome-screen.tsx
@@ -62,6 +62,7 @@ const CONTINUE: ViewStyle = {
   paddingVertical: spacing[4],
   paddingHorizontal: spacing[4],
   backgroundColor: "#5D2555",
+  marginTop: spacing[1],
 }
 const CONTINUE_TEXT: TextStyle = {
   ...TEXT,
@@ -78,6 +79,7 @@ const FOOTER_CONTENT: ViewStyle = {
 export const WelcomeScreen = observer(function WelcomeScreen() {
   const navigation = useNavigation()
   const nextScreen = () => navigation.navigate("demo")
+  const listDemoScreen = () => navigation.navigate("list")
 
   return (
     <View testID="WelcomeScreen" style={FULL}>
@@ -108,6 +110,13 @@ export const WelcomeScreen = observer(function WelcomeScreen() {
             textStyle={CONTINUE_TEXT}
             tx="welcomeScreen.continue"
             onPress={nextScreen}
+          />
+          <Button
+            testID="list-screen-button"
+            style={CONTINUE}
+            textStyle={CONTINUE_TEXT}
+            tx="welcomeScreen.demoList"
+            onPress={listDemoScreen}
           />
         </View>
       </SafeAreaView>

--- a/boilerplate/app/services/api/api.ts
+++ b/boilerplate/app/services/api/api.ts
@@ -99,4 +99,27 @@ export class Api {
       return { kind: "bad-data" }
     }
   }
+
+  async getListUser(page: number): Promise<Types.GetListResult> {
+    // make the api call
+    const response: ApiResponse<any> = await this.apisauce.get(
+      `https://rickandmortyapi.com/api/character?page=${page}`,
+    )
+
+    // the typical ways to die when calling an api
+    if (!response.ok) {
+      const problem = getGeneralApiProblem(response)
+      if (problem) return problem
+    }
+
+    // transform the data into the format we are expecting
+    try {
+      const resultUser: Types.ListProps = {
+        results: response.data?.results ?? [],
+      }
+      return { kind: "ok", data: resultUser }
+    } catch {
+      return { kind: "bad-data" }
+    }
+  }
 }

--- a/boilerplate/app/services/api/api.types.ts
+++ b/boilerplate/app/services/api/api.types.ts
@@ -1,9 +1,13 @@
 import { GeneralApiProblem } from "./api-problem"
+import { DataUserProps } from "../../models/list-demo/list-demo.props"
 
 export interface User {
   id: number
   name: string
 }
-
+export interface ListProps {
+  results: DataUserProps[]
+}
 export type GetUsersResult = { kind: "ok"; users: User[] } | GeneralApiProblem
 export type GetUserResult = { kind: "ok"; user: User } | GeneralApiProblem
+export type GetListResult = { kind: "ok"; data: ListProps } | GeneralApiProblem

--- a/boilerplate/e2e/firstTest.spec.js
+++ b/boilerplate/e2e/firstTest.spec.js
@@ -16,4 +16,9 @@ describe("Example", () => {
     await element(by.id("next-screen-button")).tap()
     await expect(element(by.id("DemoScreen"))).toBeVisible()
   })
+
+  it("should go to list screen after tap", async () => {
+    await element(by.id("list-screen-button")).tap()
+    await expect(element(by.id("ListScreen"))).toBeVisible()
+  })
 })


### PR DESCRIPTION
## Please verify the following:

- [x] `yarn ci:test` **jest** tests pass with new tests, if relevant
- [x] `README.md` has been updated with your changes, if relevant

## Describe your PR
From issue #1605, i know have many people don't understand how to integrate fetch api with mobx-state-tree, so i decided to added an example screen that used:
- Fetch api `list` inside model
- Store data inside model
- Load more api using model
- The view just show data from model
- Show count of data and remove item from model
- All logic should be inside model

Demo screen:

![Simulator Screen Shot - iPhone SE (2nd generation) - 2021-02-23 at 11 52 29](https://user-images.githubusercontent.com/9206731/108803863-571a8280-75ce-11eb-989e-6946db91ffa9.png)


API from `rickandmortyapi`