### PR TITLE
Add Demo List Screen with MST and Apisauce into boilerplate

### DIFF
--- a/boilerplate/app/i18n/en.json
+++ b/boilerplate/app/i18n/en.json
@@ -17,8 +17,12 @@
     "title": "What’s In This Stack?",
     "tagLine": "Congratulations, you’ve got a very advanced React Native app template here.  Take advantage of this boilerplate!",
     "reactotron": "Demo Reactotron",
+    "demoList": "Demo List",
     "androidReactotronHint": "If this doesn't work, ensure the Reactotron desktop app is running, run adb reverse tcp:9090 tcp:9090 from your terminal, and reload the app.",
     "iosReactotronHint": "If this doesn't work, ensure the Reactotron desktop app is running and reload app."
+  },
+  "demoListScreen": {
+    "title": "Demo List"
   },
   "storybook": {
     "placeholder": "Placeholder",

--- a/boilerplate/app/models/character-store/character-store.test.ts
+++ b/boilerplate/app/models/character-store/character-store.test.ts
@@ -1,0 +1,7 @@
+import { CharacterStoreModel } from "./character-store"
+
+test("can be created", () => {
+  const instance = CharacterStoreModel.create({})
+
+  expect(instance).toBeTruthy()
+})

--- a/boilerplate/app/models/character-store/character-store.ts
+++ b/boilerplate/app/models/character-store/character-store.ts
@@ -1,0 +1,46 @@
+import { flow, Instance, SnapshotOut, types } from "mobx-state-tree"
+import { Character, CharacterModel, CharacterSnapshot } from "../character/character"
+import { CharacterApi } from '../../services/api/character-api';
+import { GetCharactersResult } from "../../services/api";
+
+/**
+ * Model description here for TypeScript hints.
+ */
+export const CharacterStoreModel = types
+  .model("CharacterStore")
+  .props({
+    characters: types.optional(types.array(CharacterModel), []),
+  })
+  .views(self => ({})) // eslint-disable-line @typescript-eslint/no-unused-vars
+  .actions((self) => ({
+    saveCharacters: (characterSnapshots: CharacterSnapshot[]) => {
+      const characterModels: Character[] = characterSnapshots.map((c) => CharacterModel.create(c)) // create model instances from the plain objects
+      self.characters.replace(characterModels) // Replace the existing data with the new data
+    },
+  }))
+  .actions(self => ({
+    getCharacters: flow(function * () {
+      const characterApi = new CharacterApi(self.environment.api)
+      const result: GetCharactersResult = yield characterApi.getQuestions()
+
+      if (result.kind === "ok") {
+        self.saveCharacters(result.characters)
+      } else {
+        __DEV__ && console.tron.log(result.kind)
+      }
+    })
+  })) // eslint-disable-line @typescript-eslint/no-unused-vars
+
+  /**
+  * Un-comment the following to omit model attributes from your snapshots (and from async storage).
+  * Useful for sensitive data like passwords, or transitive state like whether a modal is open.
+
+  * Note that you'll need to import `omit` from ramda, which is already included in the project!
+  *  .postProcessSnapshot(omit(["password", "socialSecurityNumber", "creditCardNumber"]))
+  */
+
+type CharacterStoreType = Instance<typeof CharacterStoreModel>
+export interface CharacterStore extends CharacterStoreType {}
+type CharacterStoreSnapshotType = SnapshotOut<typeof CharacterStoreModel>
+export interface CharacterStoreSnapshot extends CharacterStoreSnapshotType {}
+export const createCharacterStoreDefaultModel = () => types.optional(CharacterStoreModel, {})

--- a/boilerplate/app/models/character-store/character-store.ts
+++ b/boilerplate/app/models/character-store/character-store.ts
@@ -21,7 +21,7 @@ export const CharacterStoreModel = types
   .actions(self => ({
     getCharacters: flow(function * () {
       const characterApi = new CharacterApi(self.environment.api)
-      const result: GetCharactersResult = yield characterApi.getQuestions()
+      const result: GetCharactersResult = yield characterApi.getCharacters()
 
       if (result.kind === "ok") {
         self.saveCharacters(result.characters)

--- a/boilerplate/app/models/character-store/character-store.ts
+++ b/boilerplate/app/models/character-store/character-store.ts
@@ -2,6 +2,7 @@ import { flow, Instance, SnapshotOut, types } from "mobx-state-tree"
 import { Character, CharacterModel, CharacterSnapshot } from "../character/character"
 import { CharacterApi } from '../../services/api/character-api';
 import { GetCharactersResult } from "../../services/api";
+import { withEnvironment } from "../extensions/with-environment";
 
 /**
  * Model description here for TypeScript hints.
@@ -11,6 +12,7 @@ export const CharacterStoreModel = types
   .props({
     characters: types.optional(types.array(CharacterModel), []),
   })
+  .extend(withEnvironment)
   .views(self => ({})) // eslint-disable-line @typescript-eslint/no-unused-vars
   .actions((self) => ({
     saveCharacters: (characterSnapshots: CharacterSnapshot[]) => {

--- a/boilerplate/app/models/character/character.test.ts
+++ b/boilerplate/app/models/character/character.test.ts
@@ -1,0 +1,7 @@
+import { CharacterModel } from "./character"
+
+test("can be created", () => {
+  const instance = CharacterModel.create({})
+
+  expect(instance).toBeTruthy()
+})

--- a/boilerplate/app/models/character/character.ts
+++ b/boilerplate/app/models/character/character.ts
@@ -1,0 +1,29 @@
+import { Instance, SnapshotOut, types } from "mobx-state-tree"
+
+/**
+ * Model description here for TypeScript hints.
+ */
+export const CharacterModel = types
+  .model("Character")
+  .props({
+    id: types.identifier,
+    name: types.maybe(types.string),
+    status: types.maybe(types.string),
+    image: types.maybe(types.string),
+  })
+  .views(self => ({})) // eslint-disable-line @typescript-eslint/no-unused-vars
+  .actions(self => ({})) // eslint-disable-line @typescript-eslint/no-unused-vars
+
+  /**
+  * Un-comment the following to omit model attributes from your snapshots (and from async storage).
+  * Useful for sensitive data like passwords, or transitive state like whether a modal is open.
+
+  * Note that you'll need to import `omit` from ramda, which is already included in the project!
+  *  .postProcessSnapshot(omit(["password", "socialSecurityNumber", "creditCardNumber"]))
+  */
+
+type CharacterType = Instance<typeof CharacterModel>
+export interface Character extends CharacterType {}
+type CharacterSnapshotType = SnapshotOut<typeof CharacterModel>
+export interface CharacterSnapshot extends CharacterSnapshotType {}
+export const createCharacterDefaultModel = () => types.optional(CharacterModel, {})

--- a/boilerplate/app/models/root-store/root-store.ts
+++ b/boilerplate/app/models/root-store/root-store.ts
@@ -1,11 +1,12 @@
 import { Instance, SnapshotOut, types } from "mobx-state-tree"
+import { CharacterStoreModel } from '../character-store/character-store';
 
 /**
  * A RootStore model.
  */
 // prettier-ignore
 export const RootStoreModel = types.model("RootStore").props({
-
+    characterStore: types.optional(CharacterStoreModel, {} as any),
 })
 
 /**

--- a/boilerplate/app/navigation/main-navigator.tsx
+++ b/boilerplate/app/navigation/main-navigator.tsx
@@ -6,7 +6,7 @@
  */
 import React from "react"
 import { createStackNavigator } from "@react-navigation/stack"
-import { WelcomeScreen, DemoScreen } from "../screens"
+import { WelcomeScreen, DemoScreen, DemoListScreen } from "../screens"
 
 /**
  * This type allows TypeScript to know what routes are defined in this navigator
@@ -23,6 +23,7 @@ import { WelcomeScreen, DemoScreen } from "../screens"
 export type PrimaryParamList = {
   welcome: undefined
   demo: undefined
+  demoList: undefined
 }
 
 // Documentation: https://reactnavigation.org/docs/stack-navigator/
@@ -37,6 +38,7 @@ export function MainNavigator() {
     >
       <Stack.Screen name="welcome" component={WelcomeScreen} />
       <Stack.Screen name="demo" component={DemoScreen} />
+      <Stack.Screen name="demoList" component={DemoListScreen} />
     </Stack.Navigator>
   )
 }

--- a/boilerplate/app/screens/demo/demo-list-screen.tsx
+++ b/boilerplate/app/screens/demo/demo-list-screen.tsx
@@ -1,0 +1,83 @@
+import React, { useEffect, useState } from "react"
+import { Image, FlatList, TextStyle, View, ViewStyle, ImageStyle } from "react-native"
+import { useNavigation } from "@react-navigation/native"
+import { observer } from "mobx-react-lite"
+import { Header, Screen, Text, Wallpaper } from "../../components"
+import { color, spacing } from "../../theme"
+
+const FULL: ViewStyle = { flex: 1 }
+const CONTAINER: ViewStyle = {
+  backgroundColor: color.transparent,
+  paddingHorizontal: spacing[4],
+}
+const BOLD: TextStyle = { fontWeight: "bold" }
+const HEADER: TextStyle = {
+  paddingTop: spacing[3],
+  paddingBottom: spacing[5] - 1,
+  paddingHorizontal: 0,
+}
+const HEADER_TITLE: TextStyle = {
+  ...BOLD,
+  fontSize: 12,
+  lineHeight: 15,
+  textAlign: "center",
+  letterSpacing: 1.5,
+}
+const LISTCONTAINER: ViewStyle = {
+  alignItems: 'center',
+  flexDirection: 'row',
+  padding: 10
+}
+const IMAGE: ImageStyle = {
+  width: 65,
+  height: 65,
+  borderRadius: 35
+}
+const LISTTEXT: TextStyle = {
+  marginLeft: 10
+}
+
+type CharacterData = { image: string; name: string; status: string}
+
+export const DemoListScreen = observer(function DemoListScreen() {
+  const navigation = useNavigation()
+  const goBack = () => navigation.goBack()
+
+  const [data, setData] = useState<CharacterData[]>()
+
+  useEffect(() => {
+    // Todo fetch the data
+    // setData(jsonArrayFromTheFetch)
+    async function fetchData() {
+      const resp = await fetch('https://rickandmortyapi.com/api/character')
+      const json: { results: CharacterData[] } = await resp.json()
+
+      setData(json.results)
+    }
+
+    fetchData()
+  }, [])
+
+  return (
+    <View testID="DemoListScreen" style={FULL}>
+      <Wallpaper />
+      <Screen style={CONTAINER} preset="fixed" backgroundColor={color.transparent}>
+        <Header
+          headerTx="demoListScreen.title"
+          leftIcon="back"
+          onLeftPress={goBack}
+          style={HEADER}
+          titleStyle={HEADER_TITLE}
+        />
+        <FlatList
+          data={data}
+          renderItem={({ item }) =>
+          <View style={LISTCONTAINER}>
+            <Image source={{ uri: item.image }} style={IMAGE} />
+            <Text style={LISTTEXT}>{item.name} ({item.status})</Text>
+            </View> }
+        />
+      </Screen>
+    </View>
+  )
+})

--- a/boilerplate/app/screens/demo/demo-list-screen.tsx
+++ b/boilerplate/app/screens/demo/demo-list-screen.tsx
@@ -4,6 +4,7 @@ import { useNavigation } from "@react-navigation/native"
 import { observer } from "mobx-react-lite"
 import { Header, Screen, Text, Wallpaper } from "../../components"
 import { color, spacing } from "../../theme"
+import { useStores } from "../../models"
 
 const FULL: ViewStyle = { flex: 1 }
 const CONTAINER: ViewStyle = {
@@ -45,14 +46,14 @@ export const DemoListScreen = observer(function DemoListScreen() {
 
   const [data, setData] = useState<CharacterData[]>()
 
+  const { characterStore } = useStores();
+  const { characters } = characterStore;
+
   useEffect(() => {
     // Todo fetch the data
     // setData(jsonArrayFromTheFetch)
     async function fetchData() {
-      const resp = await fetch('https://rickandmortyapi.com/api/character')
-      const json: { results: CharacterData[] } = await resp.json()
-
-      setData(json.results)
+      await characterStore.getCharacters();
     }
 
     fetchData()
@@ -70,7 +71,7 @@ export const DemoListScreen = observer(function DemoListScreen() {
           titleStyle={HEADER_TITLE}
         />
         <FlatList
-          data={data}
+          data={characters}
           renderItem={({ item }) =>
           <View style={LISTCONTAINER}>
             <Image source={{ uri: item.image }} style={IMAGE} />

--- a/boilerplate/app/screens/demo/demo-screen.tsx
+++ b/boilerplate/app/screens/demo/demo-screen.tsx
@@ -153,6 +153,12 @@ export const DemoScreen = observer(function DemoScreen() {
           />
           <Text style={HINT} tx={`demoScreen.${Platform.OS}ReactotronHint`} />
         </View>
+        <Button
+            style={DEMO}
+            textStyle={DEMO_TEXT}
+            tx="demoScreen.demoList"
+            onPress={() => navigation.navigate('demoList')}
+          />
         <Image source={logoIgnite} style={IGNITE} />
         <View style={LOVE_WRAPPER}>
           <Text style={LOVE} text="Made with" />

--- a/boilerplate/app/screens/index.ts
+++ b/boilerplate/app/screens/index.ts
@@ -1,3 +1,4 @@
 export * from "./welcome/welcome-screen"
 export * from "./demo/demo-screen"
+export * from "./demo/demo-list-screen"
 // export other screens here

--- a/boilerplate/app/services/api/api.types.ts
+++ b/boilerplate/app/services/api/api.types.ts
@@ -1,4 +1,5 @@
 import { GeneralApiProblem } from "./api-problem"
+import { Character } from '../../models/character/character';
 
 export interface User {
   id: number
@@ -7,3 +8,7 @@ export interface User {
 
 export type GetUsersResult = { kind: "ok"; users: User[] } | GeneralApiProblem
 export type GetUserResult = { kind: "ok"; user: User } | GeneralApiProblem
+
+
+export type GetCharactersResult = { kind: "ok"; characters: Character[] } | GeneralApiProblem
+export type GetCharacterResult = { kind: "ok"; character: Character } | GeneralApiProblem

--- a/boilerplate/app/services/api/character-api.ts
+++ b/boilerplate/app/services/api/character-api.ts
@@ -22,7 +22,7 @@ export class CharacterApi {
       this.api = api
     }
 
-    async getQuestions(): Promise<any> {
+    async getCharacters(): Promise<any> {
       // make the api call
       const response: ApiResponse<any> = await this.api.apisauce.get("https://rickandmortyapi.com/api/character", { amount: API_PAGE_SIZE })
 
@@ -37,7 +37,7 @@ export class CharacterApi {
         const rawCharacters = response.data.results
         const convertedCharacters: CharacterSnapshot[] = rawCharacters.map(convertCharacter)
 
-        const responseCharacters = { kind: "ok", questions: convertedCharacters }
+        const responseCharacters = { kind: "ok", characters: convertedCharacters }
         return responseCharacters
       } catch (e) {
         __DEV__ && console.tron.log(e.message)

--- a/boilerplate/app/services/api/character-api.ts
+++ b/boilerplate/app/services/api/character-api.ts
@@ -1,0 +1,47 @@
+import { ApiResponse } from "apisauce"
+import { CharacterSnapshot } from '../../models/character/character'
+import { makeid } from "../../utils/string"
+import { Api } from "./api"
+import { getGeneralApiProblem } from "./api-problem"
+
+const API_PAGE_SIZE = 50
+
+const convertCharacter = (raw: any): CharacterSnapshot => {
+  return {
+    id: makeid(25),
+    image: raw.image,
+    name: raw.name,
+    status: raw.status,
+  }
+}
+
+export class CharacterApi {
+    private api: Api;
+
+    constructor(api: Api) {
+      this.api = api
+    }
+
+    async getQuestions(): Promise<any> {
+      // make the api call
+      const response: ApiResponse<any> = await this.api.apisauce.get("https://rickandmortyapi.com/api/character", { amount: API_PAGE_SIZE })
+
+      // the typical ways to die when calling an api
+      if (!response.ok) {
+        const problem = getGeneralApiProblem(response)
+        if (problem) return problem
+      }
+
+      // transform the data into the format we are expecting
+      try {
+        const rawCharacters = response.data.results
+        const convertedCharacters: CharacterSnapshot[] = rawCharacters.map(convertCharacter)
+
+        const responseCharacters = { kind: "ok", questions: convertedCharacters }
+        return responseCharacters
+      } catch (e) {
+        __DEV__ && console.tron.log(e.message)
+        return { kind: "bad-data" }
+      }
+    }
+}

--- a/boilerplate/app/utils/string.ts
+++ b/boilerplate/app/utils/string.ts
@@ -1,0 +1,10 @@
+export function makeid(length) {
+    let result = ''
+    const characters = 'ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789'
+    const charactersLength = characters.length
+    for (let i = 0; i < length; i++) {
+      result += characters.charAt(Math.floor(Math.random() * charactersLength))
+    }
+    return result
+  }
+  


### PR DESCRIPTION
## Please verify the following:

- [ ] `yarn ci:test` **jest** tests pass with new tests, if relevant
- [ ] `README.md` has been updated with your changes, if relevant

## Describe your PR
As per #1605, and PR #1608 was added to add a demo screen to fetch list of data from public API. However, in that PR, it uses the fetchAPI, to standardise with the packages used in the boilerplate i.e., API Sauce and Mobx-State-Tree, I've updated the PR and changing the implementation from fetch to using MST and API Sauce.

Huge thank to @kateinkim for the initiative to add the demo list screen

The code used was inspired from this [blog](https://shift.infinite.red/creating-a-trivia-app-with-ignite-bowser-part-1-1987cc6e93a1). Huge thanks Robin Heinze as well
