### PR TITLE
Only configure git user for CircleCI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -40,6 +40,11 @@ jobs:
           command: |
             sudo ln /bin/true /usr/local/bin/pod
       - run:
+          name: Ensure git user is configured
+          command: |
+            git config --global user.email "ci@infinite.red"
+            git config --global user.name "Infinite Red"
+      - run:
           name: Run tests
           command: yarn ci:test
           no_output_timeout: 15m

--- a/test/ignite-new.test.ts
+++ b/test/ignite-new.test.ts
@@ -8,11 +8,6 @@ const EXPO_APP_NAME = "Bar"
 const originalDir = process.cwd()
 let tempDir: string
 
-beforeAll(async () => {
-  await run('git config --global user.email "ci@infinite.red"')
-  await run('git config --global user.name "Infinite Red"')
-})
-
 beforeEach(() => {
   tempDir = tempy.directory()
   process.chdir(tempDir)


### PR DESCRIPTION
I just realized that the changes made to get CI passing for #1617 will also override the git config for anyone running tests locally. 🙀 

Since we only needed to make sure CircleCI has a configured git user I moved that into the CircleCI config.

Thanks @dlaynes for bringing it to my attention! Hope this answers your question.