### PR TITLE
Fix issue where yarn was required when it shouldn't be

### DIFF
--- a/boilerplate/app/models/character/character.test.ts
+++ b/boilerplate/app/models/character/character.test.ts
@@ -3,7 +3,7 @@ import { CharacterModel } from "./character"
 test("can be created", () => {
   const instance = CharacterModel.create({
     id: 1,
-    name: "Rick Sanchez"
+    name: "Rick Sanchez",
   })
 
   expect(instance).toBeTruthy()

--- a/boilerplate/app/models/character/character.ts
+++ b/boilerplate/app/models/character/character.ts
@@ -3,14 +3,12 @@ import { Instance, SnapshotOut, types } from "mobx-state-tree"
 /**
  * Rick and Morty character model.
  */
-export const CharacterModel = types
-  .model("Character")
-  .props({
-    id: types.identifierNumber,
-    name: types.maybe(types.string),
-    status: types.maybe(types.string),
-    image: types.maybe(types.string),
-  })
+export const CharacterModel = types.model("Character").props({
+  id: types.identifierNumber,
+  name: types.maybe(types.string),
+  status: types.maybe(types.string),
+  image: types.maybe(types.string),
+})
 
 type CharacterType = Instance<typeof CharacterModel>
 export interface Character extends CharacterType {}

--- a/boilerplate/app/models/root-store/root-store.ts
+++ b/boilerplate/app/models/root-store/root-store.ts
@@ -1,5 +1,5 @@
 import { Instance, SnapshotOut, types } from "mobx-state-tree"
-import { CharacterStoreModel } from '../character-store/character-store';
+import { CharacterStoreModel } from "../character-store/character-store"
 
 /**
  * A RootStore model.

--- a/boilerplate/app/screens/demo/demo-list-screen.tsx
+++ b/boilerplate/app/screens/demo/demo-list-screen.tsx
@@ -38,7 +38,7 @@ const LIST_TEXT: TextStyle = {
   marginLeft: 10,
 }
 const FLAT_LIST: ViewStyle = {
-  paddingHorizontal: spacing[4]
+  paddingHorizontal: spacing[4],
 }
 
 export const DemoListScreen = observer(function DemoListScreen() {
@@ -70,7 +70,7 @@ export const DemoListScreen = observer(function DemoListScreen() {
         <FlatList
           contentContainerStyle={FLAT_LIST}
           data={characters}
-          keyExtractor={item => String(item.id)}
+          keyExtractor={(item) => String(item.id)}
           renderItem={({ item }) => (
             <View style={LIST_CONTAINER}>
               <Image source={{ uri: item.image }} style={IMAGE} />

--- a/boilerplate/app/screens/demo/demo-screen.tsx
+++ b/boilerplate/app/screens/demo/demo-screen.tsx
@@ -154,11 +154,11 @@ export const DemoScreen = observer(function DemoScreen() {
           <Text style={HINT} tx={`demoScreen.${Platform.OS}ReactotronHint`} />
         </View>
         <Button
-            style={DEMO}
-            textStyle={DEMO_TEXT}
-            tx="demoScreen.demoList"
-            onPress={() => navigation.navigate('demoList')}
-          />
+          style={DEMO}
+          textStyle={DEMO_TEXT}
+          tx="demoScreen.demoList"
+          onPress={() => navigation.navigate("demoList")}
+        />
         <Image source={logoIgnite} style={IGNITE} />
         <View style={LOVE_WRAPPER}>
           <Text style={LOVE} text="Made with" />

--- a/boilerplate/app/services/api/api.types.ts
+++ b/boilerplate/app/services/api/api.types.ts
@@ -1,5 +1,5 @@
 import { GeneralApiProblem } from "./api-problem"
-import { Character } from '../../models/character/character';
+import { Character } from "../../models/character/character"
 
 export interface User {
   id: number
@@ -8,7 +8,6 @@ export interface User {
 
 export type GetUsersResult = { kind: "ok"; users: User[] } | GeneralApiProblem
 export type GetUserResult = { kind: "ok"; user: User } | GeneralApiProblem
-
 
 export type GetCharactersResult = { kind: "ok"; characters: Character[] } | GeneralApiProblem
 export type GetCharacterResult = { kind: "ok"; character: Character } | GeneralApiProblem

--- a/boilerplate/app/services/api/character-api.ts
+++ b/boilerplate/app/services/api/character-api.ts
@@ -1,6 +1,6 @@
 import { ApiResponse } from "apisauce"
 import { Api } from "./api"
-import { GetCharactersResult } from './api.types'
+import { GetCharactersResult } from "./api.types"
 import { getGeneralApiProblem } from "./api-problem"
 
 const API_PAGE_SIZE = 50

--- a/src/commands/new.ts
+++ b/src/commands/new.ts
@@ -161,7 +161,8 @@ export default {
     filesystem.remove("package.expo.json")
 
     // Make sure all our modifications are formatted nicely
-    await spawnProgress("yarn format", {})
+    const npmOrYarnRun = packager.is("yarn") ? "yarn" : "npm run"
+    await spawnProgress(`${npmOrYarnRun} format`, {})
 
     // commit any changes
     if (parameters.options.git !== false) {
@@ -189,7 +190,7 @@ export default {
     direction(`To get started:`)
     command(`  cd ${projectName}`)
     if (expo) {
-      command(`  yarn start`)
+      command(`  ${npmOrYarnRun} start`)
     } else {
       if (process.platform === "darwin") {
         command(`  npx react-native run-ios`)

--- a/src/tools/packager.ts
+++ b/src/tools/packager.ts
@@ -60,9 +60,8 @@ function install() {
   }
 }
 
-function list(
-  options: PackageListOptions = packageListOptions,
-): [string, (string) => [string, string][]] {
+type PackageListOutput = [string, (string) => [string, string][]]
+function list(options: PackageListOptions = packageListOptions): PackageListOutput {
   if (options.packager === "yarn" || (options.packager === undefined && yarn())) {
     return [
       `yarn${options.global ? " global" : ""} list`,
@@ -116,4 +115,5 @@ export const packager = {
     const [cmd, parseFn] = list(options)
     return parseFn(await spawnProgress(cmd, {}))
   },
+  is: (packageManager: "yarn" | "npm"): boolean => (packageManager === "yarn" ? yarn() : !yarn()),
 }


### PR DESCRIPTION
The `new` command was assuming `yarn` is installed. This PR fixes that and adds another method to the `packager` module, `packager.is("yarn" | "npm")`.

Fixes #1597.