### PR TITLE
Add .styles to barrel export exception

### DIFF
--- a/src/tools/generators.ts
+++ b/src/tools/generators.ts
@@ -169,7 +169,8 @@ export function generateFromTemplate(generator: string, options: GeneratorOption
       !options.skipIndexFile &&
       hasIndex &&
       !filename.includes(".test") &&
-      !filename.includes(".story")
+      !filename.includes(".story") &&
+      !filename.includes(".styles")
     ) {
       const basename = filename.split(".")[0]
       const exportLine = `export * from "./${kebabCaseName}/${basename}"\n`


### PR DESCRIPTION
## Please verify the following:

- [x] `yarn ci:test` **jest** tests pass with new tests, if relevant
- [x] `README.md` has been updated with your changes, if relevant

## Describe your PR

- Adds an exception to exclude adding files containing name `.styles` to `index.ts` in `generators.ts`. This is needed to avoid manual deletion of styles file from index.ts if we add a custom template to generate separate styles file.
