### PR TITLE
Add tx types for autocomplete

### DIFF
--- a/boilerplate/app/components/button/button.props.ts
+++ b/boilerplate/app/components/button/button.props.ts
@@ -1,11 +1,12 @@
 import { ViewStyle, TextStyle, TouchableOpacityProps } from "react-native"
 import { ButtonPresetNames } from "./button.presets"
+import { TxKeyPath } from "../../i18n"
 
 export interface ButtonProps extends TouchableOpacityProps {
   /**
    * Text which is looked up via i18n.
    */
-  tx?: string
+  tx?: TxKeyPath
 
   /**
    * The text to display if not using `tx` or nested components.

--- a/boilerplate/app/components/checkbox/checkbox.props.ts
+++ b/boilerplate/app/components/checkbox/checkbox.props.ts
@@ -1,4 +1,5 @@
 import { ViewStyle } from "react-native"
+import { TxKeyPath } from "../../i18n"
 
 export interface CheckboxProps {
   /**
@@ -29,7 +30,7 @@ export interface CheckboxProps {
   /**
    * The i18n lookup key.
    */
-  tx?: string
+  tx?: TxKeyPath
 
   /**
    * Multiline or clipped single line?

--- a/boilerplate/app/components/header/header.props.ts
+++ b/boilerplate/app/components/header/header.props.ts
@@ -1,11 +1,12 @@
 import { ViewStyle, TextStyle } from "react-native"
 import { IconTypes } from "../icon/icons"
+import { TxKeyPath } from "../../i18n"
 
 export interface HeaderProps {
   /**
    * Main header, e.g. POWERED BY IGNITE
    */
-  headerTx?: string
+  headerTx?: TxKeyPath
 
   /**
    * header non-i18n

--- a/boilerplate/app/components/text-field/text-field.tsx
+++ b/boilerplate/app/components/text-field/text-field.tsx
@@ -1,7 +1,7 @@
 import React from "react"
 import { TextInput, TextInputProps, TextStyle, View, ViewStyle } from "react-native"
 import { color, spacing, typography } from "../../theme"
-import { translate } from "../../i18n"
+import { translate, TxKeyPath } from "../../i18n"
 import { Text } from "../text/text"
 import { mergeAll, flatten } from "ramda"
 
@@ -28,7 +28,7 @@ export interface TextFieldProps extends TextInputProps {
   /**
    * The placeholder i18n key.
    */
-  placeholderTx?: string
+  placeholderTx?: TxKeyPath
 
   /**
    * The Placeholder text if no placeholderTx is provided.
@@ -38,7 +38,7 @@ export interface TextFieldProps extends TextInputProps {
   /**
    * The label i18n key.
    */
-  labelTx?: string
+  labelTx?: TxKeyPath
 
   /**
    * The label text if no labelTx is provided.

--- a/boilerplate/app/components/text/text.props.ts
+++ b/boilerplate/app/components/text/text.props.ts
@@ -1,5 +1,6 @@
 import { TextStyle, TextProps as TextProperties } from "react-native"
 import { TextPresets } from "./text.presets"
+import { TxKeyPath } from "../../i18n"
 
 export interface TextProps extends TextProperties {
   /**
@@ -10,7 +11,7 @@ export interface TextProps extends TextProperties {
   /**
    * Text which is looked up via i18n.
    */
-  tx?: string
+  tx?: TxKeyPath
 
   /**
    * Optional options to pass to i18n. Useful for interpolation

--- a/boilerplate/app/i18n/en.json
+++ b/boilerplate/app/i18n/en.json
@@ -19,7 +19,10 @@
     "reactotron": "Demo Reactotron",
     "demoList": "Demo List",
     "androidReactotronHint": "If this doesn't work, ensure the Reactotron desktop app is running, run adb reverse tcp:9090 tcp:9090 from your terminal, and reload the app.",
-    "iosReactotronHint": "If this doesn't work, ensure the Reactotron desktop app is running and reload app."
+    "iosReactotronHint": "If this doesn't work, ensure the Reactotron desktop app is running and reload app.",
+    "macosReactotronHint": "If this doesn't work, ensure the Reactotron desktop app is running and reload app.",
+    "webReactotronHint": "If this doesn't work, ensure the Reactotron desktop app is running and reload app.",
+    "windowsReactotronHint": "If this doesn't work, ensure the Reactotron desktop app is running and reload app."
   },
   "demoListScreen": {
     "title": "Demo List"

--- a/boilerplate/app/i18n/i18n.ts
+++ b/boilerplate/app/i18n/i18n.ts
@@ -1,10 +1,22 @@
 import * as Localization from "expo-localization"
 import i18n from "i18n-js"
-
-const en = require("./en")
-const ja = require("./ja")
+import en from "./en.json"
+import ja from "./ja.json"
 
 i18n.fallbacks = true
 i18n.translations = { en, ja }
 
 i18n.locale = Localization.locale || "en"
+
+/**
+ * Builds up valid keypaths for translations.
+ * Update to your default locale of choice if not English.
+ */
+type DefaultLocale = typeof en
+export type TxKeyPath = RecursiveKeyOf<DefaultLocale>
+
+type RecursiveKeyOf<TObj extends Record<string, any>> = {
+  [TKey in keyof TObj & string]: TObj[TKey] extends Record<string, any>
+    ? `${TKey}` | `${TKey}.${RecursiveKeyOf<TObj[TKey]>}`
+    : `${TKey}`
+}[keyof TObj & string]

--- a/boilerplate/app/i18n/index.ts
+++ b/boilerplate/app/i18n/index.ts
@@ -1,2 +1,3 @@
 import "./i18n"
+export * from "./i18n"
 export * from "./translate"

--- a/boilerplate/app/i18n/translate.ts
+++ b/boilerplate/app/i18n/translate.ts
@@ -1,10 +1,11 @@
 import i18n from "i18n-js"
+import { TxKeyPath } from "./i18n"
 
 /**
  * Translates text.
  *
  * @param key The i18n key.
  */
-export function translate(key: string, options?: I18n.TranslateOptions) {
+export function translate(key: TxKeyPath, options?: I18n.TranslateOptions) {
   return key ? i18n.t(key, options) : null
 }

--- a/boilerplate/app/screens/demo/demo-screen.tsx
+++ b/boilerplate/app/screens/demo/demo-screen.tsx
@@ -151,7 +151,7 @@ export const DemoScreen = observer(function DemoScreen() {
             tx="demoScreen.reactotron"
             onPress={demoReactotron}
           />
-          <Text style={HINT} tx={`demoScreen.${Platform.OS}ReactotronHint`} />
+          <Text style={HINT} tx={`demoScreen.${Platform.OS}ReactotronHint` as const} />
         </View>
         <Button
           style={DEMO}

--- a/boilerplate/ios/HelloWorld.xcodeproj/project.pbxproj
+++ b/boilerplate/ios/HelloWorld.xcodeproj/project.pbxproj
@@ -210,6 +210,7 @@
 				00E356EB1AD99517003FC87E /* Frameworks */,
 				00E356EC1AD99517003FC87E /* Resources */,
 				821B8C042C64835F8AA180E7 /* [CP] Copy Pods Resources */,
+				0383829FCA59FA159DCC2589 /* [CP] Embed Pods Frameworks */,
 			);
 			buildRules = (
 			);
@@ -232,6 +233,7 @@
 				13B07F8E1A680F5B00A75B9A /* Resources */,
 				00DD1BFF1BD5951E006B06BC /* Bundle React Native code and images */,
 				105C9A386D6F7A14EE348052 /* [CP] Copy Pods Resources */,
+				EEC804BC5B13E8CB8393A370 /* [CP] Embed Pods Frameworks */,
 			);
 			buildRules = (
 			);
@@ -377,6 +379,24 @@
 			shellPath = /bin/sh;
 			shellScript = "export NODE_BINARY=node\n../node_modules/react-native/scripts/react-native-xcode.sh";
 		};
+		0383829FCA59FA159DCC2589 /* [CP] Embed Pods Frameworks */ = {
+			isa = PBXShellScriptBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			inputPaths = (
+				"${PODS_ROOT}/Target Support Files/Pods-HelloWorld-HelloWorldTests/Pods-HelloWorld-HelloWorldTests-frameworks.sh",
+				"${PODS_XCFRAMEWORKS_BUILD_DIR}/OpenSSL/OpenSSL.framework/OpenSSL",
+			);
+			name = "[CP] Embed Pods Frameworks";
+			outputPaths = (
+				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/OpenSSL.framework",
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+			shellPath = /bin/sh;
+			shellScript = "\"${PODS_ROOT}/Target Support Files/Pods-HelloWorld-HelloWorldTests/Pods-HelloWorld-HelloWorldTests-frameworks.sh\"\n";
+			showEnvVarsInLog = 0;
+		};
 		105C9A386D6F7A14EE348052 /* [CP] Copy Pods Resources */ = {
 			isa = PBXShellScriptBuildPhase;
 			buildActionMask = 2147483647;
@@ -513,6 +533,24 @@
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
 			shellScript = "diff \"${PODS_PODFILE_DIR_PATH}/Podfile.lock\" \"${PODS_ROOT}/Manifest.lock\" > /dev/null\nif [ $? != 0 ] ; then\n    # print error to STDERR\n    echo \"error: The sandbox is not in sync with the Podfile.lock. Run 'pod install' or update your CocoaPods installation.\" >&2\n    exit 1\nfi\n# This output is used by Xcode 'outputs' to avoid re-running this script phase.\necho \"SUCCESS\" > \"${SCRIPT_OUTPUT_FILE_0}\"\n";
+			showEnvVarsInLog = 0;
+		};
+		EEC804BC5B13E8CB8393A370 /* [CP] Embed Pods Frameworks */ = {
+			isa = PBXShellScriptBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			inputPaths = (
+				"${PODS_ROOT}/Target Support Files/Pods-HelloWorld/Pods-HelloWorld-frameworks.sh",
+				"${PODS_XCFRAMEWORKS_BUILD_DIR}/OpenSSL/OpenSSL.framework/OpenSSL",
+			);
+			name = "[CP] Embed Pods Frameworks";
+			outputPaths = (
+				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/OpenSSL.framework",
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+			shellPath = /bin/sh;
+			shellScript = "\"${PODS_ROOT}/Target Support Files/Pods-HelloWorld/Pods-HelloWorld-frameworks.sh\"\n";
 			showEnvVarsInLog = 0;
 		};
 		FD10A7F022414F080027D42C /* Start Packager */ = {

--- a/boilerplate/ios/Podfile.lock
+++ b/boilerplate/ios/Podfile.lock
@@ -1,7 +1,6 @@
 PODS:
   - boost-for-react-native (1.63.0)
-  - CocoaAsyncSocket (7.6.4)
-  - CocoaLibEvent (1.0.0)
+  - CocoaAsyncSocket (7.6.5)
   - DoubleConversion (1.1.6)
   - EXConstants (9.2.0):
     - UMConstantsInterface
@@ -30,16 +29,16 @@ PODS:
     - Flipper-Folly (~> 2.2)
     - Flipper-RSocket (~> 1.1)
   - Flipper-DoubleConversion (1.1.7)
-  - Flipper-Folly (2.2.0):
+  - Flipper-Folly (2.5.1):
     - boost-for-react-native
-    - CocoaLibEvent (~> 1.0)
     - Flipper-DoubleConversion
     - Flipper-Glog
-    - OpenSSL-Universal (= 1.0.2.19)
+    - libevent (~> 2.1.12)
+    - OpenSSL-Universal (= 1.1.180)
   - Flipper-Glog (0.3.6)
   - Flipper-PeerTalk (0.0.4)
-  - Flipper-RSocket (1.1.0):
-    - Flipper-Folly (~> 2.2)
+  - Flipper-RSocket (1.3.1):
+    - Flipper-Folly (~> 2.5)
   - FlipperKit (0.54.0):
     - FlipperKit/Core (= 0.54.0)
   - FlipperKit/Core (0.54.0):
@@ -82,9 +81,8 @@ PODS:
     - DoubleConversion
     - glog
   - glog (0.3.5)
-  - OpenSSL-Universal (1.0.2.19):
-    - OpenSSL-Universal/Static (= 1.0.2.19)
-  - OpenSSL-Universal/Static (1.0.2.19)
+  - libevent (2.1.12)
+  - OpenSSL-Universal (1.1.180)
   - RCTRequired (0.63.4)
   - RCTTypeSafety (0.63.4):
     - FBLazyVector (= 0.63.4)
@@ -424,7 +422,6 @@ SPEC REPOS:
   trunk:
     - boost-for-react-native
     - CocoaAsyncSocket
-    - CocoaLibEvent
     - Flipper
     - Flipper-DoubleConversion
     - Flipper-Folly
@@ -432,6 +429,7 @@ SPEC REPOS:
     - Flipper-PeerTalk
     - Flipper-RSocket
     - FlipperKit
+    - libevent
     - OpenSSL-Universal
     - YogaKit
 
@@ -541,8 +539,7 @@ EXTERNAL SOURCES:
 
 SPEC CHECKSUMS:
   boost-for-react-native: 39c7adb57c4e60d6c5479dd8623128eb5b3f0f2c
-  CocoaAsyncSocket: 694058e7c0ed05a9e217d1b3c7ded962f4180845
-  CocoaLibEvent: 2fab71b8bd46dd33ddb959f7928ec5909f838e3f
+  CocoaAsyncSocket: 065fd1e645c7abab64f7a6a2007a48038fdc6a99
   DoubleConversion: cde416483dac037923206447da6e1454df403714
   EXConstants: f486f6b4a36b86e47ab258d4d2b7b2699786fdce
   EXFileSystem: afe9b1fd937d30270bf5108ba44e2f4a1d1ad694
@@ -553,14 +550,15 @@ SPEC CHECKSUMS:
   FBReactNativeSpec: f2c97f2529dd79c083355182cc158c9f98f4bd6e
   Flipper: be611d4b742d8c87fbae2ca5f44603a02539e365
   Flipper-DoubleConversion: 38631e41ef4f9b12861c67d17cb5518d06badc41
-  Flipper-Folly: c12092ea368353b58e992843a990a3225d4533c3
+  Flipper-Folly: f7a3caafbd74bda4827954fd7a6e000e36355489
   Flipper-Glog: 1dfd6abf1e922806c52ceb8701a3599a79a200a6
   Flipper-PeerTalk: 116d8f857dc6ef55c7a5a75ea3ceaafe878aadc9
-  Flipper-RSocket: 64e7431a55835eb953b0bf984ef3b90ae9fdddd7
+  Flipper-RSocket: 127954abe8b162fcaf68d2134d34dc2bd7076154
   FlipperKit: ab353d41aea8aae2ea6daaf813e67496642f3d7d
   Folly: b73c3869541e86821df3c387eb0af5f65addfab4
   glog: 40a13f7840415b9a77023fbcae0f1e6f43192af3
-  OpenSSL-Universal: 8b48cc0d10c1b2923617dfe5c178aa9ed2689355
+  libevent: 4049cae6c81cdb3654a443be001fb9bdceff7913
+  OpenSSL-Universal: 1aa4f6a6ee7256b83db99ec1ccdaa80d10f9af9b
   RCTRequired: 082f10cd3f905d6c124597fd1c14f6f2655ff65e
   RCTTypeSafety: 8c9c544ecbf20337d069e4ae7fd9a377aadf504b
   React: b0a957a2c44da4113b0c4c9853d8387f8e64e615
@@ -606,4 +604,4 @@ SPEC CHECKSUMS:
 
 PODFILE CHECKSUM: d4ede385777da40f250b2cd7bd8a64e967f89b74
 
-COCOAPODS: 1.8.4
+COCOAPODS: 1.10.1

--- a/boilerplate/ios/Podfile.lock
+++ b/boilerplate/ios/Podfile.lock
@@ -315,7 +315,7 @@ PODS:
     - React-Core (= 0.63.4)
     - React-cxxreact (= 0.63.4)
     - React-jsi (= 0.63.4)
-  - RNCAsyncStorage (1.12.1):
+  - RNCAsyncStorage (1.14.1):
     - React-Core
   - RNCMaskedView (0.1.10):
     - React
@@ -400,7 +400,7 @@ DEPENDENCIES:
   - React-RCTText (from `../node_modules/react-native/Libraries/Text`)
   - React-RCTVibration (from `../node_modules/react-native/Libraries/Vibration`)
   - ReactCommon/turbomodule/core (from `../node_modules/react-native/ReactCommon`)
-  - "RNCAsyncStorage (from `../node_modules/@react-native-community/async-storage`)"
+  - "RNCAsyncStorage (from `../node_modules/@react-native-async-storage/async-storage`)"
   - "RNCMaskedView (from `../node_modules/@react-native-community/masked-view`)"
   - RNGestureHandler (from `../node_modules/react-native-gesture-handler`)
   - RNKeychain (from `../node_modules/react-native-keychain`)
@@ -501,7 +501,7 @@ EXTERNAL SOURCES:
   ReactCommon:
     :path: "../node_modules/react-native/ReactCommon"
   RNCAsyncStorage:
-    :path: "../node_modules/@react-native-community/async-storage"
+    :path: "../node_modules/@react-native-async-storage/async-storage"
   RNCMaskedView:
     :path: "../node_modules/@react-native-community/masked-view"
   RNGestureHandler:
@@ -583,7 +583,7 @@ SPEC CHECKSUMS:
   React-RCTText: 5c51df3f08cb9dedc6e790161195d12bac06101c
   React-RCTVibration: ae4f914cfe8de7d4de95ae1ea6cc8f6315d73d9d
   ReactCommon: 73d79c7039f473b76db6ff7c6b159c478acbbb3b
-  RNCAsyncStorage: b03032fdbdb725bea0bd9e5ec5a7272865ae7398
+  RNCAsyncStorage: fe58eec522885718d6b297b7b658bf87d7ca557b
   RNCMaskedView: 5a8ec07677aa885546a0d98da336457e2bea557f
   RNGestureHandler: 7a5833d0f788dbd107fbb913e09aa0c1ff333c39
   RNKeychain: b8e0711b959a19c5b057d1e970d3c83d159b6da5
@@ -606,4 +606,4 @@ SPEC CHECKSUMS:
 
 PODFILE CHECKSUM: d4ede385777da40f250b2cd7bd8a64e967f89b74
 
-COCOAPODS: 1.10.1
+COCOAPODS: 1.8.4

--- a/boilerplate/tsconfig.json
+++ b/boilerplate/tsconfig.json
@@ -13,7 +13,8 @@
     "sourceMap": true,
     "target": "esnext",
     "lib": ["esnext"],
-    "skipLibCheck": true
+    "skipLibCheck": true,
+    "resolveJsonModule": true
   },
   "exclude": ["node_modules"],
   "include": ["index.js", "app", "test", "storybook"]

--- a/boilerplate/yarn.lock
+++ b/boilerplate/yarn.lock
@@ -1612,10 +1612,10 @@
     prop-types "^15.6.1"
     react-lifecycles-compat "^3.0.4"
 
-"@react-native-community/async-storage@1.12.1":
-  version "1.12.1"
-  resolved "https://registry.yarnpkg.com/@react-native-community/async-storage/-/async-storage-1.12.1.tgz#25f821b4f6b13abe005ad67e47c6f1cee9f27b24"
-  integrity sha512-70WGaH3PKYASi4BThuEEKMkyAgE9k7VytBqmgPRx3MzJx9/MkspwqJGmn3QLCgHLIFUgF1pit2mWICbRJ3T3lg==
+"@react-native-async-storage/async-storage@^1.14.1":
+  version "1.14.1"
+  resolved "https://registry.yarnpkg.com/@react-native-async-storage/async-storage/-/async-storage-1.14.1.tgz#3c2ff2b1a312df3b1c809a60fa88665e50a095b8"
+  integrity sha512-UkLUox2q5DKNYB6IMUzsuwrTJeXGLySvtQlnrqd3fd+96JErCT4X3xD+W1cvQjes0nm0LbaELbwObKc+Tea7wA==
   dependencies:
     deep-assign "^3.0.0"
 

--- a/package.json
+++ b/package.json
@@ -64,7 +64,7 @@
     "husky": "^4.3.0",
     "jest": "^26.5.3",
     "npm-run-all": "4.1.5",
-    "prettier": "2.1.2",
+    "prettier": "2.2.1",
     "semantic-release": "^17.2.1",
     "strip-ansi": "^6.0.0",
     "ts-jest": "^26.4.1",


### PR DESCRIPTION
I noticed that none of the tx props were autocompleting. I updated the the tx prop types to use a recursive type built from the default locales json. Now translation keys will autocomplete in VSCode:

<img width="491" alt="Screen Shot 2021-03-25 at 7 44 13 PM" src="https://user-images.githubusercontent.com/53795920/112565341-7d386b80-8da2-11eb-92f1-02a6a66076c0.png">

