### PR TITLE
Add keyboardShouldPersistTaps to screen

### DIFF
--- a/boilerplate/app/components/screen/screen.props.ts
+++ b/boilerplate/app/components/screen/screen.props.ts
@@ -36,4 +36,10 @@ export interface ScreenProps {
    * By how much should we offset the keyboard? Defaults to none.
    */
   keyboardOffset?: KeyboardOffsets
+
+  /**
+   * Should keyboard persist on screen tap. Defaults to handled.
+   * Only applies to scroll preset.
+   */
+  keyboardShouldPersistTaps?: "handled" | "always" | "never"
 }

--- a/boilerplate/app/components/screen/screen.tsx
+++ b/boilerplate/app/components/screen/screen.tsx
@@ -43,6 +43,7 @@ function ScreenWithScrolling(props: ScreenProps) {
         <ScrollView
           style={[preset.outer, backgroundStyle]}
           contentContainerStyle={[preset.inner, style]}
+          keyboardShouldPersistTaps={props.keyboardShouldPersistTaps || "handled"}
         >
           {props.children}
         </ScrollView>

--- a/boilerplate/storybook/views/story.tsx
+++ b/boilerplate/storybook/views/story.tsx
@@ -10,7 +10,9 @@ const ROOT: ViewStyle = { flex: 1 }
 export function Story(props: StoryProps) {
   return (
     <View style={ROOT}>
-      <ScrollView>{props.children}</ScrollView>
+      <ScrollView keyboardShouldPersistTaps="handled">
+        {props.children}
+      </ScrollView>
     </View>
   )
 }


### PR DESCRIPTION
Exposes ScrollView's keyboardShouldPersistTaps prop on Screen component. Sets "handled" as a reasonable default.