### PR TITLE
Modify eslint config to apply prettier config correctly

### DIFF
--- a/boilerplate/package.json
+++ b/boilerplate/package.json
@@ -135,11 +135,12 @@
     "root": true,
     "parser": "@typescript-eslint/parser",
     "extends": [
-      "prettier",
       "plugin:@typescript-eslint/recommended",
       "plugin:react/recommended",
       "plugin:react-native/all",
-      "standard"
+      "standard",
+      "prettier",
+      "prettier/@typescript-eslint"
     ],
     "plugins": [
       "@typescript-eslint",


### PR DESCRIPTION
Refer to [readme](https://github.com/prettier/eslint-config-prettier/tree/v7.0.0) of eslint-config-prettier, they require the `"prettier"` config must to be last to override other configs.

Moreover, there is a conflict between eslint rule `@typescript-eslint/no-extra-semi` and prettier's rule. It can be checked by command `npx eslint-config-prettier ./app/app.tsx` and the output is:
```
The following rules are unnecessary or might conflict with Prettier:

- @typescript-eslint/no-extra-semi
```
In current used version (eslint-config-prettier v7.0.0), we can fix it by adding additional config `"prettier/@typescript-eslint"`. But an easier way is just update it to the latest version, after v8.0.0 it applies all configs by default.