### PR TITLE
Improve types for button.presets.ts

### DIFF
--- a/boilerplate/app/components/button/button.presets.ts
+++ b/boilerplate/app/components/button/button.presets.ts
@@ -21,7 +21,7 @@ const BASE_TEXT: TextStyle = {
  *
  * You want to customize these to whatever you need in your app.
  */
-export const viewPresets = {
+export const viewPresets: Record<string, ViewStyle> = {
   /**
    * A smaller piece of secondard information.
    */
@@ -38,7 +38,7 @@ export const viewPresets = {
   } as ViewStyle,
 }
 
-export const textPresets = {
+export const textPresets: Record<ButtonPresetNames, TextStyle> = {
   primary: { ...BASE_TEXT, fontSize: 9, color: color.palette.white } as TextStyle,
   link: {
     ...BASE_TEXT,


### PR DESCRIPTION
## Please verify the following:

- [x] `yarn ci:test` **jest** tests pass with new tests, if relevant
- [x] `README.md` has been updated with your changes, if relevant

## Describe your PR
Improving the typings on the buttons preset by using `Record<string, VIewStyle | TextStyle>`.

I ran into a cryptic error that took a very long time to debug until I realized one of the custom presets I added in the `textPresets` was not inline-typed with an `as TextStyle`. Putting these top-level types on the object made the blunder easier to spot.