### PR TITLE
Fix keyboard avoid view behaviour

### DIFF
--- a/boilerplate/app/components/screen/screen.tsx
+++ b/boilerplate/app/components/screen/screen.tsx
@@ -16,7 +16,7 @@ function ScreenWithoutScrolling(props: ScreenProps) {
   return (
     <KeyboardAvoidingView
       style={[preset.outer, backgroundStyle]}
-      behavior={isIos ? "padding" : null}
+      behavior={isIos ? "padding" : undefined}
       keyboardVerticalOffset={offsets[props.keyboardOffset || "none"]}
     >
       <StatusBar barStyle={props.statusBar || "light-content"} />
@@ -35,7 +35,7 @@ function ScreenWithScrolling(props: ScreenProps) {
   return (
     <KeyboardAvoidingView
       style={[preset.outer, backgroundStyle]}
-      behavior={isIos ? "padding" : null}
+      behavior={isIos ? "padding" : undefined}
       keyboardVerticalOffset={offsets[props.keyboardOffset || "none"]}
     >
       <StatusBar barStyle={props.statusBar || "light-content"} />

--- a/boilerplate/storybook/views/story-screen.tsx
+++ b/boilerplate/storybook/views/story-screen.tsx
@@ -7,7 +7,7 @@ export interface StoryScreenProps {
   children?: React.ReactNode
 }
 
-const behavior = Platform.OS === "ios" ? "padding" : null
+const behavior = Platform.OS === "ios" ? "padding" : undefined
 export const StoryScreen = (props) => (
   <KeyboardAvoidingView style={ROOT} behavior={behavior} keyboardVerticalOffset={50}>
     {props.children}


### PR DESCRIPTION
## Please verify the following:

- [x] `yarn ci:test` **jest** tests pass with new tests, if relevant
- [x] `README.md` has been updated with your changes, if relevant

## Describe your PR
Fix the values passed to KeyboardAvoidingView `behaviour` prop.

As per React Native documentation `behaviour` is an enum ([link](https://reactnative.dev/docs/keyboardavoidingview#behavior)) which means one of the values must be provided. In case there is no need to use behaviour, the correct value should be `undefined`.

Please see screenshot below for the TS warning:
![image](https://user-images.githubusercontent.com/394966/113581178-b385ae80-961e-11eb-9643-ce9ea66df399.png)
