### PR TITLE
Fix style prop types

### DIFF
--- a/boilerplate/app/components/button/button.props.ts
+++ b/boilerplate/app/components/button/button.props.ts
@@ -1,4 +1,4 @@
-import { ViewStyle, TextStyle, TouchableOpacityProps } from "react-native"
+import { StyleProp, TextStyle, TouchableOpacityProps, ViewStyle } from "react-native"
 import { ButtonPresetNames } from "./button.presets"
 import { TxKeyPath } from "../../i18n"
 
@@ -16,12 +16,12 @@ export interface ButtonProps extends TouchableOpacityProps {
   /**
    * An optional style override useful for padding & margin.
    */
-  style?: ViewStyle | ViewStyle[]
+  style?: StyleProp<ViewStyle>
 
   /**
    * An optional style override useful for the button text.
    */
-  textStyle?: TextStyle | TextStyle[]
+  textStyle?: StyleProp<TextStyle>
 
   /**
    * One of the different types of text presets.

--- a/boilerplate/app/components/button/button.tsx
+++ b/boilerplate/app/components/button/button.tsx
@@ -3,7 +3,7 @@ import { TouchableOpacity } from "react-native"
 import { Text } from "../text/text"
 import { viewPresets, textPresets } from "./button.presets"
 import { ButtonProps } from "./button.props"
-import { mergeAll, flatten } from "ramda"
+import { flatten } from "ramda"
 
 /**
  * For your text displaying needs.
@@ -22,15 +22,15 @@ export function Button(props: ButtonProps) {
     ...rest
   } = props
 
-  const viewStyle = mergeAll(flatten([viewPresets[preset] || viewPresets.primary, styleOverride]))
-  const textStyle = mergeAll(
-    flatten([textPresets[preset] || textPresets.primary, textStyleOverride]),
-  )
+  const viewStyle = viewPresets[preset] || viewPresets.primary
+  const viewStyles = flatten([viewStyle, styleOverride])
+  const textStyle = textPresets[preset] || textPresets.primary
+  const textStyles = flatten([textStyle, textStyleOverride])
 
-  const content = children || <Text tx={tx} text={text} style={textStyle} />
+  const content = children || <Text tx={tx} text={text} style={textStyles} />
 
   return (
-    <TouchableOpacity style={viewStyle} {...rest}>
+    <TouchableOpacity style={viewStyles} {...rest}>
       {content}
     </TouchableOpacity>
   )

--- a/boilerplate/app/components/checkbox/checkbox.props.ts
+++ b/boilerplate/app/components/checkbox/checkbox.props.ts
@@ -1,21 +1,21 @@
-import { ViewStyle } from "react-native"
+import { StyleProp, ViewStyle } from "react-native"
 import { TxKeyPath } from "../../i18n"
 
 export interface CheckboxProps {
   /**
    * Additional container style. Useful for margins.
    */
-  style?: ViewStyle | ViewStyle[]
+  style?: StyleProp<ViewStyle>
 
   /**
    * Additional outline style.
    */
-  outlineStyle?: ViewStyle | ViewStyle[]
+  outlineStyle?: StyleProp<ViewStyle>
 
   /**
    * Additional fill style. Only visible when checked.
    */
-  fillStyle?: ViewStyle | ViewStyle[]
+  fillStyle?: StyleProp<ViewStyle>
 
   /**
    * Is the checkbox checked?

--- a/boilerplate/app/components/checkbox/checkbox.tsx
+++ b/boilerplate/app/components/checkbox/checkbox.tsx
@@ -1,9 +1,9 @@
 import * as React from "react"
-import { TouchableOpacity, TextStyle, ViewStyle, View } from "react-native"
+import { TextStyle, TouchableOpacity, View, ViewStyle } from "react-native"
 import { Text } from "../text/text"
 import { color, spacing } from "../../theme"
 import { CheckboxProps } from "./checkbox.props"
-import { mergeAll, flatten } from "ramda"
+import { flatten } from "ramda"
 
 const ROOT: ViewStyle = {
   flexDirection: "row",
@@ -34,9 +34,9 @@ const LABEL: TextStyle = { paddingLeft: spacing[2] }
 export function Checkbox(props: CheckboxProps) {
   const numberOfLines = props.multiline ? 0 : 1
 
-  const rootStyle = mergeAll(flatten([ROOT, props.style]))
-  const outlineStyle = mergeAll(flatten([OUTLINE, props.outlineStyle]))
-  const fillStyle = mergeAll(flatten([FILL, props.fillStyle]))
+  const rootStyle = flatten([ROOT, props.style])
+  const outlineStyle = flatten([OUTLINE, props.outlineStyle])
+  const fillStyle = flatten([FILL, props.fillStyle])
 
   const onPress = props.onToggle ? () => props.onToggle && props.onToggle(!props.value) : null
 

--- a/boilerplate/app/components/form-row/form-row.props.tsx
+++ b/boilerplate/app/components/form-row/form-row.props.tsx
@@ -1,5 +1,5 @@
 import * as React from "react"
-import { ViewStyle } from "react-native"
+import { StyleProp, ViewStyle } from "react-native"
 import { FormRowPresets } from "./form-row.presets"
 
 /**
@@ -14,7 +14,7 @@ export interface FormRowProps {
   /**
    * Override the container style... useful for margins and padding.
    */
-  style?: ViewStyle | ViewStyle[]
+  style?: StyleProp<ViewStyle>
 
   /**
    * The type of border.

--- a/boilerplate/app/components/form-row/form-row.tsx
+++ b/boilerplate/app/components/form-row/form-row.tsx
@@ -2,13 +2,13 @@ import * as React from "react"
 import { View } from "react-native"
 import { PRESETS } from "./form-row.presets"
 import { FormRowProps } from "./form-row.props"
-import { mergeAll, flatten } from "ramda"
+import { flatten } from "ramda"
 
 /**
  * A horizontal container component used to hold a row of a form.
  */
 export function FormRow(props: FormRowProps) {
-  const viewStyle = mergeAll(flatten([PRESETS[props.preset], props.style]))
+  const viewStyle = flatten([PRESETS[props.preset], props.style])
 
   return <View style={viewStyle}>{props.children}</View>
 }

--- a/boilerplate/app/components/header/header.props.ts
+++ b/boilerplate/app/components/header/header.props.ts
@@ -1,4 +1,4 @@
-import { ViewStyle, TextStyle } from "react-native"
+import { StyleProp, TextStyle, ViewStyle } from "react-native"
 import { IconTypes } from "../icon/icons"
 import { TxKeyPath } from "../../i18n"
 
@@ -36,10 +36,10 @@ export interface HeaderProps {
   /**
    * Container style overrides.
    */
-  style?: ViewStyle
+  style?: StyleProp<ViewStyle>
 
   /**
    * Title style overrides.
    */
-  titleStyle?: TextStyle
+  titleStyle?: StyleProp<TextStyle>
 }

--- a/boilerplate/app/components/header/header.tsx
+++ b/boilerplate/app/components/header/header.tsx
@@ -38,7 +38,7 @@ export function Header(props: HeaderProps) {
   const header = headerText || (headerTx && translate(headerTx)) || ""
 
   return (
-    <View style={{ ...ROOT, ...style }}>
+    <View style={[ROOT, style]}>
       {leftIcon ? (
         <Button preset="link" onPress={onLeftPress}>
           <Icon icon={leftIcon} />
@@ -47,7 +47,7 @@ export function Header(props: HeaderProps) {
         <View style={LEFT} />
       )}
       <View style={TITLE_MIDDLE}>
-        <Text style={{ ...TITLE, ...titleStyle }} text={header} />
+        <Text style={[TITLE, titleStyle]} text={header} />
       </View>
       {rightIcon ? (
         <Button preset="link" onPress={onRightPress}>

--- a/boilerplate/app/components/icon/icon.props.ts
+++ b/boilerplate/app/components/icon/icon.props.ts
@@ -1,17 +1,17 @@
-import { ImageStyle, ViewStyle } from "react-native"
+import { ImageStyle, StyleProp, ViewStyle } from "react-native"
 import { IconTypes } from "./icons"
 
 export interface IconProps {
   /**
    * Style overrides for the icon image
    */
-  style?: ImageStyle
+  style?: StyleProp<ImageStyle>
 
   /**
    * Style overrides for the icon container
    */
 
-  containerStyle?: ViewStyle
+  containerStyle?: StyleProp<ViewStyle>
 
   /**
    * The name of the icon

--- a/boilerplate/app/components/icon/icon.tsx
+++ b/boilerplate/app/components/icon/icon.tsx
@@ -9,11 +9,10 @@ const ROOT: ImageStyle = {
 
 export function Icon(props: IconProps) {
   const { style: styleOverride, icon, containerStyle } = props
-  const style: ImageStyle = { ...ROOT, ...styleOverride }
 
   return (
     <View style={containerStyle}>
-      <Image style={style} source={icons[icon]} />
+      <Image style={[ROOT, styleOverride]} source={icons[icon]} />
     </View>
   )
 }

--- a/boilerplate/app/components/screen/screen.props.ts
+++ b/boilerplate/app/components/screen/screen.props.ts
@@ -1,4 +1,4 @@
-import { ViewStyle } from "react-native"
+import { StyleProp, ViewStyle } from "react-native"
 import { KeyboardOffsets, ScreenPresets } from "./screen.presets"
 
 export interface ScreenProps {
@@ -10,7 +10,7 @@ export interface ScreenProps {
   /**
    * An optional style override useful for padding & margin.
    */
-  style?: ViewStyle
+  style?: StyleProp<ViewStyle>
 
   /**
    * One of the different types of presets.

--- a/boilerplate/app/components/switch/switch.props.ts
+++ b/boilerplate/app/components/switch/switch.props.ts
@@ -1,4 +1,4 @@
-import { ViewStyle } from "react-native"
+import { StyleProp, ViewStyle } from "react-native"
 
 export interface SwitchProps {
   /**
@@ -15,25 +15,25 @@ export interface SwitchProps {
   /**
    * A style override to apply to the container.  Useful for margins and paddings.
    */
-  style?: ViewStyle | ViewStyle[]
+  style?: StyleProp<ViewStyle>
 
   /**
    * Additional track styling when on.
    */
-  trackOnStyle?: ViewStyle | ViewStyle[]
+  trackOnStyle?: StyleProp<ViewStyle>
 
   /**
    * Additional track styling when off.
    */
-  trackOffStyle?: ViewStyle | ViewStyle[]
+  trackOffStyle?: StyleProp<ViewStyle>
 
   /**
    * Additional thumb styling when on.
    */
-  thumbOnStyle?: ViewStyle | ViewStyle[]
+  thumbOnStyle?: StyleProp<ViewStyle>
 
   /**
    * Additional thumb styling when off.
    */
-  thumbOffStyle?: ViewStyle | ViewStyle[]
+  thumbOffStyle?: StyleProp<ViewStyle>
 }

--- a/boilerplate/app/components/switch/switch.tsx
+++ b/boilerplate/app/components/switch/switch.tsx
@@ -2,7 +2,7 @@ import React from "react"
 import { ViewStyle, Animated, Easing, TouchableWithoutFeedback } from "react-native"
 import { color } from "../../theme"
 import { SwitchProps } from "./switch.props"
-import { mergeAll, flatten } from "ramda"
+import { flatten } from "ramda"
 
 // dimensions
 const THUMB_SIZE = 30
@@ -47,7 +47,7 @@ const THUMB: ViewStyle = {
 }
 
 const enhance = (style, newStyles): any => {
-  return mergeAll(flatten([style, newStyles]))
+  return flatten([style, newStyles])
 }
 
 const makeAnimatedValue = (switchOn) => new Animated.Value(switchOn ? 1 : 0)

--- a/boilerplate/app/components/text-field/text-field.tsx
+++ b/boilerplate/app/components/text-field/text-field.tsx
@@ -1,9 +1,9 @@
 import React from "react"
-import { TextInput, TextInputProps, TextStyle, View, ViewStyle } from "react-native"
+import { StyleProp, TextInput, TextInputProps, TextStyle, View, ViewStyle } from "react-native"
 import { color, spacing, typography } from "../../theme"
 import { translate, TxKeyPath } from "../../i18n"
 import { Text } from "../text/text"
-import { mergeAll, flatten } from "ramda"
+import { flatten } from "ramda"
 
 // the base styling for the container
 const CONTAINER: ViewStyle = {
@@ -48,12 +48,12 @@ export interface TextFieldProps extends TextInputProps {
   /**
    * Optional container style overrides useful for margins & padding.
    */
-  style?: ViewStyle | ViewStyle[]
+  style?: StyleProp<ViewStyle>
 
   /**
    * Optional style overrides for the input.
    */
-  inputStyle?: TextStyle | TextStyle[]
+  inputStyle?: StyleProp<TextStyle>
 
   /**
    * Various look & feels.
@@ -61,10 +61,6 @@ export interface TextFieldProps extends TextInputProps {
   preset?: keyof typeof PRESETS
 
   forwardedRef?: any
-}
-
-const enhance = (style, styleOverride) => {
-  return mergeAll(flatten([style, styleOverride]))
 }
 
 /**
@@ -82,22 +78,20 @@ export function TextField(props: TextFieldProps) {
     forwardedRef,
     ...rest
   } = props
-  let containerStyle: ViewStyle = { ...CONTAINER, ...PRESETS[preset] }
-  containerStyle = enhance(containerStyle, styleOverride)
 
-  let inputStyle: TextStyle = INPUT
-  inputStyle = enhance(inputStyle, inputStyleOverride)
+  const containerStyles = flatten([CONTAINER, PRESETS[preset], styleOverride])
+  const inputStyles = flatten([INPUT, inputStyleOverride])
   const actualPlaceholder = placeholderTx ? translate(placeholderTx) : placeholder
 
   return (
-    <View style={containerStyle}>
+    <View style={containerStyles}>
       <Text preset="fieldLabel" tx={labelTx} text={label} />
       <TextInput
         placeholder={actualPlaceholder}
         placeholderTextColor={color.palette.lighterGrey}
         underlineColorAndroid={color.transparent}
         {...rest}
-        style={inputStyle}
+        style={inputStyles}
         ref={forwardedRef}
       />
     </View>

--- a/boilerplate/app/components/text/text.props.ts
+++ b/boilerplate/app/components/text/text.props.ts
@@ -1,4 +1,4 @@
-import { TextStyle, TextProps as TextProperties } from "react-native"
+import { StyleProp, TextProps as TextProperties, TextStyle } from "react-native"
 import { TextPresets } from "./text.presets"
 import { TxKeyPath } from "../../i18n"
 
@@ -27,7 +27,7 @@ export interface TextProps extends TextProperties {
   /**
    * An optional style override useful for padding & margin.
    */
-  style?: TextStyle | TextStyle[]
+  style?: StyleProp<TextStyle>
 
   /**
    * One of the different types of text presets.

--- a/boilerplate/app/components/text/text.tsx
+++ b/boilerplate/app/components/text/text.tsx
@@ -3,7 +3,7 @@ import { Text as ReactNativeText } from "react-native"
 import { presets } from "./text.presets"
 import { TextProps } from "./text.props"
 import { translate } from "../../i18n"
-import { mergeAll, flatten } from "ramda"
+import { flatten } from "ramda"
 
 /**
  * For your text displaying needs.
@@ -18,10 +18,11 @@ export function Text(props: TextProps) {
   const i18nText = tx && translate(tx, txOptions)
   const content = i18nText || text || children
 
-  const style = mergeAll(flatten([presets[preset] || presets.default, styleOverride]))
+  const style = presets[preset] || presets.default
+  const styles = flatten([style, styleOverride])
 
   return (
-    <ReactNativeText {...rest} style={style}>
+    <ReactNativeText {...rest} style={styles}>
       {content}
     </ReactNativeText>
   )

--- a/boilerplate/app/components/wallpaper/wallpaper.props.ts
+++ b/boilerplate/app/components/wallpaper/wallpaper.props.ts
@@ -1,11 +1,11 @@
-import { ImageStyle } from "react-native"
+import { ImageStyle, StyleProp } from "react-native"
 import { WallpaperPresets } from "./wallpaper.presets"
 
 export interface WallpaperProps {
   /**
    * An optional style override useful for padding & margin.
    */
-  style?: ImageStyle
+  style?: StyleProp<ImageStyle>
 
   /**
    * An optional background image to override the default image.

--- a/boilerplate/app/components/wallpaper/wallpaper.tsx
+++ b/boilerplate/app/components/wallpaper/wallpaper.tsx
@@ -2,6 +2,7 @@ import React from "react"
 import { Image } from "react-native"
 import { presets } from "./wallpaper.presets"
 import { WallpaperProps } from "./wallpaper.props"
+import { flatten } from "ramda"
 
 const defaultImage = require("./bg.png")
 
@@ -16,10 +17,10 @@ export function Wallpaper(props: WallpaperProps) {
 
   // assemble the style
   const presetToUse = presets[preset] || presets.stretch
-  const style = { ...presetToUse, ...styleOverride }
+  const styles = flatten([presetToUse, styleOverride])
 
   // figure out which image to use
   const source = backgroundImage || defaultImage
 
-  return <Image source={source} style={style} />
+  return <Image source={source} style={styles} />
 }

--- a/boilerplate/ignite/templates/component/NAME.tsx.ejs
+++ b/boilerplate/ignite/templates/component/NAME.tsx.ejs
@@ -1,8 +1,9 @@
 import * as React from "react"
-import { TextStyle, View, ViewStyle } from "react-native"
+import { StyleProp, TextStyle, View, ViewStyle } from "react-native"
 import { observer } from "mobx-react-lite"
 import { color, typography } from "../../theme"
 import { Text } from "../"
+import { flatten } from "ramda"
 
 const CONTAINER: ViewStyle = {
   justifyContent: "center",
@@ -18,7 +19,7 @@ export interface <%= props.pascalCaseName %>Props {
   /**
    * An optional style override useful for padding & margin.
    */
-  style?: ViewStyle
+  style?: StyleProp<ViewStyle>
 }
 
 /**
@@ -26,9 +27,10 @@ export interface <%= props.pascalCaseName %>Props {
  */
 export const <%= props.pascalCaseName %> = observer(function <%= props.pascalCaseName %>(props: <%= props.pascalCaseName %>Props) {
   const { style } = props
+  const styles = flatten([CONTAINER, style])
 
   return (
-    <View style={[CONTAINER, style]}>
+    <View style={styles}>
       <Text style={TEXT}>Hello</Text>
     </View>
   )


### PR DESCRIPTION
I discovered that I could not use false in array styles while working on a top secret project:

<img width="693" alt="Screen Shot 2021-04-17 at 7 34 29 PM" src="https://user-images.githubusercontent.com/53795920/115134020-f73ac980-9fc9-11eb-8ae3-1ced4740cf4f.png">

By using react native's `StyleProp` generic we can support array styles just like base components do:

<img width="602" alt="Screen Shot 2021-04-17 at 7 37 53 PM" src="https://user-images.githubusercontent.com/53795920/115134067-5ac4f700-9fca-11eb-810e-985d77a8d3cc.png">

This also meant a bunch of `mergeAll`s could be removed which I think cleans up the components a little bit.

