### PR TITLE
fix(windows): Fix issue #1639 -- remove "file://" from template address

### DIFF
--- a/src/commands/new.ts
+++ b/src/commands/new.ts
@@ -12,6 +12,8 @@ import {
   stopSpinner,
 } from "../tools/pretty"
 
+const isWindows = process.platform === "win32"
+
 export default {
   run: async (toolbox: GluegunToolbox) => {
     const { print, filesystem, system, meta, parameters, strings } = toolbox
@@ -53,9 +55,9 @@ export default {
     const cliEnv = expo && debug ? { ...process.env, EXPO_DEBUG: 1 } : process.env
     const cliString = expo
       ? `npx expo-cli init ${projectName} --template ${boilerplatePath} --non-interactive`
-      : `npx react-native init ${projectName} --template file://${ignitePath}${
-          debug ? " --verbose" : ""
-        }`
+      : `npx react-native init ${projectName} --template ${!isWindows ? "file://" : ""}${ignitePath}${
+        debug ? " --verbose" : ""
+      }`
 
     log({ expo, cli, ignitePath, boilerplatePath, cliString })
 


### PR DESCRIPTION
## Please verify the following:

- [ ] `yarn ci:test` **jest** tests pass with new tests, if relevant
- [ ] `README.md` has been updated with your changes, if relevant

## Describe your PR

Fix problems for windows caused by 'file://' syntax that should only be used in linux
