### PR TITLE
fix: add background color to navigators

### DIFF
--- a/boilerplate/app/navigators/main-navigator.tsx
+++ b/boilerplate/app/navigators/main-navigator.tsx
@@ -33,6 +33,7 @@ export function MainNavigator() {
   return (
     <Stack.Navigator
       screenOptions={{
+        cardStyle: { backgroundColor: "transparent" },
         headerShown: false,
       }}
     >

--- a/boilerplate/app/navigators/root-navigator.tsx
+++ b/boilerplate/app/navigators/root-navigator.tsx
@@ -29,6 +29,7 @@ const RootStack = () => {
   return (
     <Stack.Navigator
       screenOptions={{
+        cardStyle: { backgroundColor: "#5D2555" },
         headerShown: false,
       }}
     >

--- a/boilerplate/app/navigators/root-navigator.tsx
+++ b/boilerplate/app/navigators/root-navigator.tsx
@@ -8,6 +8,7 @@ import React from "react"
 import { NavigationContainer, NavigationContainerRef } from "@react-navigation/native"
 import { createStackNavigator } from "@react-navigation/stack"
 import { MainNavigator } from "./main-navigator"
+import { color } from "../theme"
 
 /**
  * This type allows TypeScript to know what routes are defined in this navigator
@@ -29,7 +30,7 @@ const RootStack = () => {
   return (
     <Stack.Navigator
       screenOptions={{
-        cardStyle: { backgroundColor: "#5D2555" },
+        cardStyle: { backgroundColor: color.palette.deepPurple },
         headerShown: false,
       }}
     >

--- a/boilerplate/app/screens/demo/demo-screen.tsx
+++ b/boilerplate/app/screens/demo/demo-screen.tsx
@@ -17,7 +17,7 @@ const CONTAINER: ViewStyle = {
 const DEMO: ViewStyle = {
   paddingVertical: spacing[4],
   paddingHorizontal: spacing[4],
-  backgroundColor: "#5D2555",
+  backgroundColor: color.palette.deepPurple,
 }
 const BOLD: TextStyle = { fontWeight: "bold" }
 const DEMO_TEXT: TextStyle = {

--- a/boilerplate/app/screens/welcome/welcome-screen.tsx
+++ b/boilerplate/app/screens/welcome/welcome-screen.tsx
@@ -61,7 +61,7 @@ const CONTENT: TextStyle = {
 const CONTINUE: ViewStyle = {
   paddingVertical: spacing[4],
   paddingHorizontal: spacing[4],
-  backgroundColor: "#5D2555",
+  backgroundColor: color.palette.deepPurple,
 }
 const CONTINUE_TEXT: TextStyle = {
   ...TEXT,

--- a/boilerplate/app/theme/palette.ts
+++ b/boilerplate/app/theme/palette.ts
@@ -7,4 +7,5 @@ export const palette = {
   lightGrey: "#939AA4",
   lighterGrey: "#CDD4DA",
   angry: "#dd3333",
+  deepPurple: "#5D2555",
 }


### PR DESCRIPTION
Fixes #1627 white flash.

## Please verify the following:

- [X] `yarn ci:test` **jest** tests pass with new tests, if relevant
- [X] `README.md` has been updated with your changes, if relevant

## Describe your PR
Adds a background color (to match the app) and transparency to the root and main navigators. This prevents the flash of white during navigation animations.

Demo with fix:

https://user-images.githubusercontent.com/57374/116876359-f4eb8880-abe1-11eb-962d-5c609be2d053.mp4

