### PR TITLE
Cut out ramda

### DIFF
--- a/boilerplate/app/components/screen/screen.presets.ts
+++ b/boilerplate/app/components/screen/screen.presets.ts
@@ -1,5 +1,4 @@
 import { ViewStyle } from "react-native"
-import { isNil } from "ramda"
 import { color } from "../../theme"
 
 /**
@@ -63,5 +62,5 @@ export type ScreenPresets = keyof typeof presets
  */
 export function isNonScrolling(preset: ScreenPresets) {
   // any of these things will make you scroll
-  return isNil(preset) || !preset.length || isNil(presets[preset]) || preset === "fixed"
+  return !preset || !presets[preset] || preset === "fixed"
 }

--- a/boilerplate/app/utils/validate.ts
+++ b/boilerplate/app/utils/validate.ts
@@ -1,4 +1,3 @@
-import { contains } from "ramda"
 const ValidateJS = require("validate.js")
 
 // HACK(steve): wierd typescript situation because of strange typings
@@ -9,7 +8,7 @@ const Validate: any = ValidateJS.default ? ValidateJS.default : ValidateJS
  */
 Validate.validators.excludes = function custom(value, options, key, attributes) {
   const list = attributes[options.attribute] || []
-  if (value && contains(value, list)) {
+  if (value && list.includes(value)) {
     return options.message || `${value} is in the list`
   }
 }

--- a/boilerplate/ios/Podfile.lock
+++ b/boilerplate/ios/Podfile.lock
@@ -575,7 +575,7 @@ SPEC CHECKSUMS:
   EXLocalization: 8b9463c81843da214476b541a27811dd885c9a76
   EXPermissions: 17d4846ad1880f6891c74ae58ca1acb43e47ed47
   FBLazyVector: 7b423f9e248eae65987838148c36eec1dbfe0b53
-  FBReactNativeSpec: 3f746e28c400b289ea09756d6f5b52d7b152e297
+  FBReactNativeSpec: d61d8e560c0bd1cd0d821e306c3cd7e43fa6ba20
   Flipper: d3da1aa199aad94455ae725e9f3aa43f3ec17021
   Flipper-DoubleConversion: 38631e41ef4f9b12861c67d17cb5518d06badc41
   Flipper-Folly: 755929a4f851b2fb2c347d533a23f191b008554c

--- a/boilerplate/package.json
+++ b/boilerplate/package.json
@@ -23,7 +23,7 @@
     "build-ios": "react-native bundle --entry-file index.js --platform ios --dev false --bundle-output ios/main.jsbundle --assets-dest ios",
     "build-android": "react-native bundle --platform android --dev false --entry-file index.js --bundle-output android/app/src/main/assets/index.android.bundle --assets-dest android/app/src/main/res",
     "clean": "react-native-clean-project",
-    "clean-all" : "npx react-native clean-project-auto"
+    "clean-all": "npx react-native clean-project-auto"
   },
   "dependencies": {
     "@react-native-async-storage/async-storage": "^1.14.1",
@@ -37,7 +37,6 @@
     "mobx": "6.1.8",
     "mobx-react-lite": "3.2.0",
     "mobx-state-tree": "5.0.1",
-    "ramda": "0.27.1",
     "react": "17.0.1",
     "react-native": "0.64.1",
     "react-native-gesture-handler": "1.10.3",


### PR DESCRIPTION
Using ramda depends on team/project and can be avoided from using in boilerplate.
In all cases where imported ramda utils, we can use simple plain js:
1. As `preset` is runtime type of string `!preset` - will cover all from ramda isNil - undefined and null, plus !preset.length. Same for !presets[preset]
2. ramda `contains` is deprecated and not needed.