### PR TITLE
Discuss: Apply insetStyle to outer view

### DIFF
--- a/boilerplate/app/components/screen/screen.tsx
+++ b/boilerplate/app/components/screen/screen.tsx
@@ -15,12 +15,12 @@ function ScreenWithoutScrolling(props: ScreenProps) {
 
   return (
     <KeyboardAvoidingView
-      style={[preset.outer, backgroundStyle]}
+      style={[preset.outer, backgroundStyle, insetStyle]}
       behavior={isIos ? "padding" : undefined}
       keyboardVerticalOffset={offsets[props.keyboardOffset || "none"]}
     >
       <StatusBar barStyle={props.statusBar || "light-content"} />
-      <View style={[preset.inner, style, insetStyle]}>{props.children}</View>
+      <View style={[preset.inner, style]}>{props.children}</View>
     </KeyboardAvoidingView>
   )
 }


### PR DESCRIPTION
I think `insetStyle` should be applied to outer view in _ScreenWithoutScrolling_ same as in _ScreenWithScrolling_.

Then styles defined in _inner preset_ like `paddingBottom` specific for app design won't overrided by `insetStyle`. Because for example in most cases we want our design paddingBottom: 20 + safe paddingBottom: 34 = 54  for iPhone 12 and 20 + 0 for iPhone SE and so on.