### PR TITLE
Use @react-native-community/cli instead of react-native-cli

### DIFF
--- a/src/commands/new.ts
+++ b/src/commands/new.ts
@@ -51,6 +51,11 @@ export default {
       process.exit(1)
     }
 
+    // are we on Windows?
+    if (parameters.options.windows === undefined) {
+      parameters.options.windows = process.platform === "win32"
+    }
+
     // debug?
     const debug = Boolean(parameters.options.debug)
     const log = (m) => {
@@ -62,7 +67,7 @@ export default {
 
     const { cliString, cliEnv, cli, boilerplatePath } = buildCLIString(
       projectName,
-      meta.src,
+      path(`${meta.src}`, ".."),
       parameters.options,
     )
     log({ cliString, cliEnv, expo, cli, boilerplatePath })

--- a/src/tools/react-native.ts
+++ b/src/tools/react-native.ts
@@ -1,4 +1,4 @@
-import { GluegunParameters, GluegunToolbox, filesystem } from "gluegun"
+import { GluegunToolbox, filesystem } from "gluegun"
 
 // export const isWindows = process.platform === "win32"
 

--- a/src/tools/react-native.ts
+++ b/src/tools/react-native.ts
@@ -1,4 +1,6 @@
-import { GluegunToolbox } from "gluegun"
+import { GluegunParameters, GluegunToolbox, filesystem } from "gluegun"
+
+// export const isWindows = process.platform === "win32"
 
 export const isAndroidInstalled = (toolbox: GluegunToolbox): boolean => {
   const androidHome = process.env.ANDROID_HOME
@@ -6,4 +8,46 @@ export const isAndroidInstalled = (toolbox: GluegunToolbox): boolean => {
   const hasAndroid = hasAndroidEnv && toolbox.filesystem.exists(`${androidHome}/tools`) === "dir"
 
   return Boolean(hasAndroid)
+}
+
+type Params = {
+  debug?: boolean
+  expo?: boolean
+}
+type CLIEnv = NodeJS.ProcessEnv & { EXPO_DEBUG?: number }
+type CLIStrings = {
+  cliString: string
+  cliEnv: CLIEnv
+  debug: boolean
+  cli: "@react-native-community/cli" | "expo-cli"
+  boilerplatePath: string
+}
+type CLISrc = string | void
+
+/**
+ *
+ * @param name The name of the app
+ * @param src The source path of Ignite's CLI (to find the boilerplate)
+ * @param parameters The parameters passed in
+ * @returns
+ */
+export const buildCLIString = (name: string, src: CLISrc, options: Params): CLIStrings => {
+  const { path } = filesystem
+
+  const debug = Boolean(options.debug)
+  const expo = Boolean(options.expo)
+  const cli = expo ? "expo-cli" : "@react-native-community/cli"
+  const ignitePath = path(`${src}`, "..")
+  const boilerplatePath = path(ignitePath, "boilerplate")
+  const cliTemplatePath = expo ? boilerplatePath : ignitePath
+  const boilerplateExtraFlags = []
+  if (expo) boilerplateExtraFlags.push("--non-interactive")
+  if (!expo && debug) boilerplateExtraFlags.push("--verbose")
+
+  const cliEnv = expo && debug ? ({ ...process.env, EXPO_DEBUG: 1 } as CLIEnv) : process.env
+  const cliString = `npx ${cli} init ${name} --template ${cliTemplatePath} ${boilerplateExtraFlags.join(
+    " ",
+  )}`.trim()
+
+  return { cliString, cliEnv, debug, cli, boilerplatePath }
 }

--- a/src/tools/react-native.ts
+++ b/src/tools/react-native.ts
@@ -1,7 +1,5 @@
 import { GluegunToolbox, filesystem } from "gluegun"
 
-// export const isWindows = process.platform === "win32"
-
 export const isAndroidInstalled = (toolbox: GluegunToolbox): boolean => {
   const androidHome = process.env.ANDROID_HOME
   const hasAndroidEnv = !toolbox.strings.isBlank(androidHome)
@@ -13,16 +11,16 @@ export const isAndroidInstalled = (toolbox: GluegunToolbox): boolean => {
 type Params = {
   debug?: boolean
   expo?: boolean
+  windows?: boolean
 }
 type CLIEnv = NodeJS.ProcessEnv & { EXPO_DEBUG?: number }
 type CLIStrings = {
   cliString: string
   cliEnv: CLIEnv
   debug: boolean
-  cli: "@react-native-community/cli" | "expo-cli"
+  cli: "react-native" | "expo-cli"
   boilerplatePath: string
 }
-type CLISrc = string | void
 
 /**
  *
@@ -31,13 +29,12 @@ type CLISrc = string | void
  * @param parameters The parameters passed in
  * @returns
  */
-export const buildCLIString = (name: string, src: CLISrc, options: Params): CLIStrings => {
+export const buildCLIString = (name: string, ignitePath: string, options: Params): CLIStrings => {
   const { path } = filesystem
 
   const debug = Boolean(options.debug)
   const expo = Boolean(options.expo)
-  const cli = expo ? "expo-cli" : "@react-native-community/cli"
-  const ignitePath = path(`${src}`, "..")
+  const cli = expo ? "expo-cli" : "react-native"
   const boilerplatePath = path(ignitePath, "boilerplate")
   const cliTemplatePath = expo ? boilerplatePath : ignitePath
   const boilerplateExtraFlags = []

--- a/template.config.js
+++ b/template.config.js
@@ -1,5 +1,6 @@
 /**
  * React Native CLI configuration file
+ * Read more here: https://github.com/react-native-community/cli/blob/master/docs/commands.md#--template-string
  */
 module.exports = {
   placeholderName: "HelloWorld",

--- a/test/tools-react-native.test.ts
+++ b/test/tools-react-native.test.ts
@@ -7,12 +7,12 @@ describe(`buildCLIString`, () => {
   test(`react-native CLI`, () => {
     const { cliString, cliEnv, cli, boilerplatePath } = buildCLIString(projectName, src, {})
 
-    expect(cliString).toEqual("npx @react-native-community/cli init Foo --template /some/fake")
+    expect(cliString).toEqual("npx react-native init Foo --template /some/fake/path")
     expect(cliEnv.USER).not.toBeUndefined()
     expect(cliEnv.USER).toEqual(process.env.USER)
     expect(cliEnv.EXPO_DEBUG).toBe(undefined)
-    expect(cli).toEqual("@react-native-community/cli")
-    expect(boilerplatePath).toEqual("/some/fake/boilerplate")
+    expect(cli).toEqual("react-native")
+    expect(boilerplatePath).toEqual("/some/fake/path/boilerplate")
   })
 
   test(`react-native CLI with debug`, () => {
@@ -20,14 +20,12 @@ describe(`buildCLIString`, () => {
       debug: true,
     })
 
-    expect(cliString).toEqual(
-      "npx @react-native-community/cli init Foo --template /some/fake --verbose",
-    )
+    expect(cliString).toEqual("npx react-native init Foo --template /some/fake/path --verbose")
     expect(cliEnv.USER).not.toBeUndefined()
     expect(cliEnv.USER).toEqual(process.env.USER)
     expect(cliEnv.EXPO_DEBUG).toBe(undefined)
-    expect(cli).toEqual("@react-native-community/cli")
-    expect(boilerplatePath).toEqual("/some/fake/boilerplate")
+    expect(cli).toEqual("react-native")
+    expect(boilerplatePath).toEqual("/some/fake/path/boilerplate")
   })
 
   test(`expo`, () => {
@@ -36,13 +34,13 @@ describe(`buildCLIString`, () => {
     })
 
     expect(cliString).toEqual(
-      "npx expo-cli init Foo --template /some/fake/boilerplate --non-interactive",
+      "npx expo-cli init Foo --template /some/fake/path/boilerplate --non-interactive",
     )
     expect(cliEnv.USER).not.toBeUndefined()
     expect(cliEnv.USER).toEqual(process.env.USER)
     expect(cliEnv.EXPO_DEBUG).toBe(undefined)
     expect(cli).toEqual("expo-cli")
-    expect(boilerplatePath).toEqual("/some/fake/boilerplate")
+    expect(boilerplatePath).toEqual("/some/fake/path/boilerplate")
   })
 
   test(`expo with debug`, () => {
@@ -52,12 +50,12 @@ describe(`buildCLIString`, () => {
     })
 
     expect(cliString).toEqual(
-      "npx expo-cli init Foo --template /some/fake/boilerplate --non-interactive",
+      "npx expo-cli init Foo --template /some/fake/path/boilerplate --non-interactive",
     )
     expect(cliEnv.USER).not.toBeUndefined()
     expect(cliEnv.USER).toEqual(process.env.USER)
     expect(cliEnv.EXPO_DEBUG).toBe(1)
     expect(cli).toEqual("expo-cli")
-    expect(boilerplatePath).toEqual("/some/fake/boilerplate")
+    expect(boilerplatePath).toEqual("/some/fake/path/boilerplate")
   })
 })

--- a/test/tools-react-native.test.ts
+++ b/test/tools-react-native.test.ts
@@ -1,0 +1,63 @@
+import { buildCLIString } from "../src/tools/react-native"
+
+describe(`buildCLIString`, () => {
+  const projectName = "Foo"
+  const src = "/some/fake/path"
+
+  test(`react-native CLI`, () => {
+    const { cliString, cliEnv, cli, boilerplatePath } = buildCLIString(projectName, src, {})
+
+    expect(cliString).toEqual("npx @react-native-community/cli init Foo --template /some/fake")
+    expect(cliEnv.USER).not.toBeUndefined()
+    expect(cliEnv.USER).toEqual(process.env.USER)
+    expect(cliEnv.EXPO_DEBUG).toBe(undefined)
+    expect(cli).toEqual("@react-native-community/cli")
+    expect(boilerplatePath).toEqual("/some/fake/boilerplate")
+  })
+
+  test(`react-native CLI with debug`, () => {
+    const { cliString, cliEnv, cli, boilerplatePath } = buildCLIString(projectName, src, {
+      debug: true,
+    })
+
+    expect(cliString).toEqual(
+      "npx @react-native-community/cli init Foo --template /some/fake --verbose",
+    )
+    expect(cliEnv.USER).not.toBeUndefined()
+    expect(cliEnv.USER).toEqual(process.env.USER)
+    expect(cliEnv.EXPO_DEBUG).toBe(undefined)
+    expect(cli).toEqual("@react-native-community/cli")
+    expect(boilerplatePath).toEqual("/some/fake/boilerplate")
+  })
+
+  test(`expo`, () => {
+    const { cliString, cliEnv, cli, boilerplatePath } = buildCLIString(projectName, src, {
+      expo: true,
+    })
+
+    expect(cliString).toEqual(
+      "npx expo-cli init Foo --template /some/fake/boilerplate --non-interactive",
+    )
+    expect(cliEnv.USER).not.toBeUndefined()
+    expect(cliEnv.USER).toEqual(process.env.USER)
+    expect(cliEnv.EXPO_DEBUG).toBe(undefined)
+    expect(cli).toEqual("expo-cli")
+    expect(boilerplatePath).toEqual("/some/fake/boilerplate")
+  })
+
+  test(`expo with debug`, () => {
+    const { cliString, cliEnv, cli, boilerplatePath } = buildCLIString(projectName, src, {
+      expo: true,
+      debug: true,
+    })
+
+    expect(cliString).toEqual(
+      "npx expo-cli init Foo --template /some/fake/boilerplate --non-interactive",
+    )
+    expect(cliEnv.USER).not.toBeUndefined()
+    expect(cliEnv.USER).toEqual(process.env.USER)
+    expect(cliEnv.EXPO_DEBUG).toBe(1)
+    expect(cli).toEqual("expo-cli")
+    expect(boilerplatePath).toEqual("/some/fake/boilerplate")
+  })
+})


### PR DESCRIPTION
First, this switches from `react-native-cli` to `@react-native-community/cli`.

Secondly, this removes the `file:///` prefix schema that seems to have caused problems in Windows (#1639 and #1663). I'm not entirely sure why it was necessary in the first place.

And lastly, this refactors the `new.ts` command a bit to use a CLI string builder, and also adds some tests. It should make it easier to add options going forward (which I'll need in order to support other platforms).

It shouldn't affect much, so it can be a patch-level release, assuming everything works of course.

