### PR TITLE
Remove react-native-cli and copy over files ourselves

### DIFF
--- a/src/tools/filesystem-ext.ts
+++ b/src/tools/filesystem-ext.ts
@@ -1,0 +1,27 @@
+import { filesystem } from "gluegun"
+import * as pathlib from "path"
+
+/**
+ * A lot like gluegun's filesystem.subdirectories(), but gets files too.
+ *
+ * This should probably go in Gluegun.
+ *
+ * Right about right here: https://github.com/infinitered/gluegun/blob/master/src/toolbox/filesystem-tools.ts#L52
+ */
+export function children(
+  path: string,
+  isRelative: boolean = false,
+  matching: string = "*",
+): string[] {
+  const dirs = filesystem.cwd(path).find({
+    matching,
+    directories: true,
+    recursive: false,
+    files: true,
+  })
+  if (isRelative) {
+    return dirs
+  } else {
+    return dirs.map((dir) => pathlib.join(path, dir))
+  }
+}

--- a/src/tools/filesystem-ext.ts
+++ b/src/tools/filesystem-ext.ts
@@ -8,11 +8,7 @@ import * as pathlib from "path"
  *
  * Right about right here: https://github.com/infinitered/gluegun/blob/master/src/toolbox/filesystem-tools.ts#L52
  */
-export function children(
-  path: string,
-  isRelative: boolean = false,
-  matching: string = "*",
-): string[] {
+export function children(path: string, isRelative = false, matching = "*"): string[] {
   const dirs = filesystem.cwd(path).find({
     matching,
     directories: true,

--- a/src/tools/pretty.ts
+++ b/src/tools/pretty.ts
@@ -25,6 +25,13 @@ export const stopSpinner = (m: string, symbol: string) => {
   }
 }
 
+export const clearSpinners = () => {
+  Object.keys(spinners).forEach((m) => {
+    spinners[m].stop()
+    delete spinners[m]
+  })
+}
+
 export const heading = (m = "") => p(white(bold(m)))
 
 export const link = (m = "") => underline(white(m))

--- a/src/tools/react-native.ts
+++ b/src/tools/react-native.ts
@@ -1,4 +1,5 @@
 import { GluegunToolbox } from "gluegun"
+import { children } from "./filesystem-ext"
 
 export const isAndroidInstalled = (toolbox: GluegunToolbox): boolean => {
   const androidHome = process.env.ANDROID_HOME
@@ -6,4 +7,41 @@ export const isAndroidInstalled = (toolbox: GluegunToolbox): boolean => {
   const hasAndroid = hasAndroidEnv && toolbox.filesystem.exists(`${androidHome}/tools`) === "dir"
 
   return Boolean(hasAndroid)
+}
+
+type CopyBoilerplateOptions = {
+  boilerplatePath: string
+  projectName: string
+  excluded: Array<string | RegExp>
+}
+
+/**
+ * Copies the boilerplate over to the destination folder.
+ *
+ */
+export async function copyBoilerplate(toolbox: GluegunToolbox, options: CopyBoilerplateOptions) {
+  const { filesystem } = toolbox
+  const { copyAsync, path } = filesystem
+
+  // ensure the desitnation folder exists
+  await filesystem.dirAsync(options.projectName)
+
+  // rather than copying everything wholesale, let's check what's in the boilerplate folder
+  // and copy over everything except stuff like lockfiles and node_modules
+  // just to make it faster, y'know? Don't want to copy unnecessary stuff
+  const filesAndFolders = children(options.boilerplatePath, true)
+  const copyTargets = filesAndFolders.filter(
+    (file) =>
+      !options.excluded.find((exclusion) =>
+        exclusion instanceof RegExp ? exclusion.test(file) : exclusion === file,
+      ),
+  )
+
+  // kick off a bunch of copies
+  const copyPromises = copyTargets.map((fileOrFolder) =>
+    copyAsync(path(options.boilerplatePath, fileOrFolder), path(options.projectName, fileOrFolder)),
+  )
+
+  // copy them all at once
+  return Promise.all(copyPromises)
 }

--- a/test/ignite-new.test.ts
+++ b/test/ignite-new.test.ts
@@ -30,7 +30,7 @@ describe("Igniting new app! 🔥\nGo get a coffee or something. This is gonna ta
   test(`ignite new ${APP_NAME}`, async (done) => {
     const result = await runIgnite(`new ${APP_NAME}`)
 
-    expect(result).toContain(`Using react-native-cli`)
+    expect(result).toContain(`Using ignite-cli`)
     expect(result).toContain(`Ignite CLI ignited ${APP_NAME}`)
 
     // now let's examine the spun-up app


### PR DESCRIPTION
This was spurred on by some (apparently local?) problems I was having with the react-native CLI. However, I think it's worth a look even if react-native-cli works fine.

This PR removes our dependency on `@react-native-community/cli` aka `react-native-cli` and instead undertakes copying over the boilerplate files ourselves (when not using Expo).

Since the boilerplate is essentially already a runnable project, this is a pretty straightforward copy operation. We still do some cleanup by removing any stray Expo files that make it in and also run `npx react-native-rename` on it -- since your app is probably not named `HelloWorld`.

It seems that most of the time spinning up a new Ignite app is still when it's `yarn install`ing. We probably need to spend time stripping our dependencies down a bit more.

This *shouldn't* make any breaking changes to the boilerplate. This would also supplant #1696 if we merge it.

