### PR TITLE
Proper error message when folder already exists

### DIFF
--- a/src/commands/new.ts
+++ b/src/commands/new.ts
@@ -33,7 +33,7 @@ export default {
     if (parameters.options.overwrite) {
       remove(projectName)
     } else if (exists(projectName)) {
-      const alreadyExists = `Error: There's already a folder with the name ${projectName}. To force overwriting that folder, run with --overwrite.`
+      const alreadyExists = `Error: There's already a folder with the name "${projectName}". To force overwriting that folder, run with --overwrite.`
       p()
       p(yellow(alreadyExists))
       process.exit(1)

--- a/src/commands/new.ts
+++ b/src/commands/new.ts
@@ -33,12 +33,9 @@ export default {
     if (parameters.options.overwrite) {
       remove(projectName)
     } else if (exists(projectName)) {
+      const alreadyExists = `Error: There's already a folder with the name ${projectName}. To force overwriting that folder, run with --overwrite.`
       p()
-      p(
-        yellow(
-          `Error: There's already a folder with the name "Foo". To force overwriting that folder, run with --overwrite.`,
-        ),
-      )
+      p(yellow(alreadyExists))
       process.exit(1)
     }
 


### PR DESCRIPTION
Currently, Ignite provides the wrong name ("Foo") on the overwrite error.

![image](https://user-images.githubusercontent.com/1479215/120864093-8717e100-c540-11eb-8c3e-f189f58a1001.png)

This fixes that.

![yo dawg](https://i.imgflip.com/5c5avv.jpg)
