### PR TITLE
modify react-native version

### DIFF
--- a/boilerplate/package.json
+++ b/boilerplate/package.json
@@ -38,7 +38,7 @@
     "mobx-react-lite": "3.2.0",
     "mobx-state-tree": "5.0.1",
     "react": "17.0.1",
-    "react-native": "0.64.1",
+    "react-native": "0.64.2",
     "react-native-gesture-handler": "1.10.3",
     "react-native-keychain": "6.2.0",
     "react-native-safe-area-context": "3.1.8",


### PR DESCRIPTION

## Chang content

### When you use Apple m1 silicon:
```
react-native @0.64.1 sometimes it comes up:
    Command line invocation:
    /Applications/Xcode.app/Contents/Developer/usr/bin/xcodebuild -workspace PizzaApp.xcworkspace -configuration Debug -scheme PizzaApp -destination id=40CDF333-C994-4927-BCEB-CA9D58606E4F
User defaults from command line:
    IDEPackageSupportUseBuiltinSCM = YES;
    ...

```

Two day ago, [react-native](https://github.com/facebook/react-native/releases/tag/v0.64.2) fix this!
So, we need use rn the latest version!

