### PR TITLE
Remove ramda-omit leftovers from NAME.ts.ejs

### DIFF
--- a/boilerplate/ignite/templates/model/NAME.ts.ejs
+++ b/boilerplate/ignite/templates/model/NAME.ts.ejs
@@ -9,14 +9,6 @@ export const <%= props.pascalCaseName %>Model = types
   .views((self) => ({})) // eslint-disable-line @typescript-eslint/no-unused-vars
   .actions((self) => ({})) // eslint-disable-line @typescript-eslint/no-unused-vars
 
-/**
- * Un-comment the following to omit model attributes from your snapshots (and from async storage).
- * Useful for sensitive data like passwords, or transitive state like whether a modal is open.
-
- * Note that you'll need to import `omit` from ramda, which is already included in the project!
- *  .postProcessSnapshot(omit(["password", "socialSecurityNumber", "creditCardNumber"]))
- */
-
 type <%= props.pascalCaseName %>Type = Instance<typeof <%= props.pascalCaseName %>Model>
 export interface <%= props.pascalCaseName %> extends <%= props.pascalCaseName %>Type {}
 type <%= props.pascalCaseName %>SnapshotType = SnapshotOut<typeof <%= props.pascalCaseName %>Model>


### PR DESCRIPTION
As 'ramda' package has been complete removed, as has the ```import {omit} from 'ramda'``` on top of file, I believe this comment section should be removed as well.

## Please verify the following:

- [ ] `yarn ci:test` **jest** tests pass with new tests, if relevant
- [ ] `README.md` has been updated with your changes, if relevant

## Describe your PR
