### PR TITLE
Remove  `"@types/ramda": "0.27.32",` from package.json

### DIFF
--- a/boilerplate/package.json
+++ b/boilerplate/package.json
@@ -59,7 +59,6 @@
     "@storybook/react-native-server": "5.3.23",
     "@types/i18n-js": "3.0.3",
     "@types/jest": "26.0.19",
-    "@types/ramda": "0.27.32",
     "@types/react": "16.14.0",
     "@types/react-native": "0.63.40",
     "@types/react-test-renderer": "16.9.4",


### PR DESCRIPTION
Since we removed ramda from this release, we shouldn't need the types anymore either

## Please verify the following:

- [ ] `yarn ci:test` **jest** tests pass with new tests, if relevant
- [ ] `README.md` has been updated with your changes, if relevant

## Describe your PR
