### PR TITLE
Typescript: prop types added

### DIFF
--- a/boilerplate/storybook/views/story-screen.tsx
+++ b/boilerplate/storybook/views/story-screen.tsx
@@ -8,7 +8,7 @@ export interface StoryScreenProps {
 }
 
 const behavior = Platform.OS === "ios" ? "padding" : undefined
-export const StoryScreen = (props) => (
+export const StoryScreen = (props: StoryScreenProps) => (
   <KeyboardAvoidingView style={ROOT} behavior={behavior} keyboardVerticalOffset={50}>
     {props.children}
   </KeyboardAvoidingView>


### PR DESCRIPTION
## Please verify the following:

- [ ] `yarn ci:test` **jest** tests pass with new tests, if relevant
- [ ] `README.md` has been updated with your changes, if relevant

## Describe your PR
`StoryScreenProps` is an unused variable since it is not used in the file.
Typescript adjustment to include the aforementioned `StoryScreenProps` as the defined interface.
as a result, the eslint for `react/prop-types` on the props.children element is now satisfied.


