### PR TITLE
Fix: Add missing RNGH android setup

### DIFF
--- a/boilerplate/android/app/src/main/java/com/helloworld/MainActivity.java
+++ b/boilerplate/android/app/src/main/java/com/helloworld/MainActivity.java
@@ -2,6 +2,10 @@ package com.helloworld;
 
 import com.facebook.react.ReactActivity;
 
+import com.facebook.react.ReactActivityDelegate;
+import com.facebook.react.ReactRootView;
+import com.swmansion.gesturehandler.react.RNGestureHandlerEnabledRootView;
+
 public class MainActivity extends ReactActivity {
 
   /**
@@ -11,5 +15,19 @@ public class MainActivity extends ReactActivity {
   @Override
   protected String getMainComponentName() {
     return "HelloWorld";
+  }
+
+  /**
+   * Required for proper react-native-gesture-handler touch handling
+   * https://docs.swmansion.com/react-native-gesture-handler/docs/#updating-mainactivityjava
+   */
+  @Override
+  protected ReactActivityDelegate createReactActivityDelegate() {
+    return new ReactActivityDelegate(this, getMainComponentName()) {
+      @Override
+      protected ReactRootView createRootView() {
+       return new RNGestureHandlerEnabledRootView(MainActivity.this);
+      }
+    };
   }
 }


### PR DESCRIPTION
## Please verify the following:

 - [ ] ~`yarn ci:test` **jest** tests pass with new tests, if relevant~  The tests hung, and either way are unlikely to touch native Android code.
- [ ] ~`README.md` has been updated with your changes, if relevant~ Not relevant
- [x] `npx react-native run-android` in `boilerplate` has successful compile

## Describe your PR

Fixes #1718.