### PR TITLE
Fixes Expo error on ignite new -- fixes issue #1725

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,6 +9,7 @@ lerna-debug.log
 node_modules
 .vscode/*
 package-lock.json
+boilerplate/yarn.lock
 
 # TS build
 /build


### PR DESCRIPTION
In issue #1725, Expo builds were failing on `react-native-rename`, which isn't necessary since we are using `expo-cli` anyway.

This avoids calling the rename functionality when using Expo.

Additionally, we discovered that using some older versions of our CLI dependencies was causing issues, so we are locking major versions.

After implementing these changes, running `npx ignite-cli new MyApp --expo` with Node 16.4.2 succeeded.

cc @derekgreenberg 
