### PR TITLE
Explicitly type rootStore in withRootStore extension

### DIFF
--- a/boilerplate/app/models/extensions/with-root-store.ts
+++ b/boilerplate/app/models/extensions/with-root-store.ts
@@ -1,5 +1,5 @@
 import { getRoot, IStateTreeNode } from "mobx-state-tree"
-import { RootStoreModel } from "../root-store/root-store"
+import { RootStore, RootStoreModel } from "../root-store/root-store"
 
 /**
  * Adds a rootStore property to the node for a convenient
@@ -10,7 +10,7 @@ export const withRootStore = (self: IStateTreeNode) => ({
     /**
      * The root store.
      */
-    get rootStore() {
+    get rootStore(): RootStore {
       return getRoot<typeof RootStoreModel>(self)
     },
   },


### PR DESCRIPTION
This fixes type resolution when using the withRootStore extension.

fixes #1720 
