### PR TITLE
Update NAME-navigator.tsx.ejs

### DIFF
--- a/boilerplate/ignite/templates/navigator/NAME-navigator.tsx.ejs
+++ b/boilerplate/ignite/templates/navigator/NAME-navigator.tsx.ejs
@@ -1,7 +1,18 @@
-import { StackNavigator } from "react-navigation"
+import React from "react"
+import { createStackNavigator } from "@react-navigation/stack"
 import {
-  SomeScreen
-} from "../screens"
+  DemoScreen
+} from "../../screens"
 
-export const <%= props.pascalCaseName %> = StackNavigator({
-})
+export type <%= props.pascalCaseName %>ParamList = {
+  demo: undefined
+}
+
+const Stack = createStackNavigator<<%= props.pascalCaseName %>ParamList>()
+export const <%= props.pascalCaseName %> = () => {
+  return (
+    <Stack.Navigator screenOptions={{ cardStyle: { backgroundColor: "transparent" }, headerShown: false, }}>
+      <Stack.Screen name="demo" component={DemoScreen} />
+    </Stack.Navigator>
+  )
+}


### PR DESCRIPTION
## Please verify the following:

- [x] `yarn ci:test` **jest** tests pass with new tests, if relevant

## Describe your PR
- Current navigator template was obsolete since we're using react-navigation v5, this PR will use stack navigator from new dependency `@react-navigation/stack`