### PR TITLE
fix(cli): rename should happen before pod install

### DIFF
--- a/src/commands/new.ts
+++ b/src/commands/new.ts
@@ -213,13 +213,6 @@ export default {
       startSpinner("Unboxing NPM dependencies")
       await packager.install({ onProgress: log })
       stopSpinner("Unboxing NPM dependencies", "🧶")
-
-      // install pods
-      startSpinner("Baking CocoaPods")
-      await spawnProgress(`npx pod-install@${cliDependencyVersions.podInstall}`, {
-        onProgress: log,
-      })
-      stopSpinner("Baking CocoaPods", "☕️")
     }
 
     // remove the expo-only package.json
@@ -232,6 +225,12 @@ export default {
       log(renameCmd)
       await spawnProgress(renameCmd, { onProgress: log })
       stopSpinner(" Writing your app name in the sand", "🏝")
+      // install pods
+      startSpinner("Baking CocoaPods")
+      await spawnProgress(`npx pod-install@${cliDependencyVersions.podInstall}`, {
+        onProgress: log,
+      })
+      stopSpinner("Baking CocoaPods", "☕️")
     }
 
     // Make sure all our modifications are formatted nicely


### PR DESCRIPTION
## Please verify the following:

- [x] `yarn ci:test` **jest** tests pass with new tests, if relevant
- [x] `README.md` has been updated with your changes, if relevant

## Describe your PR

In the `new` command, the step to rename the new project from the default HelloWorld is happening after `pod install` is run.  In testing locally, this is not reliable -- some Pods directories were not renamed, leading to breakage of `react-native run-ios` for the TV platform changes I've been testing.

I found no issues introduced by this change.  The change only affects non-expo projects.