### PR TITLE
Ensures that bundle ID is set and customizable

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,6 +42,8 @@ Run the CLI:
 npx ignite-cli new PizzaApp
 # or for Expo-powered:
 npx ignite-cli new PizzaApp --expo
+# to provide a custom bundle identifier (Android only):
+npx ignite-cli new PizzaApp --bundle=com.infinitered.pizzaapp
 ```
 
 Ignite will walk you through the rest.

--- a/src/commands/help.ts
+++ b/src/commands/help.ts
@@ -30,6 +30,7 @@ module.exports = {
     command("new         ", "Creates a new React Native app", [
       "ignite new MyApp",
       "ignite new MyApp --expo",
+      "ignite new MyApp --bundle com.mycompany.myapp",
     ])
     p()
     command("generate (g)", "Generates components and other app features", [

--- a/src/commands/new.ts
+++ b/src/commands/new.ts
@@ -221,7 +221,7 @@ export default {
     if (!expo) {
       // rename the app using `react-native-rename`
       startSpinner(" Writing your app name in the sand")
-      const renameCmd = `npx react-native-rename@${cliDependencyVersions.rnRename} ${projectName}`
+      const renameCmd = `npx react-native-rename@${cliDependencyVersions.rnRename} ${projectName} -b com.${projectName}`
       log(renameCmd)
       await spawnProgress(renameCmd, { onProgress: log })
       stopSpinner(" Writing your app name in the sand", "🏝")

--- a/src/commands/new.ts
+++ b/src/commands/new.ts
@@ -12,7 +12,6 @@ import {
   stopSpinner,
   clearSpinners,
 } from "../tools/pretty"
-import { validateBundleIdentifier } from "../tools/validations"
 
 // CLI tool versions we support
 const cliDependencyVersions: { [k: string]: string } = {
@@ -33,7 +32,7 @@ export default {
     const perfStart = new Date().getTime()
 
     // retrieve project name from toolbox
-    const { validateProjectName } = require("../tools/validations")
+    const { validateProjectName, validateBundleIdentifier } = require("../tools/validations")
     const projectName = validateProjectName(toolbox)
     const projectNameKebab = kebabCase(projectName)
 

--- a/src/commands/new.ts
+++ b/src/commands/new.ts
@@ -12,6 +12,7 @@ import {
   stopSpinner,
   clearSpinners,
 } from "../tools/pretty"
+import { validateBundleIdentifier } from "../tools/validations"
 
 // CLI tool versions we support
 const cliDependencyVersions: { [k: string]: string } = {
@@ -63,6 +64,11 @@ export default {
       return m
     }
 
+    // custom bundle identifier (android only)
+    // TODO: refactor alert, need to rethink this
+    const bundleIdentifier =
+      validateBundleIdentifier(toolbox, parameters.options.bundle) || `com.${projectName}`
+
     // expo or no?
     const expo = Boolean(parameters.options.expo)
     const ignitePath = path(`${meta.src}`, "..")
@@ -76,6 +82,7 @@ export default {
     p(` █ Creating ${magenta(projectName)} using ${red("Ignite")} ${meta.version()}`)
     p(` █ Powered by ${red("Infinite Red")} - https://infinite.red`)
     p(` █ Using ${cyan(expo ? "expo-cli" : "ignite-cli")}`)
+    p(` █ Bundle identifier: ${magenta(bundleIdentifier)}`)
     p(` ────────────────────────────────────────────────\n`)
 
     if (expo) {
@@ -221,7 +228,7 @@ export default {
     if (!expo) {
       // rename the app using `react-native-rename`
       startSpinner(" Writing your app name in the sand")
-      const renameCmd = `npx react-native-rename@${cliDependencyVersions.rnRename} ${projectName} -b com.${projectName}`
+      const renameCmd = `npx react-native-rename@${cliDependencyVersions.rnRename} ${projectName} -b ${bundleIdentifier}`
       log(renameCmd)
       await spawnProgress(renameCmd, { onProgress: log })
       stopSpinner(" Writing your app name in the sand", "🏝")

--- a/src/tools/validations.ts
+++ b/src/tools/validations.ts
@@ -52,3 +52,30 @@ export function validateProjectName(toolbox: GluegunToolbox): string {
 
   return projectName
 }
+
+export function validateBundleIdentifier(
+  toolbox: GluegunToolbox,
+  bundleID: string | undefined,
+): string | undefined {
+  const { print } = toolbox
+
+  // no bundle ID provided
+  if (bundleID === undefined) return undefined
+
+  const id = bundleID.split(".")
+  const validBundleID = /^([a-zA-Z]([a-zA-Z0-9_])*\.)+[a-zA-Z]([a-zA-Z0-9_])*$/u
+  if (id.length < 2) {
+    print.error(
+      'Invalid Bundle Identifier. Add something like "com.travelapp" or "com.junedomingo.travelapp"',
+    )
+    process.exit(1)
+  }
+  if (!validBundleID.test(bundleID)) {
+    print.error(
+      "Invalid Bundle Identifier. It must have at least two segments (one or more dots). Each segment must start with a letter. All characters must be alphanumeric or an underscore [a-zA-Z0-9_]",
+    )
+    process.exit(1)
+  }
+
+  return bundleID
+}

--- a/test/ignite-new.test.ts
+++ b/test/ignite-new.test.ts
@@ -41,6 +41,17 @@ describe("Igniting new app! 🔥\nGo get a coffee or something. This is gonna ta
     expect(dirs).toContain("android")
     expect(dirs).toContain("app")
 
+    // check the android bundle id has changed
+    const androidPackageName = APP_NAME.toLowerCase()
+    const mainAppJava = filesystem.read(
+      `./android/app/src/main/java/com/${androidPackageName}/MainApplication.java`,
+    )
+    expect(mainAppJava).toContain(`package com.${androidPackageName};`)
+    const mainActivityJava = filesystem.read(
+      `./android/app/src/main/java/com/${androidPackageName}/MainActivity.java`,
+    )
+    expect(mainActivityJava).toContain(`package com.${androidPackageName};`)
+
     await testSpunUpApp()
 
     // we're done!

--- a/test/ignite-new.test.ts
+++ b/test/ignite-new.test.ts
@@ -24,6 +24,12 @@ describe("Checking for ignite. 🪔", () => {
     expect((result as any).stdout).toContain(`Project name is required`)
     done()
   })
+
+  test(`ignite new (invalid bundle ID)`, async (done) => {
+    const result = await runError(`new BadBundleID --bundle thisisbad`)
+    expect((result as any).stdout).toContain(`Invalid Bundle Identifier.`)
+    done()
+  })
 })
 
 describe("Igniting new app! 🔥\nGo get a coffee or something. This is gonna take a while.", () => {


### PR DESCRIPTION
In #1765, the issue is that on Android (vanilla apps), the bundle identifier is not being set.

This PR fixes that (thanks @carlinisaacson) and also provides the ability to pass in `--bundle` to your `ignite-cli new` command to customize that.

![Bundle ID is set screenshot](https://user-images.githubusercontent.com/1479215/129398505-b9772af4-e371-4b5e-80a2-194f58292ad9.png)

