### PR TITLE
Copy over gitignore properly; fixes #1776

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -18,3 +18,4 @@ coverage
 # newly spun-up apps, but we do want to ignore it in
 # Ignite's source repo.
 boilerplate/yarn.lock
+boilerplate/.gitignore.template

--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
   },
   "scripts": {
     "compile": "tsc -p .",
-    "build": "yarn compile",
+    "build": "yarn compile && cp ./boilerplate/.gitignore ./boilerplate/.gitignore.template",
     "format": "npm-run-all format:*",
     "format:js": "prettier --write '**/*.js'",
     "format:json": "prettier --write '**/*.json'",
@@ -38,7 +38,7 @@
     "ci:test": "yarn build && yarn ci:lint && jest --runInBand && yarn clean",
     "ci:publish": "yarn build && yarn semantic-release && yarn clean",
     "semantic-release": "semantic-release",
-    "clean": "rm -rf ./build"
+    "clean": "rm -rf ./build && rm ./boilerplate/.gitignore.template"
   },
   "devEngines": {
     "node": ">=7.x",

--- a/src/commands/new.ts
+++ b/src/commands/new.ts
@@ -141,16 +141,21 @@ export default {
     // jump into the project to do additional tasks
     process.chdir(projectName)
 
-    // copy the .gitignore if it wasn't copied over [expo...]
-    // Release Ignite installs have the boilerplate's .gitignore in .npmignore
+    // copy the .gitignore if it wasn't copied over
+    // Release Ignite installs have the boilerplate's .gitignore in .gitignore.template
     // (see https://github.com/npm/npm/issues/3763); development Ignite still
     // has it in .gitignore. Copy it from one or the other.
     const targetIgnorePath = log(path(process.cwd(), ".gitignore"))
     if (!filesystem.exists(targetIgnorePath)) {
-      let sourceIgnorePath = log(path(boilerplatePath, ".npmignore"))
+      // gitignore in dev mode?
+      let sourceIgnorePath = log(path(boilerplatePath, ".gitignore"))
+
+      // gitignore in release mode?
       if (!filesystem.exists(sourceIgnorePath)) {
-        sourceIgnorePath = path(boilerplatePath, ".gitignore")
+        sourceIgnorePath = log(path(boilerplatePath, ".gitignore.template"))
       }
+
+      // copy the file over
       filesystem.copy(sourceIgnorePath, targetIgnorePath)
     }
 


### PR DESCRIPTION
In #1776, `npm pack` seems to no longer copy over the .gitignore (nor the .npmignore that @bryanstearns used in #1582).

So, we're doing what [everyone else seems to do](https://github.com/facebook/create-react-app/blob/bb64e31a81eb12d688c14713dce812143688750a/docusaurus/docs/custom-templates.md#the-template-folder), and that is rename the file (in this case, we're copying it to `.gitignore.template`) for publishing and then copy it back for `npx ignite-cli new`.

I'll release this and test it after release, since that's the only reliable way to really test it.

