### PR TITLE
Remove template file after generation

### DIFF
--- a/src/commands/new.ts
+++ b/src/commands/new.ts
@@ -229,6 +229,9 @@ export default {
     // remove the expo-only package.json
     filesystem.remove("package.expo.json")
 
+    // remove the gitignore template
+    filesystem.remove(".gitignore.template")
+
     if (!expo) {
       // rename the app using `react-native-rename`
       startSpinner(" Writing your app name in the sand")


### PR DESCRIPTION
With #1781, we fixed an issue where gitignore wasn't being copied. Our solution unfortunately left _two_ copies of gitignore, so this removes the extra one.

