### PR TITLE
Fix typos

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,4 +1,4 @@
-# Javascript Node CircleCI 2.0 configuration file
+# JavaScript Node CircleCI 2.0 configuration file
 #
 # Check https://circleci.com/docs/2.0/language-javascript/ for more details
 #
@@ -35,7 +35,7 @@ jobs:
             - node_modules
           key: v1-dependencies-{{ checksum "package.json" }}
       - run:
-          # We don't want to install Cocoapods on ubuntu where we run the tests.
+          # We don't want to install CocoaPods on ubuntu where we run the tests.
           name: Set up dummy `pod` command
           command: |
             sudo ln /bin/true /usr/local/bin/pod
@@ -73,7 +73,7 @@ jobs:
   #         command: |
   #           sudo yarn global add detox-cli
   #     - run:
-  #         name: Install Ruby and Cocoapods
+  #         name: Install Ruby and CocoaPods
   #         command: |
   #           sudo apt-get update &&
   #           sudo apt-get install ruby-full &&
@@ -120,7 +120,7 @@ jobs:
             - v1-dependencies-
       # Run semantic-release after all the above is set.
       - run:
-          name: Publish to NPM
+          name: Publish to npm
           command: yarn ci:publish # this will be added to your package.json scripts
 
 workflows:

--- a/README.md
+++ b/README.md
@@ -55,8 +55,8 @@ If you'd like to follow a tutorial, check out [this one from Robin Heinze](https
 The above commands may fail with various errors, depending on your operating system and dependency versions. Some troubleshooting steps to follow:
 
 - Make sure you are using the LTS version of Node. This can be checked via the `node --version` command. If you require multiple Node versions on your system, install `nvm`, and then run `nvm install --lts`. At the time of writing, Node LTS is v14.x.x.
-- If the installation fails because of an XCode error (missing XCode command line tools), the easiest way to install them is to run `sudo xcode-select --install` in your terminal.
-- If XCode and command line tools are already installed, but the installation complains about missing patch dependencies, you may need to switch the XCode location to something else: `sudo xcode-select -s /Applications/Xcode.app/Contents/Developer`
+- If the installation fails because of an Xcode error (missing Xcode command line tools), the easiest way to install them is to run `sudo xcode-select --install` in your terminal.
+- If Xcode and command line tools are already installed, but the installation complains about missing patch dependencies, you may need to switch the Xcode location to something else: `sudo xcode-select -s /Applications/Xcode.app/Contents/Developer`
 
 ## Generators
 

--- a/docs/MobX-State-Tree.md
+++ b/docs/MobX-State-Tree.md
@@ -32,7 +32,7 @@ We also recognize no state management solution is perfect. MST has some known do
 
 - Integration with TypeScript is clunky at times. MST's own typing system is sometimes at odds with what TypeScript wants
 - `mobx` and `mobx-state-tree` both seem to have "magic" or "sorcery" that makes issues less straightforward to debug because you don't always have a clear picture of what's happening (but using [Reactotron](https://github.com/infinitered/reactotron), which has `mobx-state-tree` support built-in, helps a lot). The [MobX docs](https://mobx.js.org/) can also help illuminate some of the magic.
-- The user base is small, so finding help on GitHub or Stack overflow is less convenient (however, the [Infinite Red Slack Community](http://community.infinite.red), as well as the [MobX State Tree Github Discussions group](https://github.com/mobxjs/mobx-state-tree/discussions) are both very helpful)
+- The user base is small, so finding help on GitHub or Stack overflow is less convenient (however, the [Infinite Red Slack Community](http://community.infinite.red), as well as the [MobX State Tree GitHub Discussions group](https://github.com/mobxjs/mobx-state-tree/discussions) are both very helpful)
 - Fatal errors are sometimes too-easily triggered and error messages can be verbose and hard to grok
 - The API has a large surface area and the docs tend to be technical and unfriendly
 
@@ -50,7 +50,7 @@ MobX and MobX State Tree can be a lot to learn if you're coming from Redux, so h
 
 - The official docs for [MobX](https://mobx.js.org/) are another important resource, since MST is built on MobX.
 
-- For help from real people in the community, make sure to check out the [Infinite Red Community Slack](https://community.infinite.red) as well as the [MobX State Tree Github Discussions group](https://github.com/mobxjs/mobx-state-tree/discussions).
+- For help from real people in the community, make sure to check out the [Infinite Red Community Slack](https://community.infinite.red) as well as the [MobX State Tree GitHub Discussions group](https://github.com/mobxjs/mobx-state-tree/discussions).
 
 - To see example code bases using Ignite (and MST), check out these repositories:
 - https://github.com/robinheinze/ignite-trivia (based on [this tutorial](https://shift.infinite.red/creating-a-trivia-app-with-ignite-bowser-part-1-1987cc6e93a1) by @robinheinze)

--- a/docs/Tour-of-Ignite.md
+++ b/docs/Tour-of-Ignite.md
@@ -22,7 +22,7 @@ We include a `README.md`, `LICENSE`, and `CODE_OF_CONDUCT.md` in the root of the
 
 There's also a `docs` folder which contains more documentation, including this file. They're all written in Markdown for a better/simpler developer authoring experience.
 
-## CircleCI and Github
+## CircleCI and GitHub
 
 There are a couple folders at the root, `.circleci` and `.github`. These contain configuration for both services. Feel free to take a look.
 
@@ -32,7 +32,7 @@ We use `semantic-release`, an excellent package that allows for automatically re
 
 ## Gluegun
 
-Ignite's CLI (`ignite-cli` on NPM) is powered by [Gluegun](https://github.com/infinitered/gluegun). Gluegun is another Infinite Red library that makes building a full-featured command line interface (CLI) much easier.
+Ignite's CLI (`ignite-cli` on npm) is powered by [Gluegun](https://github.com/infinitered/gluegun). Gluegun is another Infinite Red library that makes building a full-featured command line interface (CLI) much easier.
 
 ## bin
 
@@ -74,7 +74,7 @@ We also run the default tests in a generated Ignite app, which further ensures t
 
 This contains a JSON file that helps demonstrate an API request in the boilerplate's `DemoListScreen`. It's Rick & Morty themed, naturally.
 
-This file isn't even included in the NPM package at all. Instead, we just call over to Github when we need it.
+This file isn't even included in the npm package at all. Instead, we just call over to GitHub when we need it.
 
 ## boilerplate
 

--- a/src/commands/new.ts
+++ b/src/commands/new.ts
@@ -205,9 +205,9 @@ export default {
       filesystem.remove("./e2e/reload.js")
       filesystem.rename("./e2e/reload.expo.js", "reload.js")
 
-      startSpinner("Unboxing NPM dependencies")
+      startSpinner("Unboxing npm dependencies")
       await packager.install({ onProgress: log })
-      stopSpinner("Unboxing NPM dependencies", "🧶")
+      stopSpinner("Unboxing npm dependencies", "🧶")
 
       // for some reason we need to do this, or we get an error about duplicate RNCSafeAreaProviders
       // see https://github.com/th3rdwave/react-native-safe-area-context/issues/110#issuecomment-668864576
@@ -221,9 +221,9 @@ export default {
       filesystem.remove("./babel.config.expo.js")
 
       // yarn it
-      startSpinner("Unboxing NPM dependencies")
+      startSpinner("Unboxing npm dependencies")
       await packager.install({ onProgress: log })
-      stopSpinner("Unboxing NPM dependencies", "🧶")
+      stopSpinner("Unboxing npm dependencies", "🧶")
     }
 
     // remove the expo-only package.json


### PR DESCRIPTION
A few minor spelling fixes (e.g. `Github` -> `GitHub`, `XCode` -> `Xcode`) etc. No other content/functional changes.