### PR TITLE
Adds library search path for Swift error

### DIFF
--- a/boilerplate/ios/HelloWorld.xcodeproj/project.pbxproj
+++ b/boilerplate/ios/HelloWorld.xcodeproj/project.pbxproj
@@ -145,7 +145,6 @@
 				8D3D2E99D3814D73E5353ACB /* Pods-HelloWorld-HelloWorldTests.debug.xcconfig */,
 				32B04630CC446F19212E357A /* Pods-HelloWorld-HelloWorldTests.release.xcconfig */,
 			);
-			name = Pods;
 			path = Pods;
 			sourceTree = "<group>";
 		};
@@ -826,6 +825,7 @@
 				IPHONEOS_DEPLOYMENT_TARGET = 12.0;
 				LD_RUNPATH_SEARCH_PATHS = "/usr/lib/swift $(inherited)";
 				LIBRARY_SEARCH_PATHS = (
+					"$(SDKROOT)/usr/lib/swift",
 					"\"$(TOOLCHAIN_DIR)/usr/lib/swift/$(PLATFORM_NAME)\"",
 					"\"$(TOOLCHAIN_DIR)/usr/lib/swift-5.0/$(PLATFORM_NAME)\"",
 					"\"$(inherited)\"",
@@ -880,6 +880,7 @@
 				IPHONEOS_DEPLOYMENT_TARGET = 12.0;
 				LD_RUNPATH_SEARCH_PATHS = "/usr/lib/swift $(inherited)";
 				LIBRARY_SEARCH_PATHS = (
+					"$(SDKROOT)/usr/lib/swift",
 					"\"$(TOOLCHAIN_DIR)/usr/lib/swift/$(PLATFORM_NAME)\"",
 					"\"$(TOOLCHAIN_DIR)/usr/lib/swift-5.0/$(PLATFORM_NAME)\"",
 					"\"$(inherited)\"",


### PR DESCRIPTION
On my Mac M1, I was running into this error:

```
ld: warning: Could not find or use auto-linked library 'swiftCore'
```

(among many others)

<details>
<summary>Expand error</summary>

```
ld: warning: Could not find or use auto-linked library 'swiftDispatch'
ld: warning: Could not find or use auto-linked library 'swiftCore'
ld: warning: Could not find or use auto-linked library 'swiftQuartzCore'
ld: warning: Could not find or use auto-linked library 'swiftCoreGraphics'
ld: warning: Could not find or use auto-linked library 'swiftSwiftOnoneSupport'
ld: warning: Could not find or use auto-linked library 'swiftUIKit'
ld: warning: Could not find or use auto-linked library 'swiftDarwin'
ld: warning: Could not find or use auto-linked library 'swiftFoundation'
ld: warning: Could not find or use auto-linked library 'swiftsimd'
ld: warning: Could not find or use auto-linked library 'swiftObjectiveC'
ld: warning: Could not find or use auto-linked library 'swiftCoreFoundation'
ld: warning: Could not find or use auto-linked library 'swiftMetal'
ld: warning: Could not find or use auto-linked library 'swiftCoreImage'
ld: warning: Could not find or use auto-linked library 'swiftCoreAudio'
ld: warning: Could not find or use auto-linked library 'swiftAVFoundation'
ld: warning: Could not find or use auto-linked library 'swiftCoreMedia'
Undefined symbols for architecture arm64:
  "method descriptor for Swift.ExpressibleByFloatLiteral.init(floatLiteral: A.FloatLiteralType) -> A", referenced from:
      l_got.$ss25ExpressibleByFloatLiteralP05floatD0x0cD4TypeQz_tcfCTq in libYogaKit.a(YGLayoutExtensions.o)
  "associated type descriptor for Swift.ExpressibleByFloatLiteral.FloatLiteralType", referenced from:
      l_got.$s16FloatLiteralTypes013ExpressibleByaB0PTl in libYogaKit.a(YGLayoutExtensions.o)
  "associated conformance descriptor for Swift.ExpressibleByFloatLiteral.Swift.ExpressibleByFloatLiteral.FloatLiteralType: Swift._ExpressibleByBuiltinFloatLiteral", referenced from:
      l_got.$ss25ExpressibleByFloatLiteralP0cD4TypeAB_s01_ab7BuiltincD0Tn in libYogaKit.a(YGLayoutExtensions.o)
  "protocol descriptor for Swift.ExpressibleByFloatLiteral", referenced from:
      l_got.$ss25ExpressibleByFloatLiteralMp in libYogaKit.a(YGLayoutExtensions.o)
  "protocol conformance descriptor for Swift.String : Swift.Collection in Swift", referenced from:
      lazy protocol witness table accessor for type Swift.String and conformance Swift.String : Swift.Collection in Swift in libExpoModulesCore.a(Record.o)
  "_swift_makeBoxUnique", referenced from:
      ___swift_mutable_project_boxed_opaque_existential_1 in libExpoModulesCore.a(Record.o)
  "protocol conformance descriptor for Swift.AnyCollection<A> : Swift.Sequence in Swift", referenced from:
      lazy protocol witness table accessor for type Swift.AnyCollection<(label: Swift.String?, value: Any)> and conformance Swift.AnyCollection<A> : Swift.Sequence in Swift in libExpoModulesCore.a(Record.o)
# ... more omitted
```

</details>

This PR adds an additional library search path to fix the Swift error.
