### PR TITLE
Run install-colo-loco via npx

### DIFF
--- a/src/commands/new.ts
+++ b/src/commands/new.ts
@@ -254,8 +254,10 @@ export default {
         await packager.add(`react-native-colo-loco@${cliDependencyVersions.coloLoco}`, {
           dev: true,
         })
-        // run colo-loco installer
-        await packager.run("install-colo-loco --defaults", {})
+        await spawnProgress(
+          `npx install-colo-loco@${cliDependencyVersions.coloLoco} --defaults`,
+          {},
+        )
         stopSpinner("Installing React Native Colo Loco", "🤪")
       }
 


### PR DESCRIPTION
## Please verify the following:

- [☑️] `yarn ci:test` **jest** tests pass with new tests, if relevant
- [☑️] `README.md` has been updated with your changes, if relevant

## Describe your PR
It's been reported that some users are stuck on `install-colo-loco` while creating a new app, however, I was only be able to recreate it when omitting `--defaults` flag but that's just an intended hang for waiting a user input. I assume it's the package managers so let's run it via `npx` for now. (Investigation is still in progress)