### PR TITLE
Fix canExit not functioning

### DIFF
--- a/boilerplate/app/app.tsx
+++ b/boilerplate/app/app.tsx
@@ -15,7 +15,7 @@ import React, { useState, useEffect } from "react"
 import { SafeAreaProvider, initialWindowMetrics } from "react-native-safe-area-context"
 import { initFonts } from "./theme/fonts" // expo
 import * as storage from "./utils/storage"
-import { useBackButtonHandler, AppNavigator, canExit, useNavigationPersistence } from "./navigators"
+import { AppNavigator, useNavigationPersistence } from "./navigators"
 import { RootStore, RootStoreProvider, setupRootStore } from "./models"
 import { ToggleStorybook } from "../storybook/toggle-storybook"
 import { ErrorBoundary } from "./screens/error/error-boundary"
@@ -31,8 +31,6 @@ export const NAVIGATION_PERSISTENCE_KEY = "NAVIGATION_STATE"
  */
 function App() {
   const [rootStore, setRootStore] = useState<RootStore | undefined>(undefined)
-
-  useBackButtonHandler(canExit)
   const {
     initialNavigationState,
     onNavigationStateChange,

--- a/boilerplate/app/navigators/app-navigator.tsx
+++ b/boilerplate/app/navigators/app-navigator.tsx
@@ -9,7 +9,7 @@ import { useColorScheme } from "react-native"
 import { NavigationContainer, DefaultTheme, DarkTheme } from "@react-navigation/native"
 import { createNativeStackNavigator } from "@react-navigation/native-stack"
 import { WelcomeScreen, DemoScreen, DemoListScreen } from "../screens"
-import { navigationRef } from "./navigation-utilities"
+import { navigationRef, useBackButtonHandler } from "./navigation-utilities"
 
 /**
  * This type allows TypeScript to know what routes are defined in this navigator
@@ -51,6 +51,7 @@ interface NavigationProps extends Partial<React.ComponentProps<typeof Navigation
 
 export const AppNavigator = (props: NavigationProps) => {
   const colorScheme = useColorScheme()
+  useBackButtonHandler(canExit)
   return (
     <NavigationContainer
       ref={navigationRef}

--- a/boilerplate/app/navigators/navigation-utilities.tsx
+++ b/boilerplate/app/navigators/navigation-utilities.tsx
@@ -57,8 +57,9 @@ export function useBackButtonHandler(canExit: (routeName: string) => boolean) {
 
       // are we allowed to exit?
       if (canExitRef.current(routeName)) {
-        // let the system know we've not handled this event
-        return false
+        // exit and let the system know we've handled the event
+        BackHandler.exitApp()
+        return true
       }
 
       // we can't exit, so let's turn this into a back action


### PR DESCRIPTION
## Please verify the following:

- [☑️] `yarn ci:test` **jest** tests pass with new tests, if relevant
- [☑️] `README.md` has been updated with your changes, if relevant

## Describe your PR
- This fixes `canExit` not functioning (Issue: https://github.com/infinitered/ignite/issues/1841)
- There were two reasons
  1. useBackButtonHandler() was called prematurely so the hook might not be able to detect the event from the screens.
  2. When a screen `canExit`, just let the react-native listener know that we're not handling the event manually by returning `false`. We should "exit" properly and let the react-native listener know that we handled it.

## Proof
- Created a temporary screen and its route name is `test`
- Continue button on the initial screen navigates to `test` screen
- Added `test` route to `exitRoutes` in `app-navigator.tsx`
  ```
  const exitRoutes = ["test"]
  ```
- Pressed hardware back button on `test` screen

![exit](https://user-images.githubusercontent.com/8325407/144511706-f00d742f-addb-4592-b526-31e78c48a051.gif)


