### PR TITLE
Continue "new" process when there's no git config

### DIFF
--- a/src/commands/new.ts
+++ b/src/commands/new.ts
@@ -276,14 +276,18 @@ export default {
     // commit any changes
     if (parameters.options.git !== false) {
       startSpinner(" Backing everything up in source control")
-      await system.run(
-        log(`
-          \\rm -rf ./.git
-          git init;
-          git add -A;
-          git commit -m "New Ignite ${meta.version()} app";
-        `),
-      )
+      try {
+        await system.run(
+          log(`
+            \\rm -rf ./.git
+            git init;
+            git add -A;
+            git commit -m "New Ignite ${meta.version()} app";
+          `),
+        )
+      } catch (e) {
+        p(yellow("Unable to commit the initial changes. Please check your git username and email."))
+      }
       stopSpinner(" Backing everything up in source control", "🗄")
     }
 


### PR DESCRIPTION
## Please verify the following:

- [☑️] `yarn ci:test` **jest** tests pass with new tests, if relevant
- [☑️] `README.md` has been updated with your changes, if relevant

## Describe your PR
- Ref: https://github.com/infinitered/ignite/issues/1800
- When a user creates a new Ignite app without `git config` setup in the global environment(`user.name` and `user.email` to be precise) it fails on committing the initial changes after setting up the app.
- I wasn't able to recreate it when deleting `user.name` and `user.email` even deleting the items Keychain Access, but then I was when setting the items with empty(`""`) to trigger the error.
- This workaround fixes it and let the `ignite new` process complete - And let the user commit it after setting up the git config.
- Note: Didn't update the tests for when git config isn't setup, since there's not much value testing/developing without it. 


![lil'info](https://user-images.githubusercontent.com/8325407/147515365-f5d365ce-4580-4810-9352-95aec0815bef.png)

