### PR TITLE
Use ES6 imports in StorybookToggle and remove component from state

### DIFF
--- a/boilerplate/storybook/toggle-storybook.tsx
+++ b/boilerplate/storybook/toggle-storybook.tsx
@@ -2,6 +2,7 @@ import React, { useState, useEffect, useRef } from "react"
 import { DevSettings } from "react-native"
 import { loadString, saveString } from "../app/utils/storage"
 import { DEFAULT_REACTOTRON_WS_URI } from "../app/services/reactotron/reactotron-config"
+import { StorybookUIRoot } from "./storybook"
 
 /**
  * Toggle Storybook mode, in __DEV__ mode only.
@@ -15,7 +16,6 @@ import { DEFAULT_REACTOTRON_WS_URI } from "../app/services/reactotron/reactotron
  */
 export function ToggleStorybook(props) {
   const [showStorybook, setShowStorybook] = useState(false)
-  const [StorybookUIRoot, setStorybookUIRoot] = useState(null)
   const ws = useRef(new WebSocket(DEFAULT_REACTOTRON_WS_URI))
 
   useEffect(() => {
@@ -44,9 +44,6 @@ export function ToggleStorybook(props) {
         })
       }
 
-      // Load the storybook UI once
-      setStorybookUIRoot(() => require("./storybook").StorybookUIRoot)
-
       // Behave as Reactotron.storybookSwitcher(), not a HOC way.
       ws.current.onmessage = (e) => {
         const data = JSON.parse(e.data)
@@ -64,7 +61,7 @@ export function ToggleStorybook(props) {
   }, [])
 
   if (showStorybook) {
-    return StorybookUIRoot ? <StorybookUIRoot /> : null
+    return <StorybookUIRoot />
   } else {
     return props.children
   }


### PR DESCRIPTION
## Please verify the following:

- [x] `yarn ci:test` **jest** tests pass with new tests, if relevant
- [ ] `README.md` has been updated with your changes, if relevant

## Describe your PR
Refactor `storybook-toggle.ts` to use ES6 imports when importing `StorybookUIRoot` and remove component from state this is causing issues across the app regarding networking and random blank pages, in my case I was getting a blank page on Android and I fixed it with this

Here's a list of issues related:
Closes #1860, #1826?, #1769