### PR TITLE
Add better typings and instructions to screen generator

### DIFF
--- a/boilerplate/app/navigators/app-navigator.tsx
+++ b/boilerplate/app/navigators/app-navigator.tsx
@@ -27,6 +27,7 @@ export type NavigatorParamList = {
   welcome: undefined
   demo: undefined
   demoList: undefined
+  // 🔥 Your screens go here
 }
 
 // Documentation: https://reactnavigation.org/docs/stack-navigator/
@@ -43,6 +44,7 @@ const AppStack = () => {
       <Stack.Screen name="welcome" component={WelcomeScreen} />
       <Stack.Screen name="demo" component={DemoScreen} />
       <Stack.Screen name="demoList" component={DemoListScreen} />
+      {/** 🔥 Your screens go here */}
     </Stack.Navigator>
   )
 }

--- a/boilerplate/ignite/templates/screen/NAME-screen.tsx.ejs
+++ b/boilerplate/ignite/templates/screen/NAME-screen.tsx.ejs
@@ -1,6 +1,8 @@
-import React from "react"
+import React, { FC } from "react"
 import { observer } from "mobx-react-lite"
 import { ViewStyle } from "react-native"
+import { StackScreenProps } from "@react-navigation/stack"
+import { NavigatorParamList } from "../../navigators"
 import { Screen, Text } from "../../components"
 // import { useNavigation } from "@react-navigation/native"
 // import { useStores } from "../../models"
@@ -11,7 +13,14 @@ const ROOT: ViewStyle = {
   flex: 1,
 }
 
-export const <%= props.pascalCaseName %>Screen = observer(function <%= props.pascalCaseName %>Screen() {
+// STOP! READ ME FIRST!
+// To fix the TS error below, you'll need to add the following things in your navigation config:
+// - Add `<%= props.camelCaseName %>: undefined` to NavigatorParamList
+// - Import your screen, and add it to the stack:
+//     `<Stack.Screen name="<%= props.camelCaseName %>" component={<%= props.pascalCaseName%>Screen} />`
+// Hint: Look for the 🔥!
+
+export const <%= props.pascalCaseName %>Screen: FC<StackScreenProps<NavigatorParamList, "<%= props.camelCaseName %>">> = observer(function <%= props.pascalCaseName %>Screen() {
   // Pull in one of our MST stores
   // const { someStore, anotherStore } = useStores()
 
@@ -19,7 +28,7 @@ export const <%= props.pascalCaseName %>Screen = observer(function <%= props.pas
   // const navigation = useNavigation()
   return (
     <Screen style={ROOT} preset="scroll">
-      <Text preset="header" text="<%= props.camelName %>" />
+      <Text preset="header" text="<%= props.camelCaseName %>" />
     </Screen>
   )
 })

--- a/boilerplate/ignite/templates/screen/NAME-screen.tsx.ejs
+++ b/boilerplate/ignite/templates/screen/NAME-screen.tsx.ejs
@@ -20,6 +20,8 @@ const ROOT: ViewStyle = {
 //     `<Stack.Screen name="<%= props.camelCaseName %>" component={<%= props.pascalCaseName%>Screen} />`
 // Hint: Look for the 🔥!
 
+// REMOVE ME! ⬇️ This TS ignore will not be necessary after you've added the correct navigator param type
+// @ts-ignore
 export const <%= props.pascalCaseName %>Screen: FC<StackScreenProps<NavigatorParamList, "<%= props.camelCaseName %>">> = observer(function <%= props.pascalCaseName %>Screen() {
   // Pull in one of our MST stores
   // const { someStore, anotherStore } = useStores()

--- a/boilerplate/package.json
+++ b/boilerplate/package.json
@@ -172,6 +172,7 @@
     },
     "rules": {
       "@typescript-eslint/ban-ts-ignore": 0,
+      "@typescript-eslint/ban-ts-comment": 0,
       "@typescript-eslint/explicit-function-return-type": 0,
       "@typescript-eslint/explicit-member-accessibility": 0,
       "@typescript-eslint/explicit-module-boundary-types": 0,

--- a/package.json
+++ b/package.json
@@ -98,6 +98,7 @@
     },
     "rules": {
       "@typescript-eslint/ban-ts-ignore": 0,
+      "@typescript-eslint/ban-ts-comment": 0,
       "@typescript-eslint/explicit-function-return-type": 0,
       "@typescript-eslint/explicit-member-accessibility": 0,
       "@typescript-eslint/explicit-module-boundary-types": 0,


### PR DESCRIPTION
## Please verify the following:

- [x] `yarn ci:test` **jest** tests pass with new tests, if relevant
 DOES NOT PASS, looks like a `colo-loco` error? 
- [N/A] `README.md` has been updated with your changes, if relevant

## Describe your PR

- Addresses #1857 by adding in the requested types, along with some instructions for adding the screen to navigation config. 

Here's what the user sees in the generated screen: 
<img width="998" alt="Screen Shot 2022-01-27 at 3 56 30 PM" src="https://user-images.githubusercontent.com/6894653/151463004-0dfa6ea9-c5a8-4632-be9e-19951fcc60fd.png">


And here's what they see in `app-navigator.tsx` before adding their own config (arrows show what was changed):
<img width="673" alt="Screen Shot 2022-01-27 at 3 51 37 PM" src="https://user-images.githubusercontent.com/6894653/151462580-15ec8055-3d3a-4896-9e99-abe3e840695c.png">


- I'm thinking about the value of establishing a system where users can look for 🔥 in the code as a sign that they may need to add their own customization various places? This is an idea I stole from Kent C. Dodds courses. 