### PR TITLE
using `baseUrl` to avoid `../../../`

### DIFF
--- a/boilerplate/README.md
+++ b/boilerplate/README.md
@@ -65,7 +65,6 @@ ignite-project
 │   └── IgniteProjectTests
 ├── .env
 └── package.json
-
 ```
 
 ### ./app directory
@@ -113,15 +112,15 @@ This is a great place to put miscellaneous helpers and utilities. Things like da
 
 **app.tsx** This is the entry point to your app. This is where you will find the main App component which renders the rest of the application.
 
-### ./ignite directory
+### `./ignite` directory
 
 The `ignite` directory stores all things Ignite, including CLI and boilerplate items. Here you will find generators, plugins and examples to help you get started with React Native.
 
-### ./storybook directory
+### `./storybook` directory
 
 This is where your stories will be registered and where the Storybook configs will live.
 
-### ./test directory
+### `./test` directory
 
 This directory will hold your Jest configs and mocks, as well as your [storyshots](https://github.com/storybooks/storybook/tree/master/addons/storyshots) test file. This is a file that contains the snapshots of all your component storybooks.
 

--- a/boilerplate/app/components/bullet-item/bullet-item.story.tsx
+++ b/boilerplate/app/components/bullet-item/bullet-item.story.tsx
@@ -1,8 +1,8 @@
 import { storiesOf } from "@storybook/react-native"
 import * as React from "react"
 import { View } from "react-native"
-import { Story, StoryScreen, UseCase } from "../../../storybook/views"
-import { color } from "../../theme"
+import { color } from "~/theme"
+import { Story, StoryScreen, UseCase } from "~/storybook/views"
 import { BulletItem } from "./bullet-item"
 
 declare let module

--- a/boilerplate/app/components/bullet-item/bullet-item.tsx
+++ b/boilerplate/app/components/bullet-item/bullet-item.tsx
@@ -1,8 +1,7 @@
 import * as React from "react"
 import { View, ViewStyle, ImageStyle, TextStyle } from "react-native"
-import { Text } from "../text/text"
-import { Icon } from "../icon/icon"
-import { spacing, typography } from "../../theme"
+import { Icon, Text } from "~/components"
+import { spacing, typography } from "~/theme"
 
 const BULLET_ITEM: ViewStyle = {
   flexDirection: "row",

--- a/boilerplate/app/models/extensions/with-environment.ts
+++ b/boilerplate/app/models/extensions/with-environment.ts
@@ -1,5 +1,5 @@
 import { getEnv, IStateTreeNode } from "mobx-state-tree"
-import { Environment } from "../environment"
+import { Environment } from "~/models/environment"
 
 /**
  * Adds a environment property to the node for accessing our

--- a/boilerplate/app/models/root-store/root-store-context.ts
+++ b/boilerplate/app/models/root-store/root-store-context.ts
@@ -1,5 +1,5 @@
 import { createContext, useContext } from "react"
-import { RootStore } from "./root-store"
+import { RootStore } from "~/models/root-store/root-store"
 
 /**
  * Create a context we can use to

--- a/boilerplate/app/models/root-store/root-store.ts
+++ b/boilerplate/app/models/root-store/root-store.ts
@@ -1,5 +1,5 @@
 import { Instance, SnapshotOut, types } from "mobx-state-tree"
-import { CharacterStoreModel } from "../character-store/character-store"
+import { CharacterStoreModel } from "~/models/character-store/character-store"
 
 /**
  * A RootStore model.

--- a/boilerplate/app/navigators/app-navigator.tsx
+++ b/boilerplate/app/navigators/app-navigator.tsx
@@ -8,8 +8,8 @@ import React from "react"
 import { useColorScheme } from "react-native"
 import { NavigationContainer, DefaultTheme, DarkTheme } from "@react-navigation/native"
 import { createNativeStackNavigator } from "@react-navigation/native-stack"
-import { WelcomeScreen, DemoScreen, DemoListScreen } from "../screens"
-import { navigationRef, useBackButtonHandler } from "./navigation-utilities"
+import { WelcomeScreen, DemoScreen, DemoListScreen } from "~/screens"
+import { navigationRef, useBackButtonHandler } from "~/navigators"
 
 /**
  * This type allows TypeScript to know what routes are defined in this navigator

--- a/boilerplate/app/screens/demo/demo-list-screen.tsx
+++ b/boilerplate/app/screens/demo/demo-list-screen.tsx
@@ -2,10 +2,10 @@ import React, { useEffect, FC } from "react"
 import { FlatList, TextStyle, View, ViewStyle, ImageStyle } from "react-native"
 import { StackScreenProps } from "@react-navigation/stack"
 import { observer } from "mobx-react-lite"
-import { Header, Screen, Text, AutoImage as Image, GradientBackground } from "../../components"
-import { color, spacing } from "../../theme"
-import { useStores } from "../../models"
-import { NavigatorParamList } from "../../navigators"
+import { Header, Screen, Text, AutoImage as Image, GradientBackground } from "~/components"
+import { color, spacing } from "~/theme"
+import { useStores } from "~/models"
+import { NavigatorParamList } from "~/navigators"
 
 const FULL: ViewStyle = {
   flex: 1,

--- a/boilerplate/app/screens/error/error-boundary.tsx
+++ b/boilerplate/app/screens/error/error-boundary.tsx
@@ -1,5 +1,5 @@
 import React, { Component, ErrorInfo, ReactNode } from "react"
-import { ErrorComponent } from "./error-component"
+import { ErrorComponent } from "~/screens/error/error-component"
 
 interface Props {
   children: ReactNode

--- a/boilerplate/app/screens/error/error-component.tsx
+++ b/boilerplate/app/screens/error/error-component.tsx
@@ -1,7 +1,7 @@
 import React, { ErrorInfo } from "react"
 import { TextStyle, View, ViewStyle, ScrollView, ImageStyle } from "react-native"
-import { color } from "../../theme"
-import { Button, Icon, Text } from "../../components"
+import { color } from "~/theme"
+import { Button, Icon, Text } from "~/components"
 
 const CONTAINER: ViewStyle = {
   alignItems: "center",

--- a/boilerplate/app/screens/welcome/welcome-screen.tsx
+++ b/boilerplate/app/screens/welcome/welcome-screen.tsx
@@ -10,8 +10,8 @@ import {
   GradientBackground,
   AutoImage as Image,
 } from "../../components"
-import { color, spacing, typography } from "../../theme"
 import { NavigatorParamList } from "../../navigators"
+import { spacing, typography, color } from "~/theme"
 
 const bowserLogo = require("./bowser.png")
 

--- a/boilerplate/babel.config.js
+++ b/boilerplate/babel.config.js
@@ -11,5 +11,24 @@ module.exports = {
       },
     ],
     ["@babel/plugin-proposal-optional-catch-binding"],
+    [
+      "babel-plugin-root-import",
+      {
+        paths: [
+          {
+            rootPathSuffix: "./app/",
+            rootPathPrefix: "~/",
+          },
+          {
+            rootPathSuffix: "./storybook/",
+            rootPathPrefix: "~/storybook/",
+          },
+          {
+            rootPathSuffix: "./test/",
+            rootPathPrefix: "~/test/",
+          },
+        ],
+      },
+    ],
   ],
 }

--- a/boilerplate/package.json
+++ b/boilerplate/package.json
@@ -71,6 +71,7 @@
     "@typescript-eslint/parser": "4.10.0",
     "babel-jest": "26.6.3",
     "babel-loader": "8.2.2",
+    "babel-plugin-root-import": "^6.6.0",
     "detox": "19.3.0",
     "eslint": "7.15.0",
     "eslint-config-prettier": "7.0.0",

--- a/boilerplate/tsconfig.json
+++ b/boilerplate/tsconfig.json
@@ -14,7 +14,13 @@
     "target": "esnext",
     "lib": ["esnext", "dom"],
     "skipLibCheck": true,
-    "resolveJsonModule": true
+    "resolveJsonModule": true,
+    "baseUrl": "./",
+    "paths": {
+      "~/*": ["app/*"],
+      "~/storybook/*": ["storybook/*"],
+      "~/test/*": ["test/*"]
+    }
   },
   "exclude": ["node_modules"],
   "include": ["index.js", "app", "test", "storybook"]

--- a/boilerplate/yarn.lock
+++ b/boilerplate/yarn.lock
@@ -4614,6 +4614,13 @@ babel-plugin-react-native-web@~0.17.1:
   resolved "https://registry.yarnpkg.com/babel-plugin-react-native-web/-/babel-plugin-react-native-web-0.17.5.tgz#4bce51a20d21839f20506ef184bd5743a2c6d067"
   integrity sha512-UWl0E9FGYVr5Gj7lbVc4DFy8pTgc6wIXBa0rDvPGxx3OmcKwcdvCfDn9mLuh7JesYfh+wLjp01fwPplMus7IPw==
 
+babel-plugin-root-import@^6.6.0:
+  version "6.6.0"
+  resolved "https://registry.yarnpkg.com/babel-plugin-root-import/-/babel-plugin-root-import-6.6.0.tgz#85940840f308a8c292f66ca0b5bdd314046273ed"
+  integrity sha512-SPzVOHd7nDh5loZwZBxtX/oOu1MXeKjTkz+1VnnzLWC0dk8sJIGC2IDQ2uWIBjE5mUtXlQ35MTHSqN0Xn7qHrg==
+  dependencies:
+    slash "^3.0.0"
+
 babel-plugin-syntax-jsx@^6.18.0:
   version "6.18.0"
   resolved "https://registry.yarnpkg.com/babel-plugin-syntax-jsx/-/babel-plugin-syntax-jsx-6.18.0.tgz#0af32a9a6e13ca7a3fd5069e62d7b0f58d0d8946"


### PR DESCRIPTION
## Please verify the following:

- [x] `yarn ci:test` **jest** tests pass with new tests, if relevant
- [x] `README.md` has been updated with your changes, if relevant

## Describe your PR

It the first attempt to closes #1770 

I installed the tooling with https://github.com/infinitered/ignite/pull/1886/commits/2da5b74a07812c1e941cd4a4384110a676d39102

@majidln
Before migrating the entire `/boilerplate` folder I need some inputs if you think it's in a good direction
https://github.com/infinitered/ignite/pull/1886/commits/d4f364bee4eab2a90d1c11335160cf610c25972d

Let me know in the comments 😉 

---

Nex Step:

- [ ] Fix model errors to avoid

```
 FAIL  app/models/character-store/character-store.test.ts
  ● Test suite failed to run

    [mobx-state-tree] expected mobx-state-tree type as argument 1, got undefined instead

       7 | // prettier-ignore
       8 | export const RootStoreModel = types.model("RootStore").props({
    >  9 |   characterStore: types.optional(CharacterStoreModel, {} as any),
         |                         ^
```         
