### PR TITLE
Fix AsyncImage bug when component is unmounted quickly

### DIFF
--- a/boilerplate/app/components/auto-image/auto-image.tsx
+++ b/boilerplate/app/components/auto-image/auto-image.tsx
@@ -27,20 +27,26 @@ export function AutoImage(props: ImageProps) {
   const [imageSize, setImageSize] = useState({ width: 0, height: 0 })
 
   useLayoutEffect(() => {
+    let mounted = true
+
     if (props.source?.uri) {
       RNImage.getSize(props.source.uri as any, (width, height) => {
-        setImageSize({ width, height })
+        if (mounted) setImageSize({ width, height })
       })
     } else if (Platform.OS === "web") {
       // web requires a different method to get it's size
       RNImage.getSize(props.source as any, (width, height) => {
-        setImageSize({ width, height })
+        if (mounted) setImageSize({ width, height })
       })
     } else {
       const { width, height } = RNImage.resolveAssetSource(props.source)
       setImageSize({ width, height })
     }
-  }, [])
+
+    return () => {
+      mounted = false
+    }
+  }, [props.source])
 
   return <RNImage {...props} style={[imageSize, props.style]} />
 }


### PR DESCRIPTION
AsyncImage does a callback to resize the image when it is finished downloading. However, if you unmount the component while the download is in-flight, you'll get an error:

```
 ERROR  Warning: Can't perform a React state update on an unmounted component. This is a no-op, but it indicates a memory leak in your application. To fix, cancel all subscriptions and asynchronous tasks in a useEffect cleanup function.
```

This PR will ensure that the state update only happens if the component is still mounted.

