### PR TITLE
Removes custom metro config & symlinks if using Expo

### DIFF
--- a/boilerplate/metro.config.expo.js
+++ b/boilerplate/metro.config.expo.js
@@ -1,0 +1,4 @@
+// Learn more https://docs.expo.io/guides/customizing-metro
+const { getDefaultConfig } = require("expo/metro-config")
+
+module.exports = getDefaultConfig(__dirname)

--- a/boilerplate/metro.config.expo.js
+++ b/boilerplate/metro.config.expo.js
@@ -2,3 +2,6 @@
 const { getDefaultConfig } = require("expo/metro-config")
 
 module.exports = getDefaultConfig(__dirname)
+
+// For one idea on how to support symlinks in Expo, see:
+// https://github.com/infinitered/ignite/issues/1904#issuecomment-1054535068

--- a/src/commands/new.ts
+++ b/src/commands/new.ts
@@ -202,6 +202,10 @@ export default {
       // rename the babel.config.expo.js
       filesystem.rename("./babel.config.expo.js", "babel.config.js")
 
+      // remove the metro config js, which causes problems with publishing
+      // see: https://github.com/infinitered/ignite/issues/1904
+      filesystem.remove("./metro.config.js")
+
       await toolbox.patching.update("./tsconfig.json", (config) => {
         config.include[0] = "App.js"
         return config

--- a/src/commands/new.ts
+++ b/src/commands/new.ts
@@ -202,9 +202,11 @@ export default {
       // rename the babel.config.expo.js
       filesystem.rename("./babel.config.expo.js", "babel.config.js")
 
-      // remove the metro config js, which causes problems with publishing
+      // replaces the custom metro config js, which causes problems with
+      // publishing to Expo, with the default Expo metro config
       // see: https://github.com/infinitered/ignite/issues/1904
       filesystem.remove("./metro.config.js")
+      filesystem.rename("./metro.config.expo.js", "metro.config.js")
 
       await toolbox.patching.update("./tsconfig.json", (config) => {
         config.include[0] = "App.js"
@@ -229,6 +231,7 @@ export default {
       filesystem.remove("./webpack.config.js")
       filesystem.remove("./index.expo.js")
       filesystem.remove("./babel.config.expo.js")
+      filesystem.remove("./metro.config.expo.js")
 
       // pnpm/yarn/npm install it
       startSpinner("Unboxing npm dependencies")


### PR DESCRIPTION
Fixes #1904 by removing the custom metro config file if using Expo and replacing with the default Expo metro config. Expo doesn't work with pnpm anyway, so we won't bother trying to enable symlinks if using Expo.

If you want to try @AlexanderLindkjaer's experimental symlink support, check #1904's comments.

Also fixes #1899 (I think)