### PR TITLE
Remove build commands for Expo Projects

### DIFF
--- a/src/commands/new.ts
+++ b/src/commands/new.ts
@@ -185,8 +185,8 @@ export default {
     if (expo) {
       const expoJson = filesystem.read("./package.expo.json", "json")
       packageJson = merge(packageJson, expoJson)
-      delete packageJson.scripts['build-ios']
-      delete packageJson.scripts['build-android']
+      delete packageJson.scripts["build-ios"]
+      delete packageJson.scripts["build-android"]
     }
 
     filesystem.write("./package.json", packageJson)

--- a/src/commands/new.ts
+++ b/src/commands/new.ts
@@ -185,8 +185,8 @@ export default {
     if (expo) {
       const expoJson = filesystem.read("./package.expo.json", "json")
       packageJson = merge(packageJson, expoJson)
-      delete packageJson.scripts['build-ios'];
-      delete packageJson.scripts['build-android'];
+      delete packageJson.scripts['build-ios']
+      delete packageJson.scripts['build-android']
     }
 
     filesystem.write("./package.json", packageJson)

--- a/src/commands/new.ts
+++ b/src/commands/new.ts
@@ -185,6 +185,8 @@ export default {
     if (expo) {
       const expoJson = filesystem.read("./package.expo.json", "json")
       packageJson = merge(packageJson, expoJson)
+      delete packageJson.scripts['build-ios'];
+      delete packageJson.scripts['build-android'];
     }
 
     filesystem.write("./package.json", packageJson)


### PR DESCRIPTION
## Please verify the following:

- [x] `yarn ci:test` **jest** tests pass with new tests, if relevant
- [x] `README.md` has been updated with your changes, if relevant

## Describe your PR
Removes the `build-ios` and `build-android` scripts from the generated package.json when using Expo flag. 

Fixes #1901 