### PR TITLE
fix(doctor): java version throws error

### DIFF
--- a/src/commands/doctor.ts
+++ b/src/commands/doctor.ts
@@ -96,9 +96,16 @@ module.exports = {
 
     // -=-=-=- android -=-=-=-
     const androidPath = process.env.ANDROID_HOME
-    const javaPath = which("java")
+    let javaPath = which("java")
     const javaVersionCmd = "java -version 2>&1"
-    const javaVersion = javaPath && (await run(javaVersionCmd))?.match(/"(.*)"/)?.slice(-1)[0]
+    let javaVersion
+
+    try {
+      javaVersion = javaPath && (await run(javaVersionCmd))?.match(/"(.*)"/)?.slice(-1)[0]
+    } catch (_) {
+      javaVersion = "-"
+      javaPath = "not installed"
+    }
 
     info("")
     info(colors.cyan("Android"))


### PR DESCRIPTION
## Please verify the following:

- [x] `yarn ci:test` **jest** tests pass with new tests, if relevant
- [ ] `README.md` has been updated with your changes, if relevant

## Describe your PR
There's a preinstalled `java` executable on mac, but it's not java (https://apple.stackexchange.com/a/348686).
Running doctor without installing java fails because the output of this executable is this:

> % java
> The operation couldn’t be completed. Unable to locate a Java Runtime.
> Please visit http://www.java.com for information on installing Java.

This pull request checks if the command ran successfully.

---

#### Before changes:

```
% ignite-cli doctor
System
  platform           darwin                                                 
  arch               x64                                                    
  cpu                8 cores      Intel(R) Core(TM) i3-10100F CPU @ 3.60GHz 
  directory          ignite       /Users/truetiem/Desktop/ignite            

JavaScript (and globally-installed packages)
  node               16.14.2      /usr/local/bin/node 
  npm                8.6.0        /usr/local/bin/npm  
    corepack         0.10.0                           
    npm              8.6.0                            
    yarn             1.22.18                          
  yarn               1.22.18      /usr/local/bin/yarn 
    expo-cli         5.3.2                            
  pnpm               -            not installed       

Ignite
  ignite-cli         7.10.8       /usr/local/bin/ignite              
  ignite src         src          /Users/truetiem/Desktop/ignite/src 
Error: Command failed: java -version 2>&1

    at ChildProcess.exithandler (node:child_process:399:12)
    at ChildProcess.emit (node:events:526:28)
    at ChildProcess.emit (node:domain:475:12)
    at maybeClose (node:internal/child_process:1092:16)
    at Process.ChildProcess._handle.onexit (node:internal/child_process:302:5) {
  killed: false,
  code: 1,
  signal: null,
  cmd: 'java -version 2>&1',
  stdout: 'The operation couldn’t be completed. Unable to locate a Java Runtime.\n' +
    'Please visit http://www.java.com for information on installing Java.\n' +
    '\n',
  stderr: ''
}
```

#### After changes:

```
truetiem@unknown18c04dc3ebfc ignite % ignite-cli doctor
System
  platform           darwin                                                 
  arch               x64                                                    
  cpu                8 cores      Intel(R) Core(TM) i3-10100F CPU @ 3.60GHz 
  directory          ignite       /Users/truetiem/Desktop/ignite            

JavaScript (and globally-installed packages)
  node               16.14.2      /usr/local/bin/node 
  npm                8.6.0        /usr/local/bin/npm  
    corepack         0.10.0                           
    npm              8.6.0                            
    yarn             1.22.18                          
  yarn               1.22.18      /usr/local/bin/yarn 
    expo-cli         5.3.2                            
  pnpm               -            not installed       

Ignite
  ignite-cli         7.10.8       /usr/local/bin/ignite              
  ignite src         src          /Users/truetiem/Desktop/ignite/src 

Android
  java               -            not installed 
  android home       -            undefined     

iOS
  xcode              13.3       
  cocoapods          1.10.1       /usr/local/bin/pod 
```