### PR TITLE
Feat/doctor expo version

### DIFF
--- a/src/commands/doctor.ts
+++ b/src/commands/doctor.ts
@@ -15,7 +15,7 @@ module.exports = {
   run: async function (toolbox: GluegunToolbox) {
     // fistful of features
     const {
-      filesystem: { separator },
+      filesystem: { separator, isFile },
       system: { run, which },
       print: { colors, info, table },
       strings: { padEnd },
@@ -74,9 +74,30 @@ module.exports = {
       : []
     const haveGlobalPackages = npmPackages.length > 0 || yarnPackages.length > 0
 
+    const expoVersionCmd = "npm list --depth 0 expo 2>&1"
+    let expoVersion
+    let expoWorkflow
+
+    function expoWorkflowInfo() {
+      const iosFound = isFile(`${directory}\ios\.xcodeproj`)
+      const androidFound = isFile(`${directory}\android\.gradle`)
+
+      return iosFound || androidFound
+    }
+
+    try {
+      expoVersion = (await run(expoVersionCmd))?.match(/expo@(.*)/)?.slice(-1)[0]
+      expoWorkflow = expoWorkflowInfo() ? 'bare' : 'managed'
+    } catch (_) {
+      expoVersion = "-"
+      expoWorkflow = "not installed"
+    }
+
+    const expoInfo = [column1("expo"), column2(expoVersion), column3(expoWorkflow)]
+
     info("")
     info(colors.cyan(`JavaScript${haveGlobalPackages ? " (and globally-installed packages)" : ""}`))
-    table([nodeInfo, npmInfo, ...npmPackages, yarnInfo, ...yarnPackages, pnpmInfo, ...pnpmPackages])
+    table([nodeInfo, npmInfo, ...npmPackages, yarnInfo, ...yarnPackages, pnpmInfo, ...pnpmPackages, expoInfo])
 
     // -=-=-=- ignite -=-=-=-
     const ignitePath = which("ignite")

--- a/src/commands/doctor.ts
+++ b/src/commands/doctor.ts
@@ -79,8 +79,8 @@ module.exports = {
     let expoWorkflow
 
     function expoWorkflowInfo() {
-      const iosFound = isFile(`${directory}\ios\.xcodeproj`)
-      const androidFound = isFile(`${directory}\android\.gradle`)
+      const iosFound = isFile(`${directory}\\ios\\.xcodeproj`)
+      const androidFound = isFile(`${directory}\\android\\.gradle`)
 
       return iosFound || androidFound
     }


### PR DESCRIPTION
## Please verify the following:

- [ ] `yarn ci:test` **jest** tests pass with new tests, if relevant
- [ ] `README.md` has been updated with your changes, if relevant

## Describe your PR
Implements #1928 

Might still need to use yarn when npm not available in detecting the Expo version? Thoughts?

For Expo projects:
![image](https://user-images.githubusercontent.com/374022/168505053-a172ce29-f498-482b-a012-6c0570229c32.png)

For non-Expo projects:
![image](https://user-images.githubusercontent.com/374022/168505028-02e98e67-135c-4aed-93b4-e0beea346ebe.png)
