### PR TITLE
removed `prettier/@typescript-eslint` in package.json

### DIFF
--- a/boilerplate/package.json
+++ b/boilerplate/package.json
@@ -150,8 +150,7 @@
       "plugin:react/recommended",
       "plugin:react-native/all",
       "standard",
-      "prettier",
-      "prettier/@typescript-eslint"
+      "prettier"
     ],
     "plugins": [
       "@typescript-eslint",


### PR DESCRIPTION

## Please verify the following:

- [x] `yarn ci:test` **jest** tests pass with new tests, if relevant
- [x] `README.md` has been updated with your changes, if relevant

## Describe your PR

prettier/@typescript-eslint was removed in eslint-config-prettier v8.0.0

see https://github.com/prettier/eslint-config-prettier/issues/173
also see more - https://github.com/prettier/eslint-config-prettier/blob/main/CHANGELOG.md#version-800-2021-02-21
