### PR TITLE
Downgrades Some Deps for Expo-Flavor.

### DIFF
--- a/boilerplate/package.expo.json
+++ b/boilerplate/package.expo.json
@@ -12,10 +12,14 @@
   },
   "dependencies": {
     "@expo/webpack-config": "^0.12.71",
-    "expo": "43.0.0",
+    "expo-linear-gradient": "~10.0.3",
+    "expo-localization": "~11.0.0",
+    "expo-modules-core": "~0.4.10",
     "expo-status-bar": "~1.1.0",
-    "react": "17.0.1",
-    "react-native": "https://github.com/expo/react-native/archive/sdk-43.0.0.tar.gz"
+    "expo": "43.0.0",
+    "react-native-gesture-handler": "~1.10.2",
+    "react-native": "https://github.com/expo/react-native/archive/sdk-43.0.0.tar.gz",
+    "react": "17.0.1"
   },
   "devDependencies": {
     "@types/react-dom": "16.9.8",


### PR DESCRIPTION
There are some open issues mentioning Ignite not running and reference `expo-linear-gradient` (e.g. #1963 , #1954). Those aren't 100% related (since they are specific to vanilla-flavor), but I did confirm that a freshly ignited app (using expo-flavor) does not build. 

| iOS Output  | Android Output |
| ------------- | ------------- |
| ![yulolimum-capture-2022-06-21--19-39-36@2x](https://user-images.githubusercontent.com/1775841/174931911-6f89f4a1-ac2d-44dc-9ce0-39d95844a5f9.jpg) | ![yulolimum-capture-2022-06-21--19-41-51@2x](https://user-images.githubusercontent.com/1775841/174932004-6ca0e0ba-c5c3-430b-870b-51359c9b0139.jpg) |

While starting the Expo dev server, I noticed this:

![yulolimum-capture-2022-06-21--19-42-31@2x](https://user-images.githubusercontent.com/1775841/174932047-d4b78ce9-4bd6-41ee-b5dd-2d4c9709f5e6.jpg)

Recently, there have been some new Ignite releases (upgrading to 0.68.x). The expo core dep got updated in vanilla-flavor, but not in expo-flavor (possibly due to expo-cli [prerequisite issue](https://github.com/expo/expo-cli/issues/4423)?). In any case, it's a good idea to always use recommended expo library versions. Upgrading core without libraries (or vice versa) can cause things to break. The real fix to this is to upgrade the expo-flavor boilerplate to latest and make sure we continue overriding the expo-flavor deps/libs according to the recommended. 

I downgraded the packages (in the expo-flavor package.json) that have jumped major versions compared to the recommended. The app now builds: 

![yulolimum-capture-2022-06-21--19-51-02@2x](https://user-images.githubusercontent.com/1775841/174933107-9373c029-7c09-4494-9661-0cad1bb0b38b.jpg)

PS: this won't fix the tagged issues unless they re-ignite their apps which isn't practical. 
