### PR TITLE
Updating how we rename the boilerplate project to the new name

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,6 +73,7 @@ npx ignite-cli generate --help
 If you run into problems, first search the issues in this repository. If you don't find anything, you can come talk to our friendly and active developers in the Infinite Red Community Slack ([community.infinite.red](http://community.infinite.red)).
 
 Note:
+
 - Navigation persistence is OFF by default in production.
 - Error boundary is set to 'always' display by default.
 

--- a/boilerplate/app/components/screen/screen.presets.ts
+++ b/boilerplate/app/components/screen/screen.presets.ts
@@ -53,7 +53,7 @@ export const presets = {
    * No scrolling if content fits the screen, otherwise it scrolls.
    *
    * Pick this one if you are unsure your content will fit the screen or if you want to automatically adapt to screen size.
-   * 
+   *
    * Offset options can be applied to tweak scroll toggling so content may not overfit the screen.
    */
   auto: {
@@ -64,7 +64,7 @@ export const presets = {
       percent: 0.92, // Manipulates the height comparison by percentage values. For example, 0.92 enables scroll when the contents height reaches 92% of the screen.
       point: 0, // Same as above but offsets the scroll break point value by the density-independent pixels.
     } as const,
-  }
+  },
 }
 
 /**

--- a/boilerplate/app/components/screen/screen.tsx
+++ b/boilerplate/app/components/screen/screen.tsx
@@ -1,5 +1,12 @@
 import * as React from "react"
-import { KeyboardAvoidingView, Platform, ScrollView, StatusBar, View, Dimensions } from "react-native"
+import {
+  KeyboardAvoidingView,
+  Platform,
+  ScrollView,
+  StatusBar,
+  View,
+  Dimensions,
+} from "react-native"
 import { useSafeAreaInsets } from "react-native-safe-area-context"
 import { ScreenProps } from "./screen.props"
 import { isNonScrolling, offsets, presets } from "./screen.presets"
@@ -34,19 +41,20 @@ function ScreenWithScrolling(props: ScreenProps) {
 
   // The followings for <Screen preset='auto'/>
   // This will automatically disables scrolling if content fits the screen.
-  const { height } = Dimensions.get('window')
+  const { height } = Dimensions.get("window")
   const scrollViewHeight = React.useRef(null)
   const [scrollEnabled, setScrollEnabled] = React.useState(true)
 
   const updateScrollState = () => {
-    if (props.preset === 'auto'){
+    if (props.preset === "auto") {
       // check whether if content fits the screen
       // then toggle scroll state according to it
-      const contentFitsScreen = scrollViewHeight.current < height * presets.auto.offset.percent - presets.auto.offset.point
-      
+      const contentFitsScreen =
+        scrollViewHeight.current < height * presets.auto.offset.percent - presets.auto.offset.point
+
       // content is less than the size of the screen, so we can disable scrolling
       if (scrollEnabled && contentFitsScreen) setScrollEnabled(false)
-      
+
       // content is greater than the size of the screen, so let's enable scrolling
       if (!scrollEnabled && !contentFitsScreen) setScrollEnabled(true)
     } else if (!scrollEnabled) {
@@ -64,7 +72,7 @@ function ScreenWithScrolling(props: ScreenProps) {
     updateScrollState()
   }
 
-  // update scroll state on every render 
+  // update scroll state on every render
   // when scrollViewHeight isn't null
   if (scrollViewHeight.current !== null) updateScrollState()
 
@@ -80,7 +88,7 @@ function ScreenWithScrolling(props: ScreenProps) {
           style={[preset.outer, backgroundStyle]}
           contentContainerStyle={[preset.inner, style]}
           keyboardShouldPersistTaps={props.keyboardShouldPersistTaps || "handled"}
-          onContentSizeChange={props.preset === 'auto' ? onContentSizeChange : undefined}
+          onContentSizeChange={props.preset === "auto" ? onContentSizeChange : undefined}
           scrollEnabled={scrollEnabled}
         >
           {props.children}

--- a/src/tools/react-native.ts
+++ b/src/tools/react-native.ts
@@ -82,8 +82,6 @@ export async function renameReactNativeApp(
 
   // prettier-ignore
   await Promise.allSettled([
-    rename(`android/app/src/main/java/com/${oldnamelower}`, newnamelower),
-    rename(`android/app/src/debug/java/com/${oldnamelower}`, newnamelower),
     rename(`ios/${oldName}.xcodeproj/xcshareddata/xcschemes/${oldName}.xcscheme`, `${newName}.xcscheme`),
     rename(`ios/${oldName}Tests/${oldName}Tests.m`, `${newName}Tests.m`),
     rename(`ios/${oldName}-Bridging-Header.h`, `${newName}-Bridging-Header.h`),
@@ -107,13 +105,11 @@ export async function renameReactNativeApp(
 
     // move everything at the old bundle identifier path to the new one
     await Promise.allSettled([
-      moveDeepFolder(
-        toolbox,
+      filesystem.moveAsync(
         `android/app/src/main/java/${oldPath}`,
         `android/app/src/main/java/${newPath}`,
       ),
-      moveDeepFolder(
-        toolbox,
+      filesystem.moveAsync(
         `android/app/src/debug/java/${oldPath}`,
         `android/app/src/debug/java/${newPath}`,
       ),
@@ -174,23 +170,4 @@ export async function renameReactNativeApp(
       await filesystem.writeAsync(file, newContent, { atomic: true })
     }),
   )
-}
-
-async function moveDeepFolder(toolbox: GluegunToolbox, oldPath: string, newPath: string) {
-  const { filesystem } = toolbox
-  const { path } = filesystem
-
-  // ensure newPath exists
-  await filesystem.dirAsync(newPath)
-
-  // move the files
-  const filesToMove = children(oldPath)
-  const movePromises = filesToMove.map((file) =>
-    filesystem.moveAsync(path(oldPath, file), path(newPath, file)),
-  )
-
-  await Promise.allSettled(movePromises)
-
-  // remove the old folder
-  await filesystem.removeAsync(oldPath)
 }


### PR DESCRIPTION
## Please verify the following:

- [x] `yarn ci:test` **jest** tests pass with new tests, if relevant
- [ ] `README.md` has been updated with your changes, if relevant

## Describe your PR

This PR updates how we "rename" the boilerplate project to the new specified project name. Issue #1963 brought up that android wasn't renaming correctly when we have a specific bundle identifier like `com.infinitered.pizzaapp`. The result was android would keep `helloworld` instead.