### PR TITLE
Properly type Icon component icon prop as required

### DIFF
--- a/boilerplate/app/components/icon/icon.props.ts
+++ b/boilerplate/app/components/icon/icon.props.ts
@@ -17,5 +17,5 @@ export interface IconProps {
    * The name of the icon
    */
 
-  icon?: IconTypes
+  icon: IconTypes
 }


### PR DESCRIPTION
## Please verify the following:

- [ ] `yarn ci:test` **jest** tests pass with new tests, if relevant
- [ ] `README.md` has been updated with your changes, if relevant

## Describe your PR

The `Icon` component will do nothing without passing an `icon` prop to it. This corrects the prop types so that `icon` is not marked optional