### PR TITLE
SnapshotIn import missing

### DIFF
--- a/boilerplate/ignite/templates/model/NAME.ts.ejs
+++ b/boilerplate/ignite/templates/model/NAME.ts.ejs
@@ -1,4 +1,4 @@
-import { Instance, SnapshotOut, types } from "mobx-state-tree"
+import { Instance, SnapshotIn, SnapshotOut, types } from "mobx-state-tree"
 
 /**
  * Model description here for TypeScript hints.


### PR DESCRIPTION
When you create a model, you must manually import SnapshotIn. 
