### PR TITLE
Handle warn output for packager.list

### DIFF
--- a/package.json
+++ b/package.json
@@ -41,7 +41,8 @@
     "ci:test": "yarn ci:prep && yarn ci:test:vanilla && yarn ci:test:expo && yarn clean",
     "ci:publish": "yarn build && yarn semantic-release && yarn clean",
     "semantic-release": "semantic-release",
-    "clean": "rm -rf ./build && rm ./boilerplate/.gitignore.template"
+    "clean": "rm -rf ./build && rm ./boilerplate/.gitignore.template",
+    "ignite:local": "node ./bin/ignite" 
   },
   "devEngines": {
     "node": ">=7.x",

--- a/src/commands/new.ts
+++ b/src/commands/new.ts
@@ -84,7 +84,6 @@ export default {
 
     const ignitePath = path(`${meta.src}`, "..")
     const boilerplatePath = path(ignitePath, "boilerplate")
-    const cliEnv = expo && debug ? { ...process.env, EXPO_DEBUG: 1 } : process.env
     log({ expo, ignitePath, boilerplatePath })
 
     // welcome everybody!
@@ -104,7 +103,6 @@ export default {
       // generate the project
       startSpinner("Igniting app")
       await spawnProgress(log(expoCLIString), {
-        env: cliEnv,
         onProgress: (out: string) => {
           stopSpinner("Igniting app", "🔥")
 

--- a/src/tools/guards.test.ts
+++ b/src/tools/guards.test.ts
@@ -1,7 +1,7 @@
-import { isValidJson, isYarnListOutput } from "./guards"
+import { isNpmListOutput, isStringifiedJson, isYarnListOutput } from "./guards"
 
 describe("guards", () => {
-  describe("isValidJson", () => {
+  describe("isStringifiedJson", () => {
     const tests = [
       { input: '{"foo": "bar"}', output: true },
       { input: '{"foo": "bar"', output: false },
@@ -9,7 +9,7 @@ describe("guards", () => {
 
     tests.forEach(({ input, output }) => {
       it(`should return '${output}' for '${input}'`, () => {
-        expect(isValidJson(input)).toBe(output)
+        expect(isStringifiedJson(input)).toBe(output)
       })
     })
   })
@@ -40,6 +40,38 @@ describe("guards", () => {
     tests.forEach(({ input, output }) => {
       it(`should return '${output}' for '${input}'`, () => {
         expect(isYarnListOutput(input)).toBe(output)
+      })
+    })
+  })
+
+  describe("isNpmListOutput", () => {
+    const tests = [
+      {
+        input: {
+          resolved: "file:../../Roaming/fnm/node-versions/v16.16.0/installation",
+          dependencies: {
+            corepack: {
+              version: "0.10.0",
+            },
+            "expo-cli": {
+              version: "6.0.1",
+            },
+            npm: {
+              version: "8.11.0",
+            },
+          },
+        },
+        output: true,
+      },
+      {
+        input: `npm WARN config global \`--global\`, \`--local\` are deprecated. Use \`--location=global\` instead.`,
+        output: false,
+      },
+    ]
+
+    tests.forEach(({ input, output }) => {
+      it(`should return '${output}' for '${input}'`, () => {
+        expect(isNpmListOutput(input)).toBe(output)
       })
     })
   })

--- a/src/tools/guards.test.ts
+++ b/src/tools/guards.test.ts
@@ -1,4 +1,4 @@
-import { isValidJson } from "./guards"
+import { isValidJson, isYarnListOutput } from "./guards"
 
 describe("guards", () => {
   describe("isValidJson", () => {
@@ -10,6 +10,36 @@ describe("guards", () => {
     tests.forEach(({ input, output }) => {
       it(`should return '${output}' for '${input}'`, () => {
         expect(isValidJson(input)).toBe(output)
+      })
+    })
+  })
+
+  describe("isYarnListOutput", () => {
+    const tests = [
+      {
+        input: `
+          yarn global v1.22.17
+          info "create-expo-app@1.1.1" has binaries:
+            - create-expo-app
+          info "detox-cli@19.0.0" has binaries:
+            - detox
+          Done in 0.21s
+        `,
+        output: true,
+      },
+      {
+        input: `
+          yarn run v1.22.17
+          error Command "sdfsdfs" not found.
+          info Visit https://yarnpkg.com/en/docs/cli/run for documentation about this command.
+        `,
+        output: false,
+      },
+    ]
+
+    tests.forEach(({ input, output }) => {
+      it(`should return '${output}' for '${input}'`, () => {
+        expect(isYarnListOutput(input)).toBe(output)
       })
     })
   })

--- a/src/tools/guards.test.ts
+++ b/src/tools/guards.test.ts
@@ -1,0 +1,16 @@
+import { isValidJson } from "./guards"
+
+describe("guards", () => {
+  describe("isValidJson", () => {
+    const tests = [
+      { input: '{"foo": "bar"}', output: true },
+      { input: '{"foo": "bar"', output: false },
+    ]
+
+    tests.forEach(({ input, output }) => {
+      it(`should return '${output}' for '${input}'`, () => {
+        expect(isValidJson(input)).toBe(output)
+      })
+    })
+  })
+})

--- a/src/tools/guards.ts
+++ b/src/tools/guards.ts
@@ -1,4 +1,4 @@
-export function isStringifiedJson(input: unknown): boolean {
+export function isStringifiedJson(input: unknown): input is string {
   if (typeof input !== "string") {
     return false
   }
@@ -12,7 +12,7 @@ export function isStringifiedJson(input: unknown): boolean {
   return isValid
 }
 
-export function isYarnListOutput(output: unknown): boolean {
+export function isYarnListOutput(output: unknown): output is string {
   return (
     typeof output === "string" &&
     output.split("\n").some((line) => {

--- a/src/tools/guards.ts
+++ b/src/tools/guards.ts
@@ -7,3 +7,13 @@ export function isValidJson(input: string): boolean {
 
   return isValid
 }
+
+export function isYarnListOutput(output: unknown): boolean {
+  return (
+    typeof output === "string" &&
+    output.split("\n").some((line) => {
+      const match = line.match(/info "([^@]+)@([^"]+)" has binaries/)
+      return match?.length > 0
+    })
+  )
+}

--- a/src/tools/guards.ts
+++ b/src/tools/guards.ts
@@ -1,0 +1,9 @@
+export function isValidJson(input: string): boolean {
+  let isValid = false
+  try {
+    JSON.parse(input)
+    isValid = true
+  } catch {}
+
+  return isValid
+}

--- a/src/tools/guards.ts
+++ b/src/tools/guards.ts
@@ -1,4 +1,8 @@
-export function isValidJson(input: string): boolean {
+export function isStringifiedJson(input: unknown): boolean {
+  if (typeof input !== "string") {
+    return false
+  }
+
   let isValid = false
   try {
     JSON.parse(input)
@@ -15,5 +19,23 @@ export function isYarnListOutput(output: unknown): boolean {
       const match = line.match(/info "([^@]+)@([^"]+)" has binaries/)
       return match?.length > 0
     })
+  )
+}
+
+export type NpmListOutput = { dependencies: Record<string, { version: string }> }
+export function isNpmListOutput(output: unknown): output is NpmListOutput {
+  if (typeof output !== "object" || Array.isArray(output) === true || output === null) {
+    return false
+  }
+
+  return (
+    "dependencies" in output &&
+    Object.entries((output as { dependencies: unknown }).dependencies).every(
+      ([key, value]) =>
+        typeof key === "string" &&
+        typeof value === "object" &&
+        "version" in value &&
+        typeof value.version === "string",
+    )
   )
 }

--- a/src/tools/guards.ts
+++ b/src/tools/guards.ts
@@ -22,7 +22,7 @@ export function isYarnListOutput(output: unknown): output is string {
   )
 }
 
-export type NpmListOutput = { dependencies: Record<string, { version: string }> }
+export type NpmListOutput = { dependencies: Record<string, { version?: string }> }
 export function isNpmListOutput(output: unknown): output is NpmListOutput {
   if (typeof output !== "object" || Array.isArray(output) === true || output === null) {
     return false
@@ -33,9 +33,7 @@ export function isNpmListOutput(output: unknown): output is NpmListOutput {
     Object.entries((output as { dependencies: unknown }).dependencies).every(
       ([key, value]) =>
         typeof key === "string" &&
-        typeof value === "object" &&
-        "version" in value &&
-        typeof value.version === "string",
+        (typeof value?.version === "string" || value?.version === undefined),
     )
   )
 }

--- a/src/tools/packager.test.ts
+++ b/src/tools/packager.test.ts
@@ -1,0 +1,61 @@
+import { list } from "./packager"
+
+describe("packager", () => {
+  describe("list", () => {
+    it("should be defined", () => {
+      expect(list).toBeDefined()
+    })
+
+    it("should return a command and parser", () => {
+      const [cmd, parser] = list()
+      expect(cmd).toBeDefined()
+      expect(parser).toBeDefined()
+    })
+
+    describe("npm", () => {
+      it("should parse valid command output", () => {
+        const [, parser] = list({ packagerName: "npm" })
+        const cmdOutput = `
+          {
+            "resolved": "file:../../Roaming/fnm/node-versions/v16.16.0/installation",
+            "dependencies": {
+              "corepack": {
+                "version": "0.10.0"
+              },
+              "expo-cli": {
+                "version": "6.0.1"
+              },
+              "npm": {
+                "version": "8.11.0"
+              }
+            }
+          }
+        `
+        expect(parser(cmdOutput)).toEqual([
+          ["corepack", "0.10.0"],
+          ["expo-cli", "6.0.1"],
+          ["npm", "8.11.0"],
+        ])
+      })
+    })
+
+    describe("yarn", () => {
+      it("should parse valid command output", () => {
+        const output: string = `
+        yarn global v1.22.17
+        info "detox-cli@19.0.0" has binaries:
+           - detox
+        Done in 0.16s.
+        `
+        const [, parser] = list({ packagerName: "yarn" })
+        expect(parser(output)).toEqual([["detox-cli", "19.0.0"]])
+      })
+    })
+
+    describe("pnpm", () => {
+      it("should throw error", () => {
+        expect(() => list({ packagerName: "pnpm" })).toThrow()
+      })
+    })
+  })
+})

--- a/src/tools/packager.test.ts
+++ b/src/tools/packager.test.ts
@@ -1,7 +1,7 @@
 import { cmdChunkReducer, list } from "./packager"
 
 describe("packager", () => {
-  describe("outputReducer", () => {
+  describe("cmdChunkReducer", () => {
     describe("npm", () => {
       it("should be defined", () => {
         expect(cmdChunkReducer.npm).toBeDefined()
@@ -53,6 +53,29 @@ describe("packager", () => {
         ]
 
         expect(cmdChunkReducer.npm(cmdOutputChunks)).toEqual(cmdOutputChunks[2])
+      })
+
+      it("should return undefined if expected chunk with valid JSON is not found", () => {
+        const cmdOutputChunks = [
+          `npm WARN config global \`--global\`, \`--local\` are deprecated. Use \`--location=global\` instead.`,
+          `npm WARN config global \`--global\`, \`--local\` are deprecated. Use \`--location=global\` instead.`,
+        ]
+
+        expect(cmdChunkReducer.npm(cmdOutputChunks)).toBeUndefined()
+      })
+
+      it("should return undefined if dependencies key is not in json chunk", () => {
+        const cmdOutputChunks = [
+          `npm WARN config global \`--global\`, \`--local\` are deprecated. Use \`--location=global\` instead.`,
+          `npm WARN config global \`--global\`, \`--local\` are deprecated. Use \`--location=global\` instead.`,
+          `
+            {
+              "resolved": "file:../../Roaming/fnm/node-versions/v16.16.0/installation",
+            }
+          `,
+        ]
+
+        expect(cmdChunkReducer.npm(cmdOutputChunks)).toBeUndefined()
       })
     })
   })

--- a/src/tools/packager.test.ts
+++ b/src/tools/packager.test.ts
@@ -1,4 +1,4 @@
-import { cmdChunkReducer, listCmd, listCmdOutputParser } from "./packager"
+import { listCmd, listCommandServices } from "./packager"
 
 describe("packager", () => {
   const npmCommandOutput = `
@@ -19,95 +19,14 @@ describe("packager", () => {
     `
   const npmWarnOutput = `npm WARN config global \`--global\`, \`--local\` are deprecated. Use \`--location=global\` instead.`
 
-  describe("cmdChunkReducer", () => {
-    describe("npm", () => {
-      it("should be defined", () => {
-        expect(cmdChunkReducer.npm).toBeDefined()
-      })
-
-      it("should reduce single command chunk", () => {
-        expect(cmdChunkReducer.npm([npmCommandOutput])).toEqual(npmCommandOutput)
-      })
-
-      it("should reduce command chunks with warnings", () => {
-        const cmdOutputChunks = [npmWarnOutput, npmWarnOutput, npmCommandOutput]
-
-        expect(cmdChunkReducer.npm([npmCommandOutput])).toEqual(cmdOutputChunks[2])
-      })
-
-      it("should return undefined if expected chunk with valid JSON is not found", () => {
-        const cmdOutputChunks = [npmWarnOutput, npmWarnOutput]
-
-        expect(cmdChunkReducer.npm(cmdOutputChunks)).toBeUndefined()
-      })
-
-      it("should return undefined if dependencies key is not in json chunk", () => {
-        const cmdOutputChunks = [
-          npmWarnOutput,
-          npmWarnOutput,
-          `
-            {
-              "resolved": "file:../../Roaming/fnm/node-versions/v16.16.0/installation",
-            }
-          `,
-        ]
-
-        expect(cmdChunkReducer.npm(cmdOutputChunks)).toBeUndefined()
-      })
-    })
-  })
-
-  describe("listCmdOutputParser", () => {
-    it("should be defined", () => {
-      expect(listCmdOutputParser).toBeDefined()
-    })
-
-    it("should return a command and parser", () => {
-      const [cmd, parser] = listCmdOutputParser()
-      expect(cmd).toBeDefined()
-      expect(parser).toBeDefined()
-    })
-
-    describe("npm", () => {
-      it("should parse valid command output", () => {
-        const [, parser] = listCmdOutputParser({ packagerName: "npm" })
-
-        expect(parser(npmCommandOutput)).toEqual([
-          ["corepack", "0.10.0"],
-          ["expo-cli", "6.0.1"],
-          ["npm", "8.11.0"],
-        ])
-      })
-    })
-
-    describe("yarn", () => {
-      it("should parse valid command output", () => {
-        const output = `
-        yarn global v1.22.17
-        info "detox-cli@19.0.0" has binaries:
-           - detox
-        Done in 0.16s.
-        `
-        const [, parser] = listCmdOutputParser({ packagerName: "yarn" })
-        expect(parser(output)).toEqual([["detox-cli", "19.0.0"]])
-      })
-    })
-
-    describe("pnpm", () => {
-      it("should throw error", () => {
-        expect(() => listCmdOutputParser({ packagerName: "pnpm" })).toThrow()
-      })
-    })
-  })
-
   describe("listCmd", () => {
     it("should be defined", () => {
       expect(listCmd).toBeDefined()
     })
 
     describe("npm", () => {
-      const [cmd, parser] = listCmdOutputParser({ packagerName: "npm" })
-      const reducer = cmdChunkReducer.npm
+      const { factory, parser, reducer } = listCommandServices.npm
+      const cmd = factory({ global: false })
 
       it("should return expected command output", async () => {
         const executer = async () => [npmCommandOutput]
@@ -123,6 +42,68 @@ describe("packager", () => {
         const executer = async () => [npmWarnOutput, npmWarnOutput]
 
         expect(listCmd({ cmd, parser, executer, reducer })).rejects.toThrow()
+      })
+
+      describe("reducer", () => {
+        it("should be defined", () => {
+          expect(reducer).toBeDefined()
+        })
+
+        it("should reduce single command chunk", () => {
+          expect(reducer([npmCommandOutput])).toEqual(npmCommandOutput)
+        })
+
+        it("should reduce command chunks with warnings", () => {
+          const cmdOutputChunks = [npmWarnOutput, npmWarnOutput, npmCommandOutput]
+
+          expect(reducer([npmCommandOutput])).toEqual(cmdOutputChunks[2])
+        })
+
+        it("should return undefined if expected chunk with valid JSON is not found", () => {
+          const cmdOutputChunks = [npmWarnOutput, npmWarnOutput]
+
+          expect(reducer(cmdOutputChunks)).toBeUndefined()
+        })
+
+        it("should return undefined if dependencies key is not in json chunk", () => {
+          const cmdOutputChunks = [
+            npmWarnOutput,
+            npmWarnOutput,
+            `
+              {
+                "resolved": "file:../../Roaming/fnm/node-versions/v16.16.0/installation",
+              }
+            `,
+          ]
+
+          expect(reducer(cmdOutputChunks)).toBeUndefined()
+        })
+      })
+
+      describe("parser", () => {
+        it("should parse valid command output", () => {
+          expect(parser(npmCommandOutput)).toEqual([
+            ["corepack", "0.10.0"],
+            ["expo-cli", "6.0.1"],
+            ["npm", "8.11.0"],
+          ])
+        })
+      })
+    })
+
+    describe("yarn", () => {
+      const { parser } = listCommandServices.yarn
+
+      describe("parser", () => {
+        it("should parse valid command output", () => {
+          const output = `
+            yarn global v1.22.17
+            info "detox-cli@19.0.0" has binaries:
+              - detox
+            Done in 0.16s.
+          `
+          expect(parser(output)).toEqual([["detox-cli", "19.0.0"]])
+        })
       })
     })
   })

--- a/src/tools/packager.test.ts
+++ b/src/tools/packager.test.ts
@@ -97,7 +97,7 @@ describe("packager", () => {
 
     describe("yarn", () => {
       it("should parse valid command output", () => {
-        const output: string = `
+        const output = `
         yarn global v1.22.17
         info "detox-cli@19.0.0" has binaries:
            - detox

--- a/src/tools/packager.test.ts
+++ b/src/tools/packager.test.ts
@@ -56,7 +56,7 @@ describe("packager", () => {
         it("should reduce command chunks with warnings", () => {
           const cmdOutputChunks = [npmWarnOutput, npmWarnOutput, npmCommandOutput]
 
-          expect(reducer([npmCommandOutput])).toEqual(cmdOutputChunks[2])
+          expect(reducer(cmdOutputChunks)).toEqual(cmdOutputChunks[2])
         })
 
         it("should return undefined if expected chunk with valid JSON is not found", () => {

--- a/src/tools/packager.test.ts
+++ b/src/tools/packager.test.ts
@@ -1,4 +1,4 @@
-import { listCmd, listCommandServices } from "./packager"
+import { listCmd, listCmdServices } from "./packager"
 
 describe("packager", () => {
   describe("listCmd", () => {
@@ -25,7 +25,7 @@ describe("packager", () => {
       `
       const npmWarnOutput = `npm WARN config global \`--global\`, \`--local\` are deprecated. Use \`--location=global\` instead.`
 
-      const { factory, parser, reducer } = listCommandServices.npm
+      const { factory, parser, reducer } = listCmdServices.npm
       const cmd = factory({ global: false })
 
       it("should return expected command output", async () => {
@@ -101,7 +101,7 @@ describe("packager", () => {
         Done in 0.21s
       `
 
-      const { factory, parser, reducer } = listCommandServices.yarn
+      const { factory, parser, reducer } = listCmdServices.yarn
       const cmd = factory({ global: false })
 
       it("should return expected command output", async () => {

--- a/src/tools/packager.test.ts
+++ b/src/tools/packager.test.ts
@@ -1,6 +1,62 @@
-import { list } from "./packager"
+import { cmdChunkReducer, list } from "./packager"
 
 describe("packager", () => {
+  describe("outputReducer", () => {
+    describe("npm", () => {
+      it("should be defined", () => {
+        expect(cmdChunkReducer.npm).toBeDefined()
+      })
+
+      it("should reduce single command chunk", () => {
+        const cmdOutputChunks = [
+          `
+          {
+            "resolved": "file:../../Roaming/fnm/node-versions/v16.16.0/installation",
+            "dependencies": {
+              "corepack": {
+                "version": "0.10.0"
+              },
+              "expo-cli": {
+                "version": "6.0.1"
+              },
+              "npm": {
+                "version": "8.11.0"
+              }
+            }
+          }
+          `,
+        ]
+
+        expect(cmdChunkReducer.npm(cmdOutputChunks)).toEqual(cmdOutputChunks[0])
+      })
+
+      it("should reduce command chunks with warnings", () => {
+        const cmdOutputChunks = [
+          `npm WARN config global \`--global\`, \`--local\` are deprecated. Use \`--location=global\` instead.`,
+          `npm WARN config global \`--global\`, \`--local\` are deprecated. Use \`--location=global\` instead.`,
+          `
+            {
+              "resolved": "file:../../Roaming/fnm/node-versions/v16.16.0/installation",
+              "dependencies": {
+                "corepack": {
+                    "version": "0.10.0"
+                },
+                "expo-cli": {
+                    "version": "6.0.1"
+                },
+                "npm": {
+                    "version": "8.11.0"
+                }
+              }
+            }
+          `,
+        ]
+
+        expect(cmdChunkReducer.npm(cmdOutputChunks)).toEqual(cmdOutputChunks[2])
+      })
+    })
+  })
+
   describe("list", () => {
     it("should be defined", () => {
       expect(list).toBeDefined()

--- a/src/tools/packager.ts
+++ b/src/tools/packager.ts
@@ -172,7 +172,7 @@ export const listCommandServices: Record<PackageManager, ListCommandServices> = 
     reducer: (cmdChunks) => cmdChunks.find((line) => isYarnListOutput(line)),
     parser: (output) =>
       output.split("\n").reduce<Dependency[]>((acc, line) => {
-        /* Parse yarn's human-readable output*/
+        /* Parse yarn's human-readable output */
         const match = line.match(/info "([^@]+)@([^"]+)" has binaries/)
         const key = match?.[1]
         const semver = match?.[2]

--- a/src/tools/packager.ts
+++ b/src/tools/packager.ts
@@ -171,13 +171,15 @@ export const listCommandServices: Record<PackageManager, ListCommandServices> = 
   yarn: {
     factory: (options) => `yarn${options.global ? " global" : ""} list`,
     reducer: (cmdChunks) => cmdChunks.find((line) => isYarnListOutput(line)),
-    parser: (output: string): Dependency[] => {
-      // Parse yarn's human-readable output
-      return output.split("\n").reduce((acc: Dependency[], line: string): Dependency[] => {
+    parser: (output) =>
+      output.split("\n").reduce<Dependency[]>((acc, line) => {
+        /* Parse yarn's human-readable output*/
         const match = line.match(/info "([^@]+)@([^"]+)" has binaries/)
-        return match ? [...acc, [match[1], match[2]]] : acc
-      }, [])
-    },
+        const key = match?.[1]
+        const semver = match?.[2]
+
+        return key && semver ? [...acc, [key, semver]] : acc
+      }, []),
   },
   pnpm: {
     factory: () => {

--- a/src/tools/packager.ts
+++ b/src/tools/packager.ts
@@ -6,6 +6,8 @@ import { spawnChunked, spawnProgress } from "./spawn"
 // in the meantime, we'll use this hacked together version
 
 // Expo doesn't support pnpm, so we'll use yarn or npm
+
+// #region Shared Types
 type PackageManager = "npm" | "yarn" | "pnpm"
 type SupportedPackager = "npm" | "yarn"
 
@@ -28,16 +30,9 @@ type PackageOptions =
 type PackageRunOptions = PackageOptions & {
   onProgress?: (out: string) => void
 }
-const packageInstallOptions: PackageRunOptions = {
-  dev: false,
-  expo: false,
-  onProgress: (out: string) => console.log(out),
-}
+// #endregion
 
-const packageListOptions: PackageOptions = {
-  global: false,
-}
-
+// #region Utilities
 let isYarn
 function yarnAvailable() {
   if (isYarn !== undefined) return isYarn
@@ -62,6 +57,13 @@ function detectPackager(options: PackageOptions): PackageManager {
     return "npm"
   }
 }
+
+const packageInstallOptions: PackageRunOptions = {
+  dev: false,
+  expo: false,
+  onProgress: (out: string) => console.log(out),
+}
+// #endregion
 
 /**
  *
@@ -142,6 +144,7 @@ function installCmd(options: PackageRunOptions) {
   }
 }
 
+// #region listCmd
 type CmdChunkReducer = (cmdChunks: string[]) => string | undefined
 export const cmdChunkReducer: Record<PackageManager, CmdChunkReducer> = {
   npm: (cmdChunks) =>
@@ -153,6 +156,7 @@ export const cmdChunkReducer: Record<PackageManager, CmdChunkReducer> = {
 type Dependency = [key: string, semver: string]
 type DependencyParser = (output: string) => Dependency[]
 type PackageListOutputParser = [cmd: string, parser: DependencyParser]
+const packageListOptions: PackageOptions = { global: false }
 export function listCmdOutputParser(
   options: PackageOptions = packageListOptions,
 ): PackageListOutputParser {
@@ -204,6 +208,7 @@ export async function listCmd({ cmd, executer, reducer, parser }: ListCmdService
 
   return parser(cmdOutput)
 }
+// #endregion
 
 /**
  * Returns a string command to run a script via a packager of your choice.

--- a/src/tools/packager.ts
+++ b/src/tools/packager.ts
@@ -139,7 +139,7 @@ function installCmd(options: PackageRunOptions) {
 }
 
 type PackageListOutput = [string, (string) => [string, string][]]
-function list(options: PackageOptions = packageListOptions): PackageListOutput {
+export function list(options: PackageOptions = packageListOptions): PackageListOutput {
   if (options.packagerName === "pnpm") {
     // TODO: pnpm list?
     throw new Error("pnpm list is not supported yet")

--- a/src/tools/packager.ts
+++ b/src/tools/packager.ts
@@ -171,7 +171,7 @@ export const listCmdServices: Record<PackageManager, ListCmdServices> = {
       // npm returns a single JSON blob with a "dependencies" key
       const json: NpmListOutput = JSON.parse(output)
       const entries = Object.entries(json.dependencies)
-      return entries.map(([name, value]) => [name, value.version])
+      return entries.map(([name, value]) => [name, value?.version ?? ""])
     },
   },
   yarn: {
@@ -182,7 +182,7 @@ export const listCmdServices: Record<PackageManager, ListCmdServices> = {
         /* Parse yarn's human-readable output */
         const match = line.match(/info "([^@]+)@([^"]+)" has binaries/)
         const name = match?.[1]
-        const semver = match?.[2]
+        const semver = match?.[2] ?? ""
 
         return name && semver ? [...acc, [name, semver]] : acc
       }, []),

--- a/src/tools/packager.ts
+++ b/src/tools/packager.ts
@@ -1,5 +1,5 @@
 import { system } from "gluegun"
-import { isValidJson } from "./guards"
+import { isValidJson, isYarnListOutput } from "./guards"
 import { spawnChunked, spawnProgress } from "./spawn"
 
 // we really need a packager core extension on Gluegun
@@ -170,7 +170,7 @@ export const listCommandServices: Record<PackageManager, ListCommandServices> = 
   },
   yarn: {
     factory: (options) => `yarn${options.global ? " global" : ""} list`,
-    reducer: (cmdChunks) => cmdChunks[0],
+    reducer: (cmdChunks) => cmdChunks.find((line) => isYarnListOutput(line)),
     parser: (output: string): Dependency[] => {
       // Parse yarn's human-readable output
       return output.split("\n").reduce((acc: Dependency[], line: string): Dependency[] => {

--- a/src/tools/spawn.test.ts
+++ b/src/tools/spawn.test.ts
@@ -1,0 +1,27 @@
+import { spawnChunked, spawnProgress } from "./spawn"
+
+describe("spawn", () => {
+  describe("spawnProgress", () => {
+    it("should be defined", () => {
+      expect(spawnProgress).toBeDefined()
+    })
+
+    it('should not throw error on "npm list --global --depth=0 --json" input', async () => {
+      const output = await spawnProgress("npm list --global --depth=0 --json", {})
+      expect(typeof output).toBe("string")
+    })
+  })
+
+  describe("spawnChunked", () => {
+    it("should be defined", () => {
+      expect(spawnChunked).toBeDefined()
+    })
+
+    it('should not throw error on "npm list --global --depth=0 --json" input', async () => {
+      const output = await spawnChunked("npm list --global --depth=0 --json")
+      expect(output).toBeDefined()
+      expect(Array.isArray(output)).toBe(true)
+      expect(output.every((chunk) => typeof chunk === "string")).toBe(true)
+    })
+  })
+})

--- a/src/tools/spawn.ts
+++ b/src/tools/spawn.ts
@@ -1,7 +1,9 @@
 export type SpawnOptions = {
+  /** Callback on every std out from spawned process */
   onProgress?: (data: string) => void
-  env?: Record<string, unknown>
 }
+
+/** Spawn process, run commandLine string as command, and return output as string */
 export function spawnProgress(commandLine: string, options: SpawnOptions): Promise<string> {
   return new Promise((resolve, reject) => {
     const args = commandLine.split(" ")
@@ -16,4 +18,12 @@ export function spawnProgress(commandLine: string, options: SpawnOptions): Promi
     spawned.on("close", (code) => (code === 0 ? resolve(output.join("")) : reject(output.join(""))))
     spawned.on("error", (err) => reject(err))
   })
+}
+
+/** Spawn process, run commandLine string as command, and return each std out line as an array of strings */
+export async function spawnChunked(commandLine: string, options?: SpawnOptions): Promise<string[]> {
+  const output: string[] = []
+  const option = options ?? { onProgress: (data: string) => output.push(data) }
+  await spawnProgress(commandLine, option)
+  return output
 }


### PR DESCRIPTION
## Please verify the following:

- [x] `yarn ci:test` **jest** tests pass with new tests, if relevant
- [x] `README.md` has been updated with your changes, if relevant

## Describe your PR

Resolves #1993 by parsing `spawn` output as chunks of strings instead of one joined string
- Added new `spawnChunked` tool, to grab command output from a spawned process as a array of string chunks instead of one joined string
- Refactored `list` function in `packager` tool to use dependency injection for services, in order to make it easier to test specific use cases
- Added tests to ensure that `listCmd` can handle unexpected `yarn list` or `npm list` outputs
- Added guards to get runtime typechecks of command outputs

