### PR TITLE
Handle "npm WARN" output in npm packager list command via regex replace

### DIFF
--- a/src/tools/packager.test.ts
+++ b/src/tools/packager.test.ts
@@ -29,6 +29,35 @@ describe("packager", () => {
 
         expect(() => parseFn(input)).not.toThrow()
       })
+
+      it("should handle transforming input json string to expected shape", () => {
+        const [cmd, parseFn] = list({ packagerName: "npm" })
+
+        expect(cmd.includes("npm")).toBe(true)
+
+        const input = `
+            {
+                "resolved": "file:../../Roaming/fnm/node-versions/v16.16.0/installation",
+                "dependencies": {
+                    "corepack": {
+                        "version": "0.10.0"
+                    },
+                    "expo-cli": {
+                        "version": "6.0.1"
+                    },
+                    "npm": {
+                        "version": "8.11.0"
+                    }
+                }
+            }
+        `
+
+        expect(parseFn(input)).toStrictEqual([
+          ["corepack", "0.10.0"],
+          ["expo-cli", "6.0.1"],
+          ["npm", "8.11.0"],
+        ])
+      })
     })
   })
 })

--- a/src/tools/packager.test.ts
+++ b/src/tools/packager.test.ts
@@ -1,0 +1,34 @@
+import { list } from "./packager"
+
+describe("packager", () => {
+  describe("list", () => {
+    describe("npm", () => {
+      it("should handle non-json input to parseFn", () => {
+        const [cmd, parseFn] = list({ packagerName: "npm" })
+
+        expect(cmd.includes("npm")).toBe(true)
+
+        const input = `
+            npm WARN config global \`--global\`, \`--local\` are deprecated. Use \`--location=global\` instead.
+            npm WARN config global \`--global\`, \`--local\` are deprecated. Use \`--location=global\` instead.
+            {
+                "resolved": "file:../../Roaming/fnm/node-versions/v16.16.0/installation",
+                "dependencies": {
+                    "corepack": {
+                        "version": "0.10.0"
+                    },
+                    "expo-cli": {
+                        "version": "6.0.1"
+                    },
+                    "npm": {
+                        "version": "8.11.0"
+                    }
+                }
+            }
+        `
+
+        expect(() => parseFn(input)).not.toThrow()
+      })
+    })
+  })
+})

--- a/src/tools/packager.ts
+++ b/src/tools/packager.ts
@@ -164,7 +164,8 @@ export function list(options: PackageOptions = packageListOptions): PackageListO
       `npm list${options.global ? " --global" : ""} --depth=0 --json`,
       (output: string): [string, string][] => {
         // npm returns a single JSON blob with a "dependencies" key
-        const json = JSON.parse(output)
+        // however, sometimes npm can emit warning messages prepended to json output
+        const json = JSON.parse(output.replace(/npm WARN.+/g, ""))
         return Object.keys(json.dependencies || []).map((key: string): [string, string] => [
           key,
           json.dependencies[key].version,

--- a/src/tools/packager.ts
+++ b/src/tools/packager.ts
@@ -139,7 +139,7 @@ function installCmd(options: PackageRunOptions) {
 }
 
 type PackageListOutput = [string, (string) => [string, string][]]
-function list(options: PackageOptions = packageListOptions): PackageListOutput {
+export function list(options: PackageOptions = packageListOptions): PackageListOutput {
   if (options.packagerName === "pnpm") {
     // TODO: pnpm list?
     throw new Error("pnpm list is not supported yet")


### PR DESCRIPTION
## Please verify the following:

- [x] `yarn ci:test` **jest** tests pass with new tests, if relevant
- [x] `README.md` has been updated with your changes, if relevant

## Describe your PR
Resolves https://github.com/infinitered/ignite/issues/1993 by using a regex to remove any command output that has `npm WARN` at the beginning of the line
- Adds unit test to ensure that packager `list` function handles input described in issue
- Adds unit test to ensure that valid json input is parsed correctly