### PR TITLE
fix (#1652): Remove outdated mention of ignite plugins and ignite json config

### DIFF
--- a/boilerplate/README.md
+++ b/boilerplate/README.md
@@ -54,8 +54,12 @@ ignite-project
 │   ├── keystores
 │   └── settings.gradle
 ├── ignite
-│   ├── ignite.json
-│   └── plugins
+│   └── templates
+|       |── app-icon
+│       ├── component
+│       ├── model
+│       ├── navigator
+│       └── screen
 ├── index.js
 ├── ios
 │   ├── IgniteProject
@@ -115,7 +119,7 @@ This is a great place to put miscellaneous helpers and utilities. Things like da
 
 ### ./ignite directory
 
-The `ignite` directory stores all things Ignite, including CLI and boilerplate items. Here you will find generators, plugins and examples to help you get started with React Native.
+The `ignite` directory stores all things Ignite, including CLI and boilerplate items. Here you will find templates you can customize to help you get started with React Native.
 
 ### ./storybook directory
 


### PR DESCRIPTION
## Please verify the following:

- [x] `yarn ci:test` **jest** tests pass with new tests, if relevant
- [x] `README.md` has been updated with your changes, if relevant

## Describe your PR

Remove mention of plugins and ignite.json that were removed in [ignite v6: flame](https://github.com/infinitered/ignite/releases/tag/v6.0.0)

Fixes #1652 