### PR TITLE
fix: Specify Icon onPress prop is inherited from TouchableOpacity

### DIFF
--- a/boilerplate/app/components/Icon.tsx
+++ b/boilerplate/app/components/Icon.tsx
@@ -41,7 +41,7 @@ interface IconProps extends TouchableOpacityProps {
   /**
    * An optional function to be called when the icon is pressed
    */
-  onPress?: () => TouchableOpacityProps["onPress"]
+  onPress?: TouchableOpacityProps["onPress"]
 }
 
 /**

--- a/boilerplate/app/components/Icon.tsx
+++ b/boilerplate/app/components/Icon.tsx
@@ -40,8 +40,8 @@ interface IconProps extends TouchableOpacityProps {
 
   /**
    * An optional function to be called when the icon is pressed
-  */
-  onPress?: () => void
+   */
+  onPress?: () => TouchableOpacityProps["onPress"]
 }
 
 /**


### PR DESCRIPTION
## Please verify the following:

- [x] `yarn ci:test` **jest** tests pass with new tests, if relevant
- [x] `README.md` has been updated with your changes, if relevant

See [discussion here](https://github.com/infinitered/ignite/pull/2014#discussion_r946208895) for more info.
