### PR TITLE
Enhancement: package manager message consistency

### DIFF
--- a/src/commands/new.ts
+++ b/src/commands/new.ts
@@ -160,9 +160,10 @@ export default {
     // await packager.add(`react-native-safe-area-context`, packagerOptions)
 
     // pnpm/yarn/npm install it
-    startSpinner("Unboxing npm dependencies")
+    const unboxingMessage = `Unboxing ${packagerName} dependencies`
+    startSpinner(unboxingMessage)
     await packager.install({ ...packagerOptions, onProgress: log })
-    stopSpinner("Unboxing npm dependencies", "🧶")
+    stopSpinner(unboxingMessage, "🧶")
 
     // remove the gitignore template
     remove(".gitignore.template")


### PR DESCRIPTION
## Please verify the following:

- [x] `yarn ci:test` **jest** tests pass with new tests, if relevant
- [x] `README.md` has been updated with your changes, if relevant

## Describe your PR

During the `new` command process, the header makes mention of the package manager to the user but a later status message indicates the use of `npm` regardless, this could be confusing to a newer user of Ignite. 

For example, the header is written out with:

`Using ignite-cli with yarn` 

but later followed with:

`Unboxing npm dependencies`

This PR updates that message so it's consistent with the package manager in use.

![image](https://user-images.githubusercontent.com/374022/184877886-f2845e6c-a915-4508-b8b1-f8aa9699e0fb.png)
