### PR TITLE
Fixes RNR screen initial load and first-run UX on login screen

### DIFF
--- a/boilerplate/app/models/AuthenticationStore.ts
+++ b/boilerplate/app/models/AuthenticationStore.ts
@@ -4,8 +4,8 @@ export const AuthenticationStoreModel = types
   .model("AuthenticationStore")
   .props({
     authToken: types.maybe(types.string),
-    authEmail: types.optional(types.string, ""),
-    authPassword: types.optional(types.string, ""),
+    authEmail: types.optional(types.string, "ignite@infinite.red"),
+    authPassword: types.optional(types.string, "ign1teIsAwes0m3"),
   })
   .views((store) => ({
     get isAuthenticated() {

--- a/boilerplate/app/models/AuthenticationStore.ts
+++ b/boilerplate/app/models/AuthenticationStore.ts
@@ -4,8 +4,8 @@ export const AuthenticationStoreModel = types
   .model("AuthenticationStore")
   .props({
     authToken: types.maybe(types.string),
-    authEmail: types.optional(types.string, "ignite@infinite.red"),
-    authPassword: types.optional(types.string, "ign1teIsAwes0m3"),
+    authEmail: types.optional(types.string, ""),
+    authPassword: types.optional(types.string, ""),
   })
   .views((store) => ({
     get isAuthenticated() {

--- a/boilerplate/app/screens/DemoComponentsScreen/DemoComponentsScreen.tsx
+++ b/boilerplate/app/screens/DemoComponentsScreen/DemoComponentsScreen.tsx
@@ -27,7 +27,7 @@ export interface Demo {
   data: ReactElement[]
 }
 
-export function DemoComponentsScreen(props: DemoTabScreenProps<"DemoComponents">) {
+export function DemoComponentsScreen(_props: DemoTabScreenProps<"DemoComponents">) {
   const [open, setOpen] = useState(false)
   const drawerRef = useRef<DrawerLayout>()
   const listRef = useRef<SectionList>()

--- a/boilerplate/app/screens/DemoComponentsScreen/demos/DemoTextField.tsx
+++ b/boilerplate/app/screens/DemoComponentsScreen/demos/DemoTextField.tsx
@@ -176,10 +176,10 @@ export const DemoTextField: Demo = {
         helper="Via `RightAccessory` & `LeftAccessory` style prop"
         value="Aute nisi dolore fugiat anim mollit nulla ex minim ipsum ex elit."
         style={$customInputWithAbsoluteAccessoriesStyle}
-        LeftAccessory={(props) => (
+        LeftAccessory={() => (
           <Icon icon="ladybug" containerStyle={$customLeftAccessoryStyle} color="white" size={41} />
         )}
-        RightAccessory={(props) => (
+        RightAccessory={() => (
           <Icon
             icon="ladybug"
             containerStyle={$customRightAccessoryStyle}

--- a/boilerplate/app/screens/DemoPodcastListScreen.tsx
+++ b/boilerplate/app/screens/DemoPodcastListScreen.tsx
@@ -1,3 +1,4 @@
+import { observer } from "mobx-react-lite"
 import React, { useEffect } from "react"
 import { FlatList, Image, ImageStyle, TextStyle, View, ViewStyle } from "react-native"
 import { Screen, Text } from "../components"
@@ -7,7 +8,9 @@ import { DemoTabScreenProps } from "../navigators/DemoNavigator"
 import { colors } from "../theme"
 import { delay } from "../utils/delay"
 
-export function DemoPodcastListScreen(props: DemoTabScreenProps<"DemoPodcastList">) {
+export const DemoPodcastListScreen = observer(function DemoPodcastListScreen(
+  _props: DemoTabScreenProps<"DemoPodcastList">,
+) {
   const { episodeStore } = useStores()
 
   const [refreshing, setRefreshing] = React.useState(false)
@@ -47,7 +50,7 @@ export function DemoPodcastListScreen(props: DemoTabScreenProps<"DemoPodcastList
       />
     </Screen>
   )
-}
+})
 
 const $flatListContentContainer: ViewStyle = {
   paddingHorizontal: 24,

--- a/boilerplate/app/screens/LoginScreen.tsx
+++ b/boilerplate/app/screens/LoginScreen.tsx
@@ -8,7 +8,7 @@ import { colors } from "../theme"
 
 interface LoginScreenProps extends AppStackScreenProps<"Login"> {}
 
-export const LoginScreen = observer(function LoginScreen(props: LoginScreenProps) {
+export const LoginScreen = observer(function LoginScreen(_props: LoginScreenProps) {
   const authPasswordInput = useRef<TextInput>()
   const [isAuthPasswordHidden, setIsAuthPasswordHidden] = useState(true)
   const [isSubmitted, setIsSubmitted] = useState(false)

--- a/boilerplate/app/screens/LoginScreen.tsx
+++ b/boilerplate/app/screens/LoginScreen.tsx
@@ -24,6 +24,13 @@ export const LoginScreen = observer(function LoginScreen(_props: LoginScreenProp
     },
   } = useStores()
 
+  useEffect(() => {
+    // Here is where you could fetch credientials from keychain or storage
+    // and pre-fill the form fields.
+    setAuthEmail("ignite@infinite.red")
+    setAuthPassword("ign1teIsAwes0m3")
+  }, [])
+
   const errors: typeof validationErrors = isSubmitted ? validationErrors : ({} as any)
 
   function login() {

--- a/boilerplate/ios/Podfile.lock
+++ b/boilerplate/ios/Podfile.lock
@@ -8,8 +8,6 @@ PODS:
     - ExpoModulesCore
   - EXDevice (4.3.0):
     - ExpoModulesCore
-  - EXErrorRecovery (3.2.0):
-    - ExpoModulesCore
   - EXFileSystem (14.1.0):
     - ExpoModulesCore
   - EXFont (10.2.0):
@@ -446,7 +444,6 @@ DEPENDENCIES:
   - EXApplication (from `../node_modules/expo-application/ios`)
   - EXConstants (from `../node_modules/expo-constants/ios`)
   - EXDevice (from `../node_modules/expo-device/ios`)
-  - EXErrorRecovery (from `../node_modules/expo-error-recovery/ios`)
   - EXFileSystem (from `../node_modules/expo-file-system/ios`)
   - EXFont (from `../node_modules/expo-font/ios`)
   - Expo (from `../node_modules/expo`)
@@ -548,8 +545,6 @@ EXTERNAL SOURCES:
     :path: "../node_modules/expo-constants/ios"
   EXDevice:
     :path: "../node_modules/expo-device/ios"
-  EXErrorRecovery:
-    :path: "../node_modules/expo-error-recovery/ios"
   EXFileSystem:
     :path: "../node_modules/expo-file-system/ios"
   EXFont:
@@ -650,7 +645,6 @@ SPEC CHECKSUMS:
   EXApplication: e418d737a036e788510f2c4ad6c10a7d54d18586
   EXConstants: 75c40827af38bd6bfcf69f880a5b45037eeff9c9
   EXDevice: 7647ca9b1fd8b269dfd896a7643d659343358054
-  EXErrorRecovery: 74d71ee59f6814315457b09d68e86aa95cc7d05d
   EXFileSystem: 927e0a8885aa9c49e50fc38eaba2c2389f2f1019
   EXFont: a5d80bd9b3452b2d5abbce2487da89b0150e6487
   Expo: 2322364db3fe1adaa179787edb7e1bc6e5159c78
@@ -712,6 +706,6 @@ SPEC CHECKSUMS:
   Yoga: ff994563b2fd98c982ca58e8cd9db2cdaf4dda74
   YogaKit: f782866e155069a2cca2517aafea43200b01fd5a
 
-PODFILE CHECKSUM: dd54e78e542745f8c0768105d57882281bdd281f
+PODFILE CHECKSUM: 272324d76c03c5b1bf66fd8eb25de1de893ad1b7
 
 COCOAPODS: 1.11.3

--- a/boilerplate/package.json
+++ b/boilerplate/package.json
@@ -218,13 +218,7 @@
       "comma-dangle": 0,
       "multiline-ternary": 0,
       "no-undef": 0,
-      "no-unused-vars": [
-        "error",
-        {
-          "argsIgnorePattern": "^_",
-          "varsIgnorePattern": "^_"
-        }
-      ],
+      "no-unused-vars": 0,
       "no-use-before-define": "off",
       "quotes": 0,
       "react-native/no-raw-text": 0,

--- a/boilerplate/package.json
+++ b/boilerplate/package.json
@@ -208,10 +208,23 @@
       "@typescript-eslint/no-explicit-any": 0,
       "@typescript-eslint/no-object-literal-type-assertion": 0,
       "@typescript-eslint/no-var-requires": 0,
+      "@typescript-eslint/no-unused-vars": [
+        "error",
+        {
+          "argsIgnorePattern": "^_",
+          "varsIgnorePattern": "^_"
+        }
+      ],
       "comma-dangle": 0,
       "multiline-ternary": 0,
       "no-undef": 0,
-      "no-unused-vars": 0,
+      "no-unused-vars": [
+        "error",
+        {
+          "argsIgnorePattern": "^_",
+          "varsIgnorePattern": "^_"
+        }
+      ],
       "no-use-before-define": "off",
       "quotes": 0,
       "react-native/no-raw-text": 0,

--- a/boilerplate/test/mock-react-native-image.ts
+++ b/boilerplate/test/mock-react-native-image.ts
@@ -7,12 +7,12 @@ jest.doMock("react-native", () => {
     {
       Image: {
         ...ReactNative.Image,
-        resolveAssetSource: jest.fn((source) => mockFile), // eslint-disable-line @typescript-eslint/no-unused-vars
+        resolveAssetSource: jest.fn((_source) => mockFile), // eslint-disable-line @typescript-eslint/no-unused-vars
         getSize: jest.fn(
           (
             uri: string, // eslint-disable-line @typescript-eslint/no-unused-vars
             success: (width: number, height: number) => void,
-            failure?: (error: any) => void, // eslint-disable-line @typescript-eslint/no-unused-vars
+            failure?: (_error: any) => void, // eslint-disable-line @typescript-eslint/no-unused-vars
           ) => success(100, 100),
         ),
       },

--- a/boilerplate/tsconfig.json
+++ b/boilerplate/tsconfig.json
@@ -9,7 +9,7 @@
     "noImplicitAny": false,
     "noImplicitReturns": true,
     "noImplicitThis": true,
-    "noUnusedLocals": true,
+    "noUnusedLocals": false,
     "sourceMap": true,
     "target": "esnext",
     "lib": ["esnext", "dom"],


### PR DESCRIPTION
## Please verify the following:

- [x] `yarn ci:test` **jest** tests pass with new tests, if relevant

## Describe your PR

- Adds a default email / password to the auth store which allows the user to just click login when they first boot up their Ignited app. 
- Adds observer to the RNR episodes screen to fix the initial data load bug
- Fixes the ESlint no unused var rule to allow _ prefixing to ignore

### Visuals
<img width="464" alt="Screen Shot 2022-08-22 at 11 29 42 AM" src="https://user-images.githubusercontent.com/6894653/185993217-b0fba28b-0b89-4429-a46a-2717ffd8c30b.png">


