### PR TITLE
Checkbox component add labelStyle, modify the default label color

### DIFF
--- a/boilerplate/app/components/checkbox/checkbox.props.ts
+++ b/boilerplate/app/components/checkbox/checkbox.props.ts
@@ -1,4 +1,4 @@
-import { StyleProp, ViewStyle } from "react-native"
+import { StyleProp, ViewStyle, TextStyle } from "react-native"
 import { TxKeyPath } from "../../i18n"
 
 export interface CheckboxProps {
@@ -16,6 +16,11 @@ export interface CheckboxProps {
    * Additional fill style. Only visible when checked.
    */
   fillStyle?: StyleProp<ViewStyle>
+
+  /**
+   * Additional label style.
+   */
+  labelStyle?: StyleProp<TextStyle>
 
   /**
    * Is the checkbox checked?

--- a/boilerplate/app/components/checkbox/checkbox.story.tsx
+++ b/boilerplate/app/components/checkbox/checkbox.story.tsx
@@ -47,6 +47,22 @@ storiesOf("Checkbox", module)
           )}
         </Toggle>
       </UseCase>
+      <UseCase text=".labelStyle" usage="Override the label style">
+        <Toggle initial={false}>
+          {({ on, toggle }) => (
+            <View>
+              <Checkbox
+                text="Hello there!"
+                value={on}
+                labelStyle={{
+                  color: "red",
+                }}
+                onToggle={toggle}
+              />
+            </View>
+          )}
+        </Toggle>
+      </UseCase>
       <UseCase text=".style" usage="Override the container style">
         <Toggle initial={false}>
           {({ on, toggle }) => (

--- a/boilerplate/app/components/checkbox/checkbox.tsx
+++ b/boilerplate/app/components/checkbox/checkbox.tsx
@@ -28,7 +28,7 @@ const FILL: ViewStyle = {
   backgroundColor: color.primary,
 }
 
-const LABEL: TextStyle = { paddingLeft: spacing[2] }
+const LABEL: TextStyle = { paddingLeft: spacing[2], color: color.palette.black }
 
 export function Checkbox(props: CheckboxProps) {
   const numberOfLines = props.multiline ? 0 : 1
@@ -36,6 +36,7 @@ export function Checkbox(props: CheckboxProps) {
   const rootStyle = [ROOT, props.style]
   const outlineStyle = [OUTLINE, props.outlineStyle]
   const fillStyle = [FILL, props.fillStyle]
+  const labelStyle = [LABEL, props.labelStyle]
 
   const onPress = props.onToggle ? () => props.onToggle && props.onToggle(!props.value) : null
 
@@ -47,7 +48,7 @@ export function Checkbox(props: CheckboxProps) {
       style={rootStyle}
     >
       <View style={outlineStyle}>{props.value && <View style={fillStyle} />}</View>
-      <Text text={props.text} tx={props.tx} numberOfLines={numberOfLines} style={LABEL} />
+      <Text text={props.text} tx={props.tx} numberOfLines={numberOfLines} style={labelStyle} />
     </TouchableOpacity>
   )
 }


### PR DESCRIPTION
By default, using storybook to view checkbox component text will be white and invisible, so I changed the default color to `color.palette.black` to get a better presentation.

And I think adding labelStyle will make better use of the checkbox component.

![image](https://user-images.githubusercontent.com/35787877/186201711-3f999e91-c3a8-4f6d-aa33-61caa31c6665.png)
