### PR TITLE
Fix the problem of TextField component in Android height

### DIFF
--- a/boilerplate/app/components/TextField.tsx
+++ b/boilerplate/app/components/TextField.tsx
@@ -246,7 +246,7 @@ const $inputStyle: TextStyle = {
   fontFamily: typography.primary.normal,
   color: colors.text,
   fontSize: 16,
-  height: 20, // to make the height consistent on Android and iOS
+  height: 24, // to make the height consistent on Android and iOS
   // https://github.com/facebook/react-native/issues/21720#issuecomment-532642093
   paddingTop: 0,
   paddingBottom: 0,


### PR DESCRIPTION
## Please verify the following:

- [ ] `yarn ci:test` **jest** tests pass with new tests, if relevant
- [ ] `README.md` has been updated with your changes, if relevant

## Describe your PR

By default the TextField component has a problem with draggable text up and down on Android.

So I changed the default `20` to `24` to ensure proper display.

## Default

![d692b0b2-e3ae-47ee-a2dd-661bf39b974a](https://user-images.githubusercontent.com/35787877/186357991-6ff40298-58a9-4395-9c68-f4eaea63785b.gif)

## After modification

![c27eb29b-ab79-405c-998d-46818be7591b](https://user-images.githubusercontent.com/35787877/186358045-534b7bef-ca05-444e-9ec8-c834aa105ab3.gif)
