### PR TITLE
Feat/add config base

### DIFF
--- a/boilerplate/app/app.tsx
+++ b/boilerplate/app/app.tsx
@@ -21,6 +21,7 @@ import { ErrorBoundary } from "./screens/ErrorScreen/ErrorBoundary"
 import * as storage from "./utils/storage"
 import { customFontsToLoad } from "./theme"
 import { setupReactotron } from "./services/reactotron"
+import Config from "./config"
 
 // Set up Reactotron, which is a free desktop app for inspecting and debugging
 // React Native apps. Learn more here: https://github.com/infinitered/reactotron
@@ -77,7 +78,7 @@ function App(props: AppProps) {
   // otherwise, we're ready to render the app
   return (
     <SafeAreaProvider initialMetrics={initialWindowMetrics}>
-      <ErrorBoundary catchErrors="always">
+      <ErrorBoundary catchErrors={Config.catchErrors}>
         <AppNavigator
           initialState={initialNavigationState}
           onStateChange={onNavigationStateChange}

--- a/boilerplate/app/config/config.base.ts
+++ b/boilerplate/app/config/config.base.ts
@@ -1,20 +1,20 @@
 export interface ConfigBaseProps {
-  NavigationIsRestored: boolean,
+  persistNavigation: "always" | "dev" | "prod" | "never"
   catchErrors: "always" | "dev" | "prod" | "never"
   exitRoutes: string[]
 }
 
+export type PersistNavigationConfig = ConfigBaseProps["persistNavigation"]
+
 const BaseConfig: ConfigBaseProps = {
-  // This feature is particularly useful in development mode.
-  // It is selectively enabled in development mode with
-  // the following approach. If you'd like to use navigation persistence
-  // in production and dev both, remove the __DEV__ and set the state to false
-  NavigationIsRestored: !__DEV__,
+  // This feature is particularly useful in development mode, but
+  // can be used in production as well if you prefer.
+  persistNavigation: "dev",
 
   /**
    * Only enable if we're catching errors in the right environment
    */
-  catchErrors: 'always',
+  catchErrors: "always",
 
   /**
    * This is a list of all the route names that will exit the app if the back button

--- a/boilerplate/app/config/config.base.ts
+++ b/boilerplate/app/config/config.base.ts
@@ -4,7 +4,7 @@ export interface ConfigBaseProps {
   exitRoutes: string[]
 }
 
-export default {
+const BaseConfig: ConfigBaseProps = {
   // This feature is particularly useful in development mode.
   // It is selectively enabled in development mode with
   // the following approach. If you'd like to use navigation persistence
@@ -21,4 +21,6 @@ export default {
    * is pressed while in that screen. Only affects Android.
    */
   exitRoutes: ["Welcome"],
-} as ConfigBaseProps
+}
+
+export default  BaseConfig

--- a/boilerplate/app/config/config.base.ts
+++ b/boilerplate/app/config/config.base.ts
@@ -1,0 +1,24 @@
+export interface ConfigBaseProps {
+  NavigtaionIsRestored: boolean,
+  catchErrors: "always" | "dev" | "prod" | "never"
+  exitRoutes: string[]
+}
+
+export default {
+  // This feature is particularly useful in development mode.
+  // It is selectively enabled in development mode with
+  // the following approach. If you'd like to use navigation persistence
+  // in production and dev both, remove the __DEV__ and set the state to false
+  NavigtaionIsRestored: !__DEV__,
+
+  /**
+   * Only enable if we're catching errors in the right environment
+   */
+  catchErrors: 'always',
+
+  /**
+   * This is a list of all the route names that will exit the app if the back button
+   * is pressed while in that screen. Only affects Android.
+   */
+  exitRoutes: ["Welcome"]
+} as ConfigBaseProps

--- a/boilerplate/app/config/config.base.ts
+++ b/boilerplate/app/config/config.base.ts
@@ -1,5 +1,5 @@
 export interface ConfigBaseProps {
-  NavigtaionIsRestored: boolean,
+  NavigationIsRestored: boolean,
   catchErrors: "always" | "dev" | "prod" | "never"
   exitRoutes: string[]
 }
@@ -9,7 +9,7 @@ export default {
   // It is selectively enabled in development mode with
   // the following approach. If you'd like to use navigation persistence
   // in production and dev both, remove the __DEV__ and set the state to false
-  NavigtaionIsRestored: !__DEV__,
+  NavigationIsRestored: !__DEV__,
 
   /**
    * Only enable if we're catching errors in the right environment
@@ -20,5 +20,5 @@ export default {
    * This is a list of all the route names that will exit the app if the back button
    * is pressed while in that screen. Only affects Android.
    */
-  exitRoutes: ["Welcome"]
+  exitRoutes: ["Welcome"],
 } as ConfigBaseProps

--- a/boilerplate/app/config/config.base.ts
+++ b/boilerplate/app/config/config.base.ts
@@ -23,4 +23,4 @@ const BaseConfig: ConfigBaseProps = {
   exitRoutes: ["Welcome"],
 }
 
-export default  BaseConfig
+export default BaseConfig

--- a/boilerplate/app/config/index.ts
+++ b/boilerplate/app/config/index.ts
@@ -13,13 +13,16 @@
  *
  * Read more here: https://reactnative.dev/docs/security#storing-sensitive-info
  */
+import BaseConfig from './config.base'
 import ProdConfig from "./config.prod"
 import DevConfig from "./config.dev"
 
-let Config = ProdConfig
+let ExtraConfig = ProdConfig
 
 if (__DEV__) {
-  Config = DevConfig
+  ExtraConfig = DevConfig
 }
+
+let Config = {...BaseConfig, ...ExtraConfig}
 
 export default Config

--- a/boilerplate/app/config/index.ts
+++ b/boilerplate/app/config/index.ts
@@ -13,7 +13,7 @@
  *
  * Read more here: https://reactnative.dev/docs/security#storing-sensitive-info
  */
-import BaseConfig from './config.base'
+import BaseConfig from "./config.base"
 import ProdConfig from "./config.prod"
 import DevConfig from "./config.dev"
 
@@ -23,6 +23,6 @@ if (__DEV__) {
   ExtraConfig = DevConfig
 }
 
-let Config = {...BaseConfig, ...ExtraConfig}
+const Config = { ...BaseConfig, ...ExtraConfig }
 
 export default Config

--- a/boilerplate/app/navigators/AppNavigator.tsx
+++ b/boilerplate/app/navigators/AppNavigator.tsx
@@ -15,6 +15,7 @@ import { StackScreenProps } from "@react-navigation/stack"
 import { observer } from "mobx-react-lite"
 import React from "react"
 import { useColorScheme } from "react-native"
+import Config from "../config"
 import { useStores } from "../models"
 import { LoginScreen, WelcomeScreen } from "../screens"
 import { DemoNavigator, DemoTabParamList } from "./DemoNavigator"
@@ -44,7 +45,7 @@ export type AppStackParamList = {
  * This is a list of all the route names that will exit the app if the back button
  * is pressed while in that screen. Only affects Android.
  */
-const exitRoutes = ["Welcome"]
+const exitRoutes = Config.exitRoutes
 
 export type AppStackScreenProps<T extends keyof AppStackParamList> = StackScreenProps<
   AppStackParamList,

--- a/boilerplate/app/navigators/navigation-utilities.ts
+++ b/boilerplate/app/navigators/navigation-utilities.ts
@@ -95,7 +95,7 @@ export function useNavigationPersistence(storage: any, persistenceKey: string) {
   // It is selectively enabled in development mode with
   // the following approach. If you'd like to use navigation persistence
   // in production and dev both, remove the __DEV__ and set the state to false
-  const [isRestored, setIsRestored] = useState(Config.NavigtaionIsRestored)
+  const [isRestored, setIsRestored] = useState(Config.NavigationIsRestored)
 
   const routeNameRef = useRef<string | undefined>()
 

--- a/boilerplate/app/navigators/navigation-utilities.ts
+++ b/boilerplate/app/navigators/navigation-utilities.ts
@@ -6,6 +6,7 @@ import {
   NavigationAction,
   createNavigationContainerRef,
 } from "@react-navigation/native"
+import Config from "../config"
 
 /* eslint-disable */
 export const RootNavigation = {
@@ -94,7 +95,7 @@ export function useNavigationPersistence(storage: any, persistenceKey: string) {
   // It is selectively enabled in development mode with
   // the following approach. If you'd like to use navigation persistence
   // in production and dev both, remove the __DEV__ and set the state to false
-  const [isRestored, setIsRestored] = useState(!__DEV__)
+  const [isRestored, setIsRestored] = useState(Config.NavigtaionIsRestored)
 
   const routeNameRef = useRef<string | undefined>()
 

--- a/boilerplate/app/navigators/navigation-utilities.ts
+++ b/boilerplate/app/navigators/navigation-utilities.ts
@@ -7,6 +7,7 @@ import {
   createNavigationContainerRef,
 } from "@react-navigation/native"
 import Config from "../config"
+import type { PersistNavigationConfig } from "../config/config.base"
 
 /* eslint-disable */
 export const RootNavigation = {
@@ -86,16 +87,26 @@ export function useBackButtonHandler(canExit: (routeName: string) => boolean) {
 }
 
 /**
+ * This helper function will determine whether we should enable navigation persistence
+ * based on a config setting and the __DEV__ environment (dev or prod).
+ */
+function navigationRestoredDefaultState(persistNavigation: PersistNavigationConfig) {
+  if (persistNavigation === "always") return false
+  if (persistNavigation === "dev" && __DEV__) return false
+  if (persistNavigation === "prod" && !__DEV__) return false
+
+  // all other cases, disable restoration by returning true
+  return true
+}
+
+/**
  * Custom hook for persisting navigation state.
  */
 export function useNavigationPersistence(storage: any, persistenceKey: string) {
   const [initialNavigationState, setInitialNavigationState] = useState()
 
-  // This feature is particularly useful in development mode.
-  // It is selectively enabled in development mode with
-  // the following approach. If you'd like to use navigation persistence
-  // in production and dev both, remove the __DEV__ and set the state to false
-  const [isRestored, setIsRestored] = useState(Config.NavigationIsRestored)
+  const initNavState = navigationRestoredDefaultState(Config.persistNavigation)
+  const [isRestored, setIsRestored] = useState(initNavState)
 
   const routeNameRef = useRef<string | undefined>()
 


### PR DESCRIPTION
## Please verify the following:

- [ ] `yarn ci:test` **jest** tests pass with new tests, if relevant
- [ ] `README.md` has been updated with your changes, if relevant

## Describe your PR

Add config.base to centralize the optional configuration in the template, and developers won't have to go looking for it in the code.

This might be useful when we have more configurations?

Of course I have now added `isRestored: NavigtaionIsRestored`, `catchErrors`, and `exitRoutes` to config.base from the template