### PR TITLE
Optimize the preparation of translated texts under different platforms

### DIFF
--- a/boilerplate/app/i18n/i18n.ts
+++ b/boilerplate/app/i18n/i18n.ts
@@ -3,9 +3,9 @@ import i18n from "i18n-js"
 import { I18nManager } from "react-native"
 
 // if English isn't your default language, move Translations to the appropriate language file.
-import en, { Translations } from "./en"
-import ar from "./ar"
-import ko from "./ko"
+import en, { Translations } from "./translations/en"
+import ar from "./translations/ar"
+import ko from "./translations/ko"
 
 i18n.fallbacks = true
 /**

--- a/boilerplate/app/i18n/translate.ts
+++ b/boilerplate/app/i18n/translate.ts
@@ -9,3 +9,30 @@ import { TxKeyPath } from "./i18n"
 export function translate(key: TxKeyPath, options?: i18n.TranslateOptions) {
   return key ? i18n.t(key, options) : null
 }
+
+export interface PlatformValuesProps {
+  android?: string
+  ios?: string
+  web?: string
+  macos?: string
+  windows?: string
+}
+
+/**
+ * Return translated text for all platforms
+ *
+ * @param defaultValue
+ * @param platformValues
+ * @returns
+ */
+export function PT(key: string, defaultValue: string, platformValues: PlatformValuesProps) {
+  const platformOSTypes = ["android", "ios", "web", "macos", "windows"]
+
+  let translationValues = platformOSTypes.reduce((data, platformType) => {
+    const keyPath = platformType + key
+    data[keyPath] = platformValues[platformType] || defaultValue
+    return data
+  }, {})
+
+  return translationValues
+}

--- a/boilerplate/app/i18n/translate.ts
+++ b/boilerplate/app/i18n/translate.ts
@@ -1,5 +1,4 @@
 import i18n from "i18n-js"
-import { PlatformOSType } from "react-native"
 import { TxKeyPath } from "./i18n"
 
 /**

--- a/boilerplate/app/i18n/translate.ts
+++ b/boilerplate/app/i18n/translate.ts
@@ -1,4 +1,5 @@
 import i18n from "i18n-js"
+import { PlatformOSType } from "react-native"
 import { TxKeyPath } from "./i18n"
 
 /**
@@ -18,6 +19,10 @@ export interface PlatformValuesProps {
   windows?: string
 }
 
+export type PTKeyPath<keyPath extends string | number> = {
+  [TKey in keyof PlatformValuesProps as `${TKey}${keyPath}`]: string
+}
+
 /**
  * Return translated text for all platforms
  *
@@ -25,10 +30,14 @@ export interface PlatformValuesProps {
  * @param platformValues
  * @returns
  */
-export function PT(key: string, defaultValue: string, platformValues: PlatformValuesProps) {
+export function PT<keyPath extends string | number>(
+  key: string | number,
+  defaultValue: string,
+  platformValues: PlatformValuesProps,
+): PTKeyPath<keyPath> {
   const platformOSTypes = ["android", "ios", "web", "macos", "windows"]
 
-  let translationValues = platformOSTypes.reduce((data, platformType) => {
+  const translationValues = platformOSTypes.reduce((data, platformType) => {
     const keyPath = platformType + key
     data[keyPath] = platformValues[platformType] || defaultValue
     return data

--- a/boilerplate/app/i18n/translations/ar.ts
+++ b/boilerplate/app/i18n/translations/ar.ts
@@ -77,7 +77,7 @@ const ar: Translations = {
     reportBugs: "Ignite الابلاغ عن اخطاء",
     demoList: "قائمة تجريبية",
     demoPodcastList: "قائمة البودكاست التجريبي",
-    ...PT(
+    ...PT<"ReactotronHint">(
       "ReactotronHint",
       "اذا لم ينجح ذلك، فتأكد من تشغيل تطبيق الحاسوب الخاص ب Reactotron وأعد تحميل التطبيق",
       {

--- a/boilerplate/app/i18n/translations/ar.ts
+++ b/boilerplate/app/i18n/translations/ar.ts
@@ -1,4 +1,5 @@
-import { Translations } from "./en"
+import { Translations } from "../en"
+import { PT } from "../translate"
 
 const ar: Translations = {
   common: {
@@ -74,14 +75,14 @@ const ar: Translations = {
     reportBugs: "Ignite الابلاغ عن اخطاء",
     demoList: "قائمة تجريبية",
     demoPodcastList: "قائمة البودكاست التجريبي",
-    androidReactotronHint:
-      "اذا لم ينجح ذللك، فتأكد من تشغيل تطبيق الحاسوب الخاص Reactotron، وقم بتشغيل عكس adb tcp:9090 \ntcp:9090 من جهازك الطرفي ، واعد تحميل التطبيق",
-    iosReactotronHint:
+    ...PT(
+      "ReactotronHint",
       "اذا لم ينجح ذلك، فتأكد من تشغيل تطبيق الحاسوب الخاص ب Reactotron وأعد تحميل التطبيق",
-    macosReactotronHint: "اذا لم ينجح ذلك، فتأكد من تشغيل الحاسوب ب Reactotron وأعد تحميل التطبيق",
-    webReactotronHint: "اذا لم ينجح ذلك، فتأكد من تشغيل الحاسوب ب Reactotron وأعد تحميل التطبيق",
-    windowsReactotronHint:
-      "اذا لم ينجح ذلك، فتأكد من تشغيل الحاسوب ب Reactotron وأعد تحميل التطبيق",
+      {
+        android:
+          "اذا لم ينجح ذللك، فتأكد من تشغيل تطبيق الحاسوب الخاص Reactotron، وقم بتشغيل عكس adb tcp:9090 \ntcp:9090 من جهازك الطرفي ، واعد تحميل التطبيق",
+      },
+    ),
   },
   demoPodcastListScreen: {
     title: "حلقات إذاعية React Native",

--- a/boilerplate/app/i18n/translations/ar.ts
+++ b/boilerplate/app/i18n/translations/ar.ts
@@ -1,4 +1,4 @@
-import { Translations } from "../en"
+import { Translations } from "./en"
 import { PT } from "../translate"
 
 const ar: Translations = {
@@ -9,6 +9,8 @@ const ar: Translations = {
   },
   errors: {
     invalidEmail: "عنوان البريد الالكتروني غير صالح",
+    cannotBeEmpty: "can't be blank",
+    requireLength: "must be at least {{number}} characters",
   },
   welcomeScreen: {
     headerRight: "تسجيل خروج",

--- a/boilerplate/app/i18n/translations/en.ts
+++ b/boilerplate/app/i18n/translations/en.ts
@@ -1,3 +1,5 @@
+import { PT } from "../translate"
+
 const en = {
   common: {
     ok: "OK!",
@@ -6,6 +8,8 @@ const en = {
   },
   errors: {
     invalidEmail: "Invalid email address.",
+    cannotBeEmpty: "can't be blank",
+    requireLength: "must be at least {{number}} characters",
   },
   welcomeScreen: {
     headerRight: "Log Out",
@@ -73,16 +77,14 @@ const en = {
     reportBugs: "Report bugs about Ignite",
     demoList: "Demo List",
     demoPodcastList: "Demo Podcast List",
-    androidReactotronHint:
-      "If this doesn't work, ensure the Reactotron desktop app is running, run adb reverse tcp:9090 tcp:9090 from your terminal, and reload the app.",
-    iosReactotronHint:
+    ...PT(
+      "ReactotronHint",
       "If this doesn't work, ensure the Reactotron desktop app is running and reload app.",
-    macosReactotronHint:
-      "If this doesn't work, ensure the Reactotron desktop app is running and reload app.",
-    webReactotronHint:
-      "If this doesn't work, ensure the Reactotron desktop app is running and reload app.",
-    windowsReactotronHint:
-      "If this doesn't work, ensure the Reactotron desktop app is running and reload app.",
+      {
+        android:
+          "If this doesn't work, ensure the Reactotron desktop app is running, run adb reverse tcp:9090 tcp:9090 from your terminal, and reload the app.",
+      },
+    ),
   },
   demoPodcastListScreen: {
     title: "React Native Radio episodes",

--- a/boilerplate/app/i18n/translations/en.ts
+++ b/boilerplate/app/i18n/translations/en.ts
@@ -77,7 +77,7 @@ const en = {
     reportBugs: "Report bugs about Ignite",
     demoList: "Demo List",
     demoPodcastList: "Demo Podcast List",
-    ...PT(
+    ...PT<"ReactotronHint">(
       "ReactotronHint",
       "If this doesn't work, ensure the Reactotron desktop app is running and reload app.",
       {

--- a/boilerplate/app/i18n/translations/ko.ts
+++ b/boilerplate/app/i18n/translations/ko.ts
@@ -78,7 +78,7 @@ const ko: Translations = {
     reportBugs: "Ignite 에 관한 버그 보고하기",
     demoList: "데모 목록",
     demoPodcastList: "데모 팟캐스트 목록",
-    ...PT(
+    ...PT<"ReactotronHint">(
       "ReactotronHint",
       "만약에 동작하지 않는 경우, Reactotron 데스크탑 앱이 실행중인지 확인 후 앱을 다시 실행해보세요.",
       {

--- a/boilerplate/app/i18n/translations/ko.ts
+++ b/boilerplate/app/i18n/translations/ko.ts
@@ -1,3 +1,4 @@
+import { PT } from "../translate"
 import { Translations } from "./en"
 
 const ko: Translations = {
@@ -75,16 +76,14 @@ const ko: Translations = {
     reportBugs: "Ignite 에 관한 버그 보고하기",
     demoList: "데모 목록",
     demoPodcastList: "데모 팟캐스트 목록",
-    androidReactotronHint:
-      "만약에 동작하지 않는 경우, Reactotron 데스크탑 앱이 실행중인지 확인 후, 터미널에서 adb reverse tcp:9090 tcp:9090 을 실행한 다음 앱을 다시 실행해보세요.",
-    iosReactotronHint:
+    ...PT(
+      "ReactotronHint",
       "만약에 동작하지 않는 경우, Reactotron 데스크탑 앱이 실행중인지 확인 후 앱을 다시 실행해보세요.",
-    macosReactotronHint:
-      "만약에 동작하지 않는 경우, Reactotron 데스크탑 앱이 실행중인지 확인 후 앱을 다시 실행해보세요.",
-    webReactotronHint:
-      "만약에 동작하지 않는 경우, Reactotron 데스크탑 앱이 실행중인지 확인 후 앱을 다시 실행해보세요.",
-    windowsReactotronHint:
-      "만약에 동작하지 않는 경우, Reactotron 데스크탑 앱이 실행중인지 확인 후 앱을 다시 실행해보세요.",
+      {
+        android:
+          "만약에 동작하지 않는 경우, Reactotron 데스크탑 앱이 실행중인지 확인 후, 터미널에서 adb reverse tcp:9090 tcp:9090 을 실행한 다음 앱을 다시 실행해보세요.",
+      },
+    ),
   },
   demoPodcastListScreen: {
     title: "React Native 라디오 에피소드",

--- a/boilerplate/app/i18n/translations/ko.ts
+++ b/boilerplate/app/i18n/translations/ko.ts
@@ -9,6 +9,8 @@ const ko: Translations = {
   },
   errors: {
     invalidEmail: "잘못된 이메일 주소 입니다.",
+    cannotBeEmpty: "can't be blank",
+    requireLength: "must be at least {{number}} characters",
   },
   welcomeScreen: {
     headerRight: "로그아웃",

--- a/boilerplate/app/models/AuthenticationStore.ts
+++ b/boilerplate/app/models/AuthenticationStore.ts
@@ -1,4 +1,5 @@
 import { Instance, SnapshotOut, types } from "mobx-state-tree"
+import { translate } from "../i18n"
 
 export const AuthenticationStoreModel = types
   .model("AuthenticationStore")
@@ -14,15 +15,15 @@ export const AuthenticationStoreModel = types
     get validationErrors() {
       return {
         authEmail: (function () {
-          if (store.authEmail.length === 0) return "can't be blank"
-          if (store.authEmail.length < 6) return "must be at least 6 characters"
+          if (store.authEmail.length === 0) return translate("errors.cannotBeEmpty")
+          if (store.authEmail.length < 6) return translate("errors.requireLength", { number: 6 })
           if (!/^[^\s@]+@[^\s@]+\.[^\s@]+$/.test(store.authEmail))
-            return "must be a valid email address"
+            return translate("errors.invalidEmail")
           return ""
         })(),
         authPassword: (function () {
-          if (store.authPassword.length === 0) return "can't be blank"
-          if (store.authPassword.length < 6) return "must be at least 6 characters"
+          if (store.authPassword.length === 0) return translate("errors.cannotBeEmpty")
+          if (store.authPassword.length < 6) return translate("errors.requireLength", { number: 6 })
           return ""
         })(),
       }

--- a/boilerplate/test/i18n.test.ts
+++ b/boilerplate/test/i18n.test.ts
@@ -1,4 +1,4 @@
-import en from "../app/i18n/en"
+import en from "../app/i18n/translations/en"
 import { exec } from "child_process"
 
 // Use this array for keys that for whatever reason aren't greppable so they


### PR DESCRIPTION
## Please verify the following:

- [ ] `yarn ci:test` **jest** tests pass with new tests, if relevant
- [ ] `README.md` has been updated with your changes, if relevant

## Describe your PR

The changes this time are as follows：

* Optimize the i18n directory structure by placing all translation files in the `translations` directory
* Error message in login screen input box supports i18n (By the way, ar and ko I did not update)
* Added `PT` function to simplify translating text under different platforms. (After adding the return type, this function is a bit strange to use 😭)