### PR TITLE
(feat): more user-friendly spacing scale

### DIFF
--- a/boilerplate/app/components/bullet-item/bullet-item.tsx
+++ b/boilerplate/app/components/bullet-item/bullet-item.tsx
@@ -6,14 +6,14 @@ import { Text } from "../Text"
 
 const BULLET_ITEM: ViewStyle = {
   flexDirection: "row",
-  marginTop: spacing[4],
-  paddingBottom: spacing[4],
+  marginTop: spacing.medium,
+  paddingBottom: spacing.medium,
   borderBottomWidth: 1,
   borderBottomColor: "#3A3048",
 }
 const BULLET_CONTAINER: ViewStyle = {
-  marginRight: spacing[4] - 1,
-  marginTop: spacing[2],
+  marginRight: spacing.medium - 1,
+  marginTop: spacing.extraSmall,
 }
 const BULLET: ImageStyle = {
   width: 8,

--- a/boilerplate/app/components/checkbox/checkbox.tsx
+++ b/boilerplate/app/components/checkbox/checkbox.tsx
@@ -6,7 +6,7 @@ import { CheckboxProps } from "./checkbox.props"
 
 const ROOT: ViewStyle = {
   flexDirection: "row",
-  paddingVertical: spacing[1],
+  paddingVertical: spacing.tiny,
   alignSelf: "flex-start",
 }
 
@@ -28,7 +28,7 @@ const FILL: ViewStyle = {
   backgroundColor: colors.tint,
 }
 
-const LABEL: TextStyle = { paddingLeft: spacing[2], color: colors.palette.neutral900 }
+const LABEL: TextStyle = { paddingLeft: spacing.extraSmall, color: colors.palette.neutral900 }
 
 export function Checkbox(props: CheckboxProps) {
   const numberOfLines = props.multiline ? 0 : 1

--- a/boilerplate/app/screens/DemoPodcastListScreen.tsx
+++ b/boilerplate/app/screens/DemoPodcastListScreen.tsx
@@ -102,12 +102,12 @@ const EpisodeCard = observer(function EpisodeCard({
 const THUMBNAIL_DIMENSION = 100
 
 const $flatListContentContainer: ViewStyle = {
-  paddingHorizontal: spacing[5],
-  paddingTop: spacing[5],
+  paddingHorizontal: spacing.large,
+  paddingTop: spacing.large,
 }
 
 const $heading: ViewStyle = {
-  marginBottom: spacing[4],
+  marginBottom: spacing.medium,
 }
 
 const $description: TextStyle = {
@@ -118,8 +118,8 @@ const $description: TextStyle = {
 const $item: ViewStyle = {
   backgroundColor: colors.palette.neutral100,
   borderRadius: 8,
-  padding: spacing[4],
-  marginTop: spacing[4],
+  padding: spacing.medium,
+  marginTop: spacing.medium,
 }
 
 const $rowLayout: ViewStyle = {
@@ -128,21 +128,21 @@ const $rowLayout: ViewStyle = {
 
 const $toggle: ViewStyle = {
   alignItems: "center",
-  marginTop: spacing[3],
+  marginTop: spacing.small,
 }
 
 const $toggleText: TextStyle = {
-  marginLeft: spacing[2],
+  marginLeft: spacing.extraSmall,
 }
 
 const $itemThumbnail: ImageStyle = {
   width: THUMBNAIL_DIMENSION,
   height: THUMBNAIL_DIMENSION,
-  marginStart: spacing[2],
+  marginStart: spacing.extraSmall,
 }
 
 const $metadata: TextStyle = {
   justifyContent: "space-between",
   color: colors.textDim,
-  marginTop: spacing[2],
+  marginTop: spacing.extraSmall,
 }

--- a/boilerplate/app/screens/WelcomeScreen.tsx
+++ b/boilerplate/app/screens/WelcomeScreen.tsx
@@ -63,7 +63,7 @@ const $topContainer: ViewStyle = {
   flexGrow: 1,
   flexBasis: "57%",
   justifyContent: "center",
-  paddingHorizontal: spacing[5],
+  paddingHorizontal: spacing.large,
 }
 
 const $bottomContainer: ViewStyle = {
@@ -77,14 +77,14 @@ const $bottomContainer: ViewStyle = {
 
 const $bottomContentContainer: ViewStyle = {
   flex: 1,
-  paddingHorizontal: spacing[5],
+  paddingHorizontal: spacing.large,
   justifyContent: "space-around",
 }
 
 const $welcomeLogo: ImageStyle = {
   height: 88,
   width: "100%",
-  marginBottom: spacing[7],
+  marginBottom: spacing.huge,
 }
 
 const $welcomeFace: ImageStyle = {
@@ -97,5 +97,5 @@ const $welcomeFace: ImageStyle = {
 }
 
 const $welcomeHeading: TextStyle = {
-  marginBottom: spacing[4],
+  marginBottom: spacing.medium,
 }

--- a/boilerplate/app/theme/spacing.ts
+++ b/boilerplate/app/theme/spacing.ts
@@ -1,44 +1,16 @@
-// MAVERICKTODO: move the below documentation into its own markdown file and add links
-// https://github.com/infinitered/ignite/issues/2037
-
 /**
- * NOTE TO DEVS:
- *
- * Spacing should be consistent and whitespace thought of as a first class technique up
- * there with color and typefaces.
- *
- * Which type of scale you use is based on the design.
- *
- * If you've got simpler app, you may only need 6 items.  Or maybe you want a spacing scale
- * to be named:
- *
- * export const spacing = {
- *   tiny: 4,
- *   small: 8,
- *   medium: 12,
- *   large: 24,
- *   huge: 64
- * }
- *
- * Whatever you choose, try to stick with these, and not freestyle it everywhere.
- *
- * Feel free to delete this block.
+  Use these spacings for margins/paddings and other whitespace throughout your app.
  */
+export const spacing = {
+  micro: 2,
+  tiny: 4,
+  extraSmall: 8,
+  small: 12,
+  medium: 16,
+  large: 24,
+  extraLarge: 32,
+  huge: 48,
+  massive: 64,
+} as const
 
-/**
- * The available spacing.
- *
- * Here's the rough guideline.  Customize this for you usage.  It's ok to put exceptions
- * within the components themselves if they are truly exceptions.
- *
- * 0 = none    - nothing. only here to bust out of a zero-based array.
- * 1 = tiny    - elements contextually close to each other
- * 2 = smaller - for groups of closely related items or perhaps borders
- * 3 = small   - ?
- * 4 = medium  - ?
- * 5 = medium+ - ?
- * 6 = large   - between groups of content that aren't related?
- * 7 = huge    - ?
- * 8 = massive - an uncomfortable amount of whitespace
- */
-export const spacing = [0, 4, 8, 12, 16, 24, 32, 48, 64]
+export type Spacing = keyof typeof spacing

--- a/docs/Theming-Spacing.md
+++ b/docs/Theming-Spacing.md
@@ -1,0 +1,40 @@
+# Spacing
+
+[Back to Theming](./Theming.md)
+
+Spacing refers to the whitespace in between the elements in your app. Spacing should be
+consistent and thought of as a first class technique right alongside [colors](./Theming-Colors-And-Palettes.md) and [typography](./Theming-Fonts-And-Typography.md).
+Anytime you add margins, or padding, they should come from this spacing scale, with
+relatively few exceptions.
+
+Spacings are defined in `app/theme/spacing.ts`. The scale we use in Ignite is:
+
+```ts
+export const spacing = {
+  micro: 2,
+  tiny: 4,
+  extraSmall: 8,
+  small: 12,
+  medium: 16,
+  large: 24,
+  extraLarge: 32,
+  huge: 48,
+  massive: 64,
+}
+```
+
+Example:
+
+```ts
+import { spacing } from "../theme"
+
+$containerStyle = {
+  margin: spacing.small,
+}
+```
+
+Which type of scale you use is based on the design.
+If you've got simpler app, you may only need 6 items. Or maybe you need lots of items.
+
+Whatever you choose, try to stick with your scale and not use custom values if possible,
+as consistent spacing will give your app a very polished look and feel.

--- a/docs/Theming.md
+++ b/docs/Theming.md
@@ -1,6 +1,6 @@
 # Theming Ignite Apps
 
-[Back to README][./README.md]
+[Back to README][./readme.md]
 
 Theming involves creating a consistent look & feel across your application. It's a collection of style attributes and building blocks that are used everywhere.
 
@@ -27,3 +27,5 @@ Timings are defined in `app/theme/timing.ts`. They can be used for consistent an
 ## Spacing
 
 Spacing is a first class citizen in Ignite. We use a spacing scale to define the spacing between elements in the app. This allows us to have a consistent spacing scale across the app, and also allows us to change the spacing easily. It is recommended to use the spacing scale for all spacing in the app if possible.
+
+[Spacing](./Theming-Spacing.md)


### PR DESCRIPTION
## Please verify the following:

- [x] `yarn ci:test` **jest** tests pass with new tests, if relevant
- [x] `README.md` has been updated with your changes, if relevant

## Describe your PR

- Change the spacing scale to have more user friendly names, vs an array. Also add better typeahead hints by exporting `as const`
- Updated the descriptive documentation and moved it to `docs`

### Visuals

<img width="631" alt="Screen Shot 2022-08-25 at 11 50 57 AM" src="https://user-images.githubusercontent.com/6894653/186760682-377df045-8df1-434a-8a6c-f8403e161004.png">
<img width="1030" alt="Screen Shot 2022-08-25 at 11 51 34 AM" src="https://user-images.githubusercontent.com/6894653/186760690-e6f21f5f-ec99-4911-bbbb-964b6b1066fa.png">


