### PR TITLE
Fix `new` command target directory flag for non-default arguments

### DIFF
--- a/src/commands/new.ts
+++ b/src/commands/new.ts
@@ -13,6 +13,7 @@ import {
   clearSpinners,
 } from "../tools/pretty"
 import type { ValidationsExports } from "../tools/validations"
+import { bool } from "../tools/flag"
 
 // CLI tool versions we support
 const deps: { [k: string]: string } = {
@@ -203,7 +204,7 @@ export default {
     // #region Overwrite
     // if they pass in --overwrite, remove existing directory otherwise throw if exists
     const defaultOverwrite = false
-    let overwrite = useDefault(options.overwrite) ? defaultOverwrite : options.overwrite
+    let overwrite = useDefault(options.overwrite) ? defaultOverwrite : bool(options.overwrite)
     if (exists(targetPath)) {
       if (overwrite === undefined) {
         overwrite = await prompt.confirm(
@@ -327,18 +328,25 @@ export default {
     stopSpinner("Igniting app", "🔥")
 
     startSpinner(" 3D-printing a new React Native app")
+
+    // ensure that the target path exists
+    if (exists(targetPath) === false) {
+      filesystem.dir(targetPath)
+    }
+
+    // jump into the project to do additional tasks
+    process.chdir(targetPath)
+
     await copyBoilerplate(toolbox, {
       boilerplatePath,
       targetPath,
       excluded: [".vscode", "node_modules", "yarn.lock"],
+      overwrite,
     })
     stopSpinner(" 3D-printing a new React Native app", "🖨")
 
     // note the original directory
     const cwd = log(process.cwd())
-
-    // jump into the project to do additional tasks
-    process.chdir(projectName)
 
     // copy the .gitignore if it wasn't copied over
     // Release Ignite installs have the boilerplate's .gitignore in .gitignore.template

--- a/src/commands/new.ts
+++ b/src/commands/new.ts
@@ -312,7 +312,7 @@ export default {
     p(` █ Powered by ${red("Infinite Red")} - https://infinite.red`)
     p(` █ Using ${cyan("ignite-cli")} with ${green(packagerName)}`)
     p(` █ Bundle identifier: ${magenta(bundleIdentifier)}`)
-    p(` █ Path: ${gray(path(process.cwd(), projectName))}`)
+    p(` █ Path: ${gray(targetPath)}`)
     p(` ────────────────────────────────────────────────\n`)
 
     startSpinner("Igniting app")

--- a/src/commands/new.ts
+++ b/src/commands/new.ts
@@ -13,7 +13,7 @@ import {
   clearSpinners,
 } from "../tools/pretty"
 import type { ValidationsExports } from "../tools/validations"
-import { bool } from "../tools/flag"
+import { boolFlag } from "../tools/flag"
 
 // CLI tool versions we support
 const deps: { [k: string]: string } = {
@@ -127,7 +127,6 @@ export default {
 
     const yname = !!options.y || !!options.yes
     const useDefault = (option: unknown) => yname && option === undefined
-    const boolFlag = (option: unknown) => (option !== undefined ? bool(option) : undefined)
     // #endregion
 
     // #region Debug

--- a/src/commands/new.ts
+++ b/src/commands/new.ts
@@ -348,6 +348,9 @@ export default {
     // note the original directory
     const cwd = log(process.cwd())
 
+    // jump into the project to do additional tasks
+    process.chdir(targetPath)
+
     // copy the .gitignore if it wasn't copied over
     // Release Ignite installs have the boilerplate's .gitignore in .gitignore.template
     // (see https://github.com/npm/npm/issues/3763); development Ignite still

--- a/src/commands/new.ts
+++ b/src/commands/new.ts
@@ -331,14 +331,6 @@ export default {
 
     startSpinner(" 3D-printing a new React Native app")
 
-    // ensure that the target path exists
-    if (exists(targetPath) === false) {
-      filesystem.dir(targetPath)
-    }
-
-    // jump into the project to do additional tasks
-    process.chdir(targetPath)
-
     await copyBoilerplate(toolbox, {
       boilerplatePath,
       targetPath,

--- a/src/commands/new.ts
+++ b/src/commands/new.ts
@@ -127,6 +127,7 @@ export default {
 
     const yname = !!options.y || !!options.yes
     const useDefault = (option: unknown) => yname && option === undefined
+    const boolFlag = (option: unknown) => (option !== undefined ? bool(option) : undefined)
     // #endregion
 
     // #region Debug
@@ -204,7 +205,8 @@ export default {
     // #region Overwrite
     // if they pass in --overwrite, remove existing directory otherwise throw if exists
     const defaultOverwrite = false
-    let overwrite = useDefault(options.overwrite) ? defaultOverwrite : bool(options.overwrite)
+    let overwrite = useDefault(options.overwrite) ? defaultOverwrite : boolFlag(options.overwrite)
+
     if (exists(targetPath)) {
       if (overwrite === undefined) {
         overwrite = await prompt.confirm(

--- a/src/tools/flag.ts
+++ b/src/tools/flag.ts
@@ -1,0 +1,20 @@
+/**
+ * Utility for converting 'true' and 'false' strings to booleans.
+ *
+ * Both `Boolean('true')` and `Boolean('false')` return `true`, because any string is a truthy value.
+ * `!!'true'` and `!!'false'` also return `true`, for the same reason.
+ * @see https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Boolean
+ *
+ * @param value The value to check.
+ * @returns `true` for 'true', `false` for 'false', `Boolean` result otherwise.
+ */
+export function bool<Value extends Parameters<typeof Boolean>[0]>(value: Value): boolean {
+  if (value === "true") {
+    return true
+  }
+  if (value === "false") {
+    return false
+  }
+
+  return Boolean<Value>(value)
+}

--- a/src/tools/flag.ts
+++ b/src/tools/flag.ts
@@ -10,5 +10,5 @@
  */
 export function bool(value: string | boolean): boolean {
   if (value === "false") return false
-  return Boolean<Value>(value)
+  return Boolean(value)
 }

--- a/src/tools/flag.ts
+++ b/src/tools/flag.ts
@@ -8,13 +8,7 @@
  * @param value The value to check.
  * @returns `true` for 'true', `false` for 'false', `Boolean` result otherwise.
  */
-export function bool<Value extends Parameters<typeof Boolean>[0]>(value: Value): boolean {
-  if (value === "true") {
-    return true
-  }
-  if (value === "false") {
-    return false
-  }
-
+export function bool(value: string | boolean): boolean {
+  if (value === "false") return false
   return Boolean<Value>(value)
 }

--- a/src/tools/flag.ts
+++ b/src/tools/flag.ts
@@ -8,7 +8,16 @@
  * @param value The value to check.
  * @returns `true` for 'true', `false` for 'false', `Boolean` result otherwise.
  */
-export function bool(value: string | boolean): boolean {
+export function bool(value: unknown): boolean {
   if (value === "false") return false
   return Boolean(value)
+}
+
+/**
+ * Utility for converting 'true' and 'false' strings to booleans,
+ * while preserving `undefined` values as `undefined` instead of `false`.
+ */
+export function boolFlag(option: unknown): boolean | undefined {
+  if (option === undefined) return undefined
+  return bool(option)
 }

--- a/src/tools/react-native.ts
+++ b/src/tools/react-native.ts
@@ -13,6 +13,7 @@ type CopyBoilerplateOptions = {
   boilerplatePath: string
   targetPath: string
   excluded: Array<string>
+  overwrite?: boolean
 }
 
 /**
@@ -34,9 +35,12 @@ export async function copyBoilerplate(toolbox: GluegunToolbox, options: CopyBoil
     (file) => !options.excluded.find((exclusion) => file.includes(exclusion)),
   )
 
+  const { overwrite } = options
   // kick off a bunch of copies
   const copyPromises = copyTargets.map((fileOrFolder) =>
-    copyAsync(path(options.boilerplatePath, fileOrFolder), path(options.targetPath, fileOrFolder)),
+    copyAsync(path(options.boilerplatePath, fileOrFolder), path(options.targetPath, fileOrFolder), {
+      ...(overwrite && { overwrite }),
+    }),
   )
 
   // copy them all at once


### PR DESCRIPTION
## Please verify the following:

- [x] `yarn ci:test` **jest** tests pass with new tests, if relevant
- [x] `README.md` has been updated with your changes, if relevant

## Describe your PR
Resolves https://github.com/infinitered/ignite/issues/2056 by checking if directory exists or not before moving into target directory