### PR TITLE
Maverick Styling and Date to account for i18n (and RTL)

### DIFF
--- a/boilerplate/app/components/Button.tsx
+++ b/boilerplate/app/components/Button.tsx
@@ -145,8 +145,8 @@ const $baseTextStyle: TextStyle = {
   zIndex: 2,
 }
 
-const $rightAccessoryStyle: ViewStyle = { marginLeft: 8, zIndex: 1 }
-const $leftAccessoryStyle: ViewStyle = { marginRight: 8, zIndex: 1 }
+const $rightAccessoryStyle: ViewStyle = { marginStart: 8, zIndex: 1 }
+const $leftAccessoryStyle: ViewStyle = { marginEnd: 8, zIndex: 1 }
 
 const $viewPresets = {
   default: [

--- a/boilerplate/app/components/ListItem.tsx
+++ b/boilerplate/app/components/ListItem.tsx
@@ -197,8 +197,7 @@ const $separatorBottom: ViewStyle = {
 }
 
 const $textStyle: TextStyle = {
-  paddingTop: 8,
-  paddingBottom: 8,
+  paddingVertical: 8,
   alignSelf: "center",
   flexGrow: 1,
   flexShrink: 1,
@@ -215,9 +214,9 @@ const $iconContainer: ViewStyle = {
   flexGrow: 0,
 }
 const $iconContainerLeft: ViewStyle = {
-  marginRight: 16,
+  marginEnd: 16,
 }
 
 const $iconContainerRight: ViewStyle = {
-  marginLeft: 16,
+  marginStart: 16,
 }

--- a/boilerplate/app/components/TextField.tsx
+++ b/boilerplate/app/components/TextField.tsx
@@ -139,8 +139,8 @@ export const TextField = forwardRef(function TextField(props: TextFieldProps, re
     $inputWrapperStyle,
     status === "error" && { borderColor: colors.error },
     TextInputProps.multiline && { minHeight: 112 },
-    LeftAccessory && { paddingLeft: 0 },
-    RightAccessory && { paddingRight: 0 },
+    LeftAccessory && { paddingStart: 0 },
+    RightAccessory && { paddingEnd: 0 },
     $inputWrapperStyleOverride,
   ]
 
@@ -246,14 +246,10 @@ const $inputStyle: TextStyle = {
   fontSize: 16,
   height: 24,
   // https://github.com/facebook/react-native/issues/21720#issuecomment-532642093
-  paddingTop: 0,
-  paddingBottom: 0,
-  paddingLeft: 0,
-  paddingRight: 0,
-  marginTop: 8,
-  marginBottom: 8,
-  marginLeft: 10,
-  marginRight: 10,
+  paddingVertical: 0,
+  paddingHorizontal: 0,
+  marginVertical: 8,
+  marginHorizontal: 10,
 }
 
 const $helperStyle: TextStyle = {
@@ -261,13 +257,13 @@ const $helperStyle: TextStyle = {
 }
 
 const $rightAccessoryStyle: ViewStyle = {
-  marginRight: 8,
+  marginEnd: 8,
   height: 40,
   justifyContent: "center",
   alignItems: "center",
 }
 const $leftAccessoryStyle: ViewStyle = {
-  marginLeft: 8,
+  marginStart: 8,
   height: 40,
   justifyContent: "center",
   alignItems: "center",

--- a/boilerplate/app/components/bullet-item/bullet-item.tsx
+++ b/boilerplate/app/components/bullet-item/bullet-item.tsx
@@ -12,7 +12,7 @@ const BULLET_ITEM: ViewStyle = {
   borderBottomColor: "#3A3048",
 }
 const BULLET_CONTAINER: ViewStyle = {
-  marginRight: spacing[4] - 1,
+  marginEnd: spacing[4] - 1,
   marginTop: spacing[2],
 }
 const BULLET: ImageStyle = {

--- a/boilerplate/app/components/checkbox/checkbox.tsx
+++ b/boilerplate/app/components/checkbox/checkbox.tsx
@@ -28,7 +28,7 @@ const FILL: ViewStyle = {
   backgroundColor: colors.tint,
 }
 
-const LABEL: TextStyle = { paddingLeft: spacing[2], color: colors.palette.neutral900 }
+const LABEL: TextStyle = { paddingStart: spacing[2], color: colors.palette.neutral900 }
 
 export function Checkbox(props: CheckboxProps) {
   const numberOfLines = props.multiline ? 0 : 1

--- a/boilerplate/app/models/Episode.test.ts
+++ b/boilerplate/app/models/Episode.test.ts
@@ -24,6 +24,10 @@ const data = {
 }
 const episode = EpisodeModel.create(data)
 
+jest.mock("i18n-js", () => ({
+  currentLocale: () => "en",
+}))
+
 test("publish date format", () => {
   expect(episode.datePublished).toBe("Jan 20, 2022")
 })

--- a/boilerplate/app/models/Episode.ts
+++ b/boilerplate/app/models/Episode.ts
@@ -1,6 +1,6 @@
 import { Instance, SnapshotIn, SnapshotOut, types } from "mobx-state-tree"
 import { withSetPropAction } from "./helpers/with-set-prop-action"
-import { format, parseISO } from "date-fns"
+import { formatDate } from "../utils/format-date"
 
 interface Enclosure {
   link: string
@@ -31,7 +31,7 @@ export const EpisodeModel = types
   .views((episode) => ({
     get datePublished() {
       try {
-        return format(parseISO(episode.pubDate), "MMM dd, yyyy")
+        return formatDate(episode.pubDate)
       } catch (error) {
         return ""
       }

--- a/boilerplate/app/screens/DemoCommunityScreen.tsx
+++ b/boilerplate/app/screens/DemoCommunityScreen.tsx
@@ -124,7 +124,7 @@ const $sectionTitle: TextStyle = {
 }
 
 const $logoContainer: ViewStyle = {
-  marginRight: 16,
+  marginEnd: 16,
   flexDirection: "row",
   flexWrap: "wrap",
   alignContent: "center",

--- a/boilerplate/app/screens/DemoComponentsScreen/demos/DemoListItem.tsx
+++ b/boilerplate/app/screens/DemoComponentsScreen/demos/DemoListItem.tsx
@@ -101,7 +101,7 @@ export const DemoListItem: Demo = {
       <ListItem
         topSeparator
         LeftComponent={
-          <View style={[$customLeft, { marginRight: 16 }]}>
+          <View style={[$customLeft, { marginEnd: 16 }]}>
             {Array.from({ length: 9 }, (x, i) => i).map((i) => (
               <Icon key={i} icon="ladybug" color={colors.palette.neutral100} size={20} />
             ))}
@@ -115,7 +115,7 @@ export const DemoListItem: Demo = {
         topSeparator
         bottomSeparator
         RightComponent={
-          <View style={[$customLeft, { marginLeft: 16 }]}>
+          <View style={[$customLeft, { marginStart: 16 }]}>
             {Array.from({ length: 9 }, (x, i) => i).map((i) => (
               <Icon key={i} icon="ladybug" color={colors.palette.neutral100} size={20} />
             ))}

--- a/boilerplate/app/screens/DemoComponentsScreen/demos/DemoTextField.tsx
+++ b/boilerplate/app/screens/DemoComponentsScreen/demos/DemoTextField.tsx
@@ -26,8 +26,7 @@ const $customLabelAndHelperStyle: TextStyle = {
 }
 
 const $customInputWithAbsoluteAccessoriesStyle: ViewStyle = {
-  marginLeft: 50,
-  marginRight: 50,
+  marginHorizontal: 50,
 }
 
 const $customLeftAccessoryStyle: ViewStyle = {

--- a/boilerplate/app/screens/DemoPodcastListScreen.tsx
+++ b/boilerplate/app/screens/DemoPodcastListScreen.tsx
@@ -132,7 +132,7 @@ const $toggle: ViewStyle = {
 }
 
 const $toggleText: TextStyle = {
-  marginLeft: spacing[2],
+  marginStart: spacing[2],
 }
 
 const $itemThumbnail: ImageStyle = {

--- a/boilerplate/app/utils/format-date.ts
+++ b/boilerplate/app/utils/format-date.ts
@@ -1,0 +1,28 @@
+import { Locale, format, parseISO } from "date-fns"
+import I18n from "i18n-js"
+
+import ar from "date-fns/locale/ar-SA"
+import ko from "date-fns/locale/ko"
+import en from "date-fns/locale/en-US"
+
+interface Options {
+  locale?: Locale
+  weekStartsOn?: 0 | 1 | 2 | 3 | 4 | 5 | 6
+  firstWeekContainsDate?: number
+  useAdditionalWeekYearTokens?: boolean
+  useAdditionalDayOfYearTokens?: boolean
+}
+
+const getLocale = (): Locale => {
+  const locale = I18n.currentLocale().split("-")[0]
+  return locale === "ar" ? ar : locale === "ko" ? ko : en
+}
+
+export const formatDate = (date: string, dateFormat?: string, options?: Options) => {
+  const locale = getLocale()
+  const dateOptions = {
+    ...options,
+    locale,
+  }
+  return format(parseISO(date), dateFormat ?? "MMM dd, yyyy", dateOptions)
+}

--- a/docs/Components-Checkbox.md
+++ b/docs/Components-Checkbox.md
@@ -13,9 +13,9 @@ const [on, setOn] = useState(false)
   multiline
   style={{
     backgroundColor: "purple",
-    marginLeft: 40,
+    marginStart: 40,
     paddingVertical: 30,
-    paddingLeft: 60,
+    paddingStart: 60,
   }}
   fillStyle={{
     backgroundColor: "red",
@@ -76,9 +76,9 @@ The optional [`style`](https://reactnative.dev/docs/viewstyle) prop is applied t
   value={on}
   style={{
     backgroundColor: "purple",
-    marginLeft: 40,
+    marginStart: 40,
     paddingVertical: 30,
-    paddingLeft: 60,
+    paddingStart: 60,
   }}
   onToggle={setOn}
 />

--- a/docs/Components.md
+++ b/docs/Components.md
@@ -68,9 +68,9 @@ const [on, setOn] = useState(false)
   multiline
   style={{
     backgroundColor: "purple",
-    marginLeft: 40,
+    marginStart: 40,
     paddingVertical: 30,
-    paddingLeft: 60,
+    paddingStart: 60,
   }}
   fillStyle={{
     backgroundColor: "red",


### PR DESCRIPTION
## Please verify the following:

- [x] `yarn ci:test` **jest** tests pass with new tests, if relevant
- [x] `README.md` has been updated with your changes, if relevant

## Describe your PR

This PR address some changes to the work @yulolimum did in another [PR](https://github.com/infinitered/ignite/pull/2065). The two main aspects are how we're stying left/right/top/bottom for margins and padding and updating our dates formatter to take locale into account.

### Stying

Since we're supporting RTL, we should move away from using `{margin/padding}Left` and `{margin/padding}Right`. 

For LTR: start = left, end = right
For RTL: start = right, end = left

In [Android 4.2's support for RTL layouts](http://developer.android.com/about/versions/android-4.2.html#RTL) they give an example of how to use this flow following the above mentioned.

### Date

Added a new `/app/utils/format-date.ts` util file that makes our `date-fns` format function locale specific. 

NOTE: there is a known bug where this package doesn't localize numbers. Here is some activity about it on [StackOverflow](https://stackoverflow.com/questions/64869932/date-fns-format-is-not-localizing-numbers)
