### PR TITLE
fix(boilerplate): Demo podcast list screen initial render

### DIFF
--- a/boilerplate/app/screens/DemoPodcastListScreen.tsx
+++ b/boilerplate/app/screens/DemoPodcastListScreen.tsx
@@ -40,7 +40,7 @@ export const DemoPodcastListScreen = observer(function DemoPodcastListScreen(
     <Screen preset="fixed" safeAreaEdges={["top"]}>
       <FlatList<Episode>
         data={episodeStore.episodesForList}
-        extraData={episodeStore.favorites.length}
+        extraData={episodeStore.episodeForList.length}
         contentContainerStyle={$flatListContentContainer}
         refreshing={refreshing}
         onRefresh={manualRefresh}

--- a/boilerplate/app/screens/DemoPodcastListScreen.tsx
+++ b/boilerplate/app/screens/DemoPodcastListScreen.tsx
@@ -40,7 +40,7 @@ export const DemoPodcastListScreen = observer(function DemoPodcastListScreen(
     <Screen preset="fixed" safeAreaEdges={["top"]}>
       <FlatList<Episode>
         data={episodeStore.episodesForList}
-        extraData={episodeStore.episodeForList.length}
+        extraData={episodeStore.episodesForList.length}
         contentContainerStyle={$flatListContentContainer}
         refreshing={refreshing}
         onRefresh={manualRefresh}

--- a/boilerplate/app/screens/DemoPodcastListScreen.tsx
+++ b/boilerplate/app/screens/DemoPodcastListScreen.tsx
@@ -40,7 +40,7 @@ export const DemoPodcastListScreen = observer(function DemoPodcastListScreen(
     <Screen preset="fixed" safeAreaEdges={["top"]}>
       <FlatList<Episode>
         data={episodeStore.episodesForList}
-        extraData={episodeStore.episodesForList.length}
+        extraData={episodeStore.favorites.length + episodeStore.episodes.length}
         contentContainerStyle={$flatListContentContainer}
         refreshing={refreshing}
         onRefresh={manualRefresh}


### PR DESCRIPTION
## Please verify the following:

- [ ] `yarn ci:test` **jest** tests pass with new tests, if relevant
- [ ] `README.md` has been updated with your changes, if relevant

## Describe your PR

Found an issue when spinning up a new app, `DemoPodcastListScreen` is empty: #2075 
I think the favorites feature was related. The length of favorites doesn't change on initial load so extra data doesn't change and the flatList never re-renders. But I still don't understand why the lists would show up on the reload.

### Photo/Video

|Fixed|Favorite List persists|
|-|-|
|![CleanShot 2022-08-29 at 11 08 27](https://user-images.githubusercontent.com/53795920/187257526-f6ab45ca-ebea-4722-87cd-4daa6cec578b.gif)|![CleanShot 2022-08-29 at 11 09 38](https://user-images.githubusercontent.com/53795920/187257336-24458aba-8e70-4f5e-ae61-6349418cbdd0.gif)|
