### PR TITLE
Remove `}` from `false` flag suggestion after `new` command

### DIFF
--- a/src/commands/new.ts
+++ b/src/commands/new.ts
@@ -535,7 +535,7 @@ export default {
 
     const stringFlag = ([key, value]: FlagEntry) => `--${kebabCase(key)}=${value}`
     const booleanFlag = ([key, value]: FlagEntry) =>
-      value ? `--${kebabCase(key)}` : `--${kebabCase(key)}=${value}}`
+      value ? `--${kebabCase(key)}` : `--${kebabCase(key)}=${value}`
 
     const cliCommand = `npx ignite-cli new ${projectName} ${(Object.entries(flags) as FlagEntry[])
       .filter(([key]) => privateFlags.includes(key) === false)


### PR DESCRIPTION
## Please verify the following:

- [x] `yarn ci:test` **jest** tests pass with new tests, if relevant
- [x] `README.md` has been updated with your changes, if relevant

## Describe your PR
When a flag value (like `--git=false`) is suggested from the chosen options, a dangling `}` is added.

Example:
```
npx ignite-cli new PizzaApp --bundle=com.pizzaapp --git=false} --install-deps=false} --packager=yarn --target-path=/Users/joshuayoes/Code/PizzaApp
```

This PR removes that dangling `}` from output