### PR TITLE
Fix `remove-demo` command from removing the first line of every file with `@demo remove-next-line`

### DIFF
--- a/src/tools/__snapshots__/demo.test.ts.snap
+++ b/src/tools/__snapshots__/demo.test.ts.snap
@@ -83,13 +83,15 @@ exports[`demo removeCurrentLine should remove line with "// @demo remove-current
 `;
 
 exports[`demo removeNextLine should remove comment and next line after "/* @demo remove-next-line */" 1`] = `
-"        export * from \\"./WelcomeScreen\\"
+"
+        export * from \\"./WelcomeScreen\\"
         export * from \\"./LoginScreen\\"
       "
 `;
 
 exports[`demo removeNextLine should remove comment and next line after "// @demo remove-next-line" 1`] = `
-"        export * from \\"./WelcomeScreen\\"
+"
+        export * from \\"./WelcomeScreen\\"
         export * from \\"./LoginScreen\\"
       "
 `;

--- a/src/tools/demo.test.ts
+++ b/src/tools/demo.test.ts
@@ -101,6 +101,34 @@ describe("demo", () => {
       expect(result).not.toContain(demo.CommentType.REMOVE_NEXT_LINE)
       expect(result).not.toContain("DemoCommunityScreen")
     })
+
+    it(`should not modify other lines other than "// ${demo.CommentType.REMOVE_NEXT_LINE} and line after"`, () => {
+      // simulate whitespace and new lines of file after prettier format
+      const contents = [
+        `export * from "./DemoIcon"`,
+        `export * from "./DemoTextField"`,
+        `export * from "./DemoButton"`,
+        `export * from "./DemoListItem"`,
+        `export * from "./DemoHeader"`,
+        `// ${demo.CommentType.REMOVE_NEXT_LINE}`,
+        `export * from "./DemoAutoImage"`,
+        `export * from "./DemoText"`,
+      ].join("\n")
+
+      const result = demo.removeNextLine(contents)
+      expect(result).not.toContain(demo.CommentType.REMOVE_NEXT_LINE)
+      expect(result).not.toContain("DemoAutoImage")
+      expect(result).toEqual(
+        [
+          `export * from "./DemoIcon"`,
+          `export * from "./DemoTextField"`,
+          `export * from "./DemoButton"`,
+          `export * from "./DemoListItem"`,
+          `export * from "./DemoHeader"`,
+          `export * from "./DemoText"`,
+        ].join("\n"),
+      )
+    })
   })
 
   describe("removeBlock", () => {

--- a/src/tools/demo.ts
+++ b/src/tools/demo.ts
@@ -24,7 +24,16 @@ function removeNextLine(contents: string, comment = CommentType.REMOVE_NEXT_LINE
   const lines = contents.split("\n")
   const result = lines.filter((line, index) => {
     const prevLine = lines[index - 1]
-    return line.includes(comment) === false && prevLine?.includes(comment) === false
+
+    const commentInCurrent = line.includes(comment) === false
+    const commentInPrevious = prevLine?.includes(comment) === false
+
+    if (index === 0) {
+      // if we are on the first line, there is no previous line to check
+      return commentInCurrent
+    }
+
+    return commentInCurrent && commentInPrevious
   })
   return result.join("\n")
 }

--- a/src/tools/demo.ts
+++ b/src/tools/demo.ts
@@ -25,15 +25,17 @@ function removeNextLine(contents: string, comment = CommentType.REMOVE_NEXT_LINE
   const result = lines.filter((line, index) => {
     const prevLine = lines[index - 1]
 
-    const commentInCurrent = line.includes(comment) === false
-    const commentInPrevious = prevLine?.includes(comment) === false
+    const preserveCurrent = line.includes(comment) === false
+    const preservePrevious = prevLine !== undefined && prevLine.includes(comment) === false
 
     if (index === 0) {
       // if we are on the first line, there is no previous line to check
-      return commentInCurrent
+      return preserveCurrent
     }
 
-    return commentInCurrent && commentInPrevious
+    // keep current line if there is no comment in current or previous line
+    const keepLine = preserveCurrent && preservePrevious
+    return keepLine
   })
   return result.join("\n")
 }


### PR DESCRIPTION
## Please verify the following:

- [x] `yarn ci:test` **jest** tests pass with new tests, if relevant
- [x] `README.md` has been updated with your changes, if relevant

## Describe your PR

### Problem
@yulolimum discovered that `demo.removeNextLine` would remove the first line of a file, even if it didn't have a comment

![yulolimum-capture-2022-08-29--13-03-40@2x](https://user-images.githubusercontent.com/37849890/187312976-be074708-d4a3-4898-bae8-de3382ba5671.jpg)

### Solution
Only check whether the previous line has a comment in `demo.removeNextLine` if it is not the first line of a file
