### PR TITLE
Fix `--overwrite` in `new` command for not default target path

### DIFF
--- a/src/commands/new.ts
+++ b/src/commands/new.ts
@@ -221,8 +221,10 @@ export default {
         process.exit(1)
       }
 
-      log(`Removing existing project ${projectName}`)
-      remove(projectName)
+      if (overwrite === true) {
+        log(`Removing existing project ${targetPath}`)
+        remove(targetPath)
+      }
     }
     // #endregion
 


### PR DESCRIPTION
## Please verify the following:

- [x] `yarn ci:test` **jest** tests pass with new tests, if relevant
- [x] `README.md` has been updated with your changes, if relevant

## Describe your PR

### Problem
`--overwrite` was deleting the relative path of the project name, not the actual target directory. So if we had a different path from the present working directory, it wasn't actually deleting the target directory

### Solution
Delete the target path, not a relative path of the project name