### PR TITLE
feat(generator): custom file names

### DIFF
--- a/boilerplate/ignite/templates/navigator/NAMENavigator.tsx.ejs
+++ b/boilerplate/ignite/templates/navigator/NAMENavigator.tsx.ejs
@@ -2,7 +2,7 @@
 destinationDir: app/navigators
 patch:
   path: "app/navigators/index.ts"
-  append: "export * from \"./<%= props.kebabCaseName %>-navigator\"\n"
+  append: "export * from \"./<%= props.pascalCaseName %>Navigator\"\n"
   skip: <%= props.skipIndexFile %>
 ---
 import React from "react"

--- a/boilerplate/ignite/templates/screen/NAMEScreen.tsx.ejs
+++ b/boilerplate/ignite/templates/screen/NAMEScreen.tsx.ejs
@@ -1,7 +1,7 @@
 ---
 patch:
   path: "app/screens/index.ts"
-  append: "export * from \"./<%= props.kebabCaseName %>-screen\"\n"
+  append: "export * from \"./<%= props.pascalCaseName %>Screen\"\n"
   skip: <%= props.skipIndexFile %>
 ---
 import React, { FC } from "react"

--- a/docs/Generator-Templates.md
+++ b/docs/Generator-Templates.md
@@ -16,13 +16,21 @@ Any files in that folder will be copied over & run through the generator with th
 
 ## File naming conventions
 
-If you use all upper-case `NAME` in your template filenames, that will be replaced by a kebab-case version of the name provided by the person running the generator.
+If you use all upper-case `NAME` in your template filenames, that will be replaced by a pascal-case version of the name provided by the person running the generator.
 
 It's best to just look at an example:
 
-Let's say you have a file called `NAME-model.ts`.
+Let's say you have a file called `NAMEModel.ts`.
 
-If they run `npx ignite-cli generate model Pizza`, it'll name the file `pizza-model.ts`.
+If they run `npx ignite-cli generate model Pizza`, it'll name the file `PizzaModel.ts`.
+
+If you'd like to customize the filename you can provide a filename option in the frontmatter of the template like so:
+
+```
+---
+filename: <%= props.camelCaseName %>.tsx
+---
+```
 
 ## Props
 

--- a/docs/Generator-Templates.md
+++ b/docs/Generator-Templates.md
@@ -20,9 +20,9 @@ If you use all upper-case `NAME` in your template filenames, that will be replac
 
 It's best to just look at an example:
 
-Let's say you have a file called `NAMEModel.ts`.
+Let's say you have a file called `NAMEScreen.ts`.
 
-If they run `npx ignite-cli generate model Pizza`, it'll name the file `PizzaModel.ts`.
+If they run `npx ignite-cli generate screen Pizza`, it'll name the file `PizzaScreen.ts`.
 
 If you'd like to customize the filename you can provide a filename option in the frontmatter of the template like so:
 

--- a/src/tools/generators.ts
+++ b/src/tools/generators.ts
@@ -273,7 +273,7 @@ export function generateFromTemplate(
     const destinationDir = templateDestinationDir
       ? path(cwd(), templateDestinationDir)
       : defaultDestinationDir
-    const destinationPath = path(destinationDir, filename)
+    const destinationPath = path(destinationDir, data.filename ?? filename)
 
     // ensure destination folder exists
     dir(destinationDir)


### PR DESCRIPTION
## Describe your PR

Per the discussion https://github.com/infinitered/ignite/discussions/2133, the users can now configure the case of the generated filenames. The default is still `pascalCaseName` but it is configurable to both `kebabCaseName` or `camelCaseName`

## Photos

|Using Generator|`camelCaseName` in template|
|-|-|
|<img width="609" alt="CleanShot 2022-09-09 at 14 19 44@2x" src="https://user-images.githubusercontent.com/53795920/189436556-f4f3a6d6-a0bf-470d-8a15-845c99d051af.png">|<img width="575" alt="CleanShot 2022-09-09 at 13 46 45@2x" src="https://user-images.githubusercontent.com/53795920/189435963-3b20949b-41a7-45f8-b31d-e9ff2430e9d0.png">|
|List of screens|index.ts|
|<img width="200" alt="CleanShot 2022-09-09 at 14 15 19@2x" src="https://user-images.githubusercontent.com/53795920/189435987-6c2e9e47-2e15-4629-a352-89ea92d1f7bf.png">|<img width="521" alt="CleanShot 2022-09-09 at 13 48 58@2x" src="https://user-images.githubusercontent.com/53795920/189435980-de2e4cd4-a599-4c86-a860-02310a20e744.png">|
