### PR TITLE
Switching to async for copy/remove

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
   "scripts": {
     "compile": "tsc -p .",
     "typecheck": "tsc -p . --noEmit",
-    "build": "yarn compile && cp ./boilerplate/.gitignore ./boilerplate/.gitignore.template",
+    "build": "yarn compile && cp ./boilerplate/.gitignore ./boilerplate/.gitignore.template && cp ./src/assets/*.txt ./build/assets/",
     "format": "prettier '**/*{.js,.ts,.tsx,.json,.md}'",
     "format:write": "yarn format --write",
     "format:check": "yarn format --check",

--- a/src/commands/cache.ts
+++ b/src/commands/cache.ts
@@ -19,9 +19,8 @@ const help = (_toolbox: GluegunToolbox) => {
   igniteHeading()
   heading("ignite cache")
   p()
-  p(
-    "ignite cache is a parent command for interacting with the dependency cache ignite uses on your machine to speed up the packager installation process.",
-  )
+  p("ignite cache is a parent command for interacting with the dependency cache")
+  p("ignite uses on your machine to speed up the packager installation process.")
   p()
   heading("Subcommands:")
   p()

--- a/src/commands/new.ts
+++ b/src/commands/new.ts
@@ -444,7 +444,9 @@ export default {
     log(`${!cacheExists ? "expected " : ""}cachePath: ${cachePath}`)
     log(`cacheExists: ${cacheExists}`)
 
-    const defaultUseCache = true
+    // use-cache defaults to `false` for now; if we make it robust enough,
+    // we can enable it by default in the future.
+    const defaultUseCache = false
     const useCache = options.useCache === undefined ? defaultUseCache : boolFlag(options.useCache)
 
     const shouldUseCache = installDeps && cacheExists && useCache

--- a/src/commands/new.ts
+++ b/src/commands/new.ts
@@ -126,7 +126,7 @@ export default {
     // #region Toolbox
     const { print, filesystem, system, meta, parameters, strings, prompt } = toolbox
     const { kebabCase } = strings
-    const { exists, path, remove, copy, read, write } = filesystem
+    const { exists, path, removeAsync, copy, read, write } = filesystem
     const { info, colors, warning } = print
     const { gray, cyan, yellow, underline, white } = colors
     const options: Options = parameters.options
@@ -359,15 +359,22 @@ export default {
     if (exists(targetPath) === "dir" && overwrite === true) {
       const msg = ` Tossing that old app like it's hot`
       startSpinner(msg)
-      remove(targetPath)
+      await removeAsync(targetPath)
       stopSpinner(msg, "🗑️")
     }
+    // #endregion
+
+    // #region Local build folder clean
     // Remove some folders that we don't want to copy over
-    // This mostly only applies to when you're developing locally
-    remove(path(boilerplatePath, "ios", "Pods"))
-    remove(path(boilerplatePath, "node_modules"))
-    remove(path(boilerplatePath, "android", ".idea"))
-    remove(path(boilerplatePath, "android", ".gradle"))
+    // This mostly only applies when you're developing locally
+    await Promise.all([
+      removeAsync(path(boilerplatePath, "node_modules")),
+      removeAsync(path(boilerplatePath, "ios", "Pods")),
+      removeAsync(path(boilerplatePath, "ios", "build")),
+      removeAsync(path(boilerplatePath, "android", ".idea")),
+      removeAsync(path(boilerplatePath, "android", ".gradle")),
+      removeAsync(path(boilerplatePath, "android", "build")),
+    ])
     // #endregion
 
     // #region Copy Boilerplate Files
@@ -444,7 +451,7 @@ export default {
     if (shouldUseCache) {
       const msg = `Grabbing those ${packagerName} dependencies from the back`
       startSpinner(msg)
-      cache.copy({
+      await cache.copy({
         fromRootDir: cachePath,
         toRootDir: targetPath,
         packagerName,
@@ -461,7 +468,7 @@ export default {
     }
 
     // remove the gitignore template
-    remove(".gitignore.template")
+    await removeAsync(".gitignore.template")
     // #endregion
 
     // #region Rename App
@@ -495,7 +502,8 @@ export default {
     if (shouldFreshInstallDeps && cacheExists === false) {
       const msg = `Saving ${packagerName} dependencies for next time`
       startSpinner(msg)
-      cache.copy({
+      log(targetPath)
+      await cache.copy({
         fromRootDir: targetPath,
         toRootDir: cachePath,
         packagerName,

--- a/src/tools/cache.ts
+++ b/src/tools/cache.ts
@@ -28,13 +28,14 @@ interface TargetsOptions {
   packagerName: PackagerName
   platform: NodeJS.Platform | undefined
 }
-const targets = ({ rootDir, packagerName, platform }: TargetsOptions) =>
-  [
+const targets = ({ rootDir, packagerName, platform }: TargetsOptions) => {
+  return [
     { type: "dir", path: path(rootDir, "node_modules") },
     { type: "file", path: path(rootDir, lockFile[packagerName]) },
     { type: "dir", path: path(rootDir, "ios", "Pods"), platform: ["darwin"] },
     { type: "dir", path: path(rootDir, "ios", "build"), platform: ["darwin"] },
   ].filter((target) => (target.platform ? target.platform.includes(platform) : true))
+}
 
 interface CopyOptions {
   fromRootDir: string
@@ -48,14 +49,16 @@ function copy(options: CopyOptions) {
   const fromTargets = targets({ rootDir: fromRootDir, packagerName, platform })
   const toTargets = targets({ rootDir: toRootDir, packagerName, platform })
 
-  fromTargets.forEach((from, index) => {
-    const to = toTargets[index]
-    if (from.type === "dir") {
-      dir(from.path)
-    }
+  return Promise.all(
+    fromTargets.map((from, index) => {
+      const to = toTargets[index]
+      if (from.type === "dir") {
+        dir(from.path)
+      }
 
-    filesystem.copy(from.path, to.path, { overwrite: true })
-  })
+      return filesystem.copyAsync(from.path, to.path, { overwrite: true })
+    }),
+  )
 }
 
 /**


### PR DESCRIPTION
I noticed the CLI spinners were locking up when doing certain operations, so I made them async and parallelized them, and gained a little speed when restoring from a cache, plus not locking up the UI.

Before (no cache): 90s
After (no cache): 85s
Before (cached): 21s
After (cached): 19s
