### PR TITLE
[maverick] Fix path of RootStore in model template

### DIFF
--- a/boilerplate/ignite/templates/model/NAME.ts.ejs
+++ b/boilerplate/ignite/templates/model/NAME.ts.ejs
@@ -1,10 +1,10 @@
 ---
 patches:
-  - path: "app/models/root-store/root-store.ts"
+  - path: "app/models/RootStore.ts"
     after: "from \"mobx-state-tree\"\n"
-    insert: "import { <%= props.pascalCaseName %>Model } from \"../<%= props.pascalCaseName %>\"\n"
+    insert: "import { <%= props.pascalCaseName %>Model } from \"./<%= props.pascalCaseName %>\"\n"
     skip: <%= !props.pascalCaseName.endsWith('Store') %>
-  - path: "app/models/root-store/root-store.ts"
+  - path: "app/models/RootStore.ts"
     after: "types.model(\"RootStore\").props({\n"
     insert: "  <%= props.camelCaseName %>: types.optional(<%= props.pascalCaseName %>Model, {} as any),\n"
     skip: <%= !props.pascalCaseName.endsWith('Store') %>


### PR DESCRIPTION
Also fix the path to the newly-created model that's added to the RootStore

## Please verify the following:

- [x] `yarn ci:test` **jest** tests pass with new tests, if relevant
- [x] `README.md` has been updated with your changes, if relevant

## Describe your PR

Creating a new model store on maverick uses an incorrect path for the RootStore leading to an error. This PR fixes the path the the RootStore and also the path to the newly-created model
