### PR TITLE
Fix: Calling console.tron in release builds causes crash

### DIFF
--- a/boilerplate/app/models/environment.ts
+++ b/boilerplate/app/models/environment.ts
@@ -1,8 +1,8 @@
 import { Api } from "../services/api"
-
+import { Reactotron } from "../services/reactotron"
+  
 let ReactotronDev
 if (__DEV__) {
-  const { Reactotron } = require("../services/reactotron")
   ReactotronDev = Reactotron
 }
 


### PR DESCRIPTION
If the import to reactotron is locked behind `__DEV__ `the interface-compatible mock at [services/reactotron/reactotron.ts#L30](https://github.com/infinitered/ignite/blob/master/boilerplate/app/services/reactotron/reactotron.ts#L30) never gets attached causing the app to fail in production builds unless you prefix every `console.tron` with `__DEV__ && `.