### PR TITLE
Handle relative paths and `~` character in `--target-path` of `new` command

### DIFF
--- a/src/commands/new.ts
+++ b/src/commands/new.ts
@@ -196,7 +196,7 @@ export default {
 
     // #region Project Path
     const defaultTargetPath = path(projectName)
-    let targetPath = useDefault(options.targetPath) ? defaultTargetPath : options.targetPath
+    let targetPath = useDefault(options.targetPath) ? defaultTargetPath : path(options.targetPath)
     if (targetPath === undefined) {
       const targetPathResponse = await prompt.ask(() => ({
         type: "input",

--- a/src/commands/new.ts
+++ b/src/commands/new.ts
@@ -505,7 +505,7 @@ export default {
     // #endregion
 
     // #region Cache dependencies
-    if (shouldFreshInstallDeps && cacheExists === false) {
+    if (shouldFreshInstallDeps && cacheExists === false && useCache) {
       const msg = `Saving ${packagerName} dependencies for next time`
       startSpinner(msg)
       log(targetPath)

--- a/src/commands/new.ts
+++ b/src/commands/new.ts
@@ -397,7 +397,7 @@ export default {
     // Release Ignite installs have the boilerplate's .gitignore in .gitignore.template
     // (see https://github.com/npm/npm/issues/3763); development Ignite still
     // has it in .gitignore. Copy it from one or the other.
-    const targetIgnorePath = log(path(process.cwd(), ".gitignore"))
+    const targetIgnorePath = log(path(boilerplatePath, ".gitignore"))
     if (!exists(targetIgnorePath)) {
       // gitignore in dev mode?
       let sourceIgnorePath = log(path(boilerplatePath, ".gitignore"))

--- a/src/commands/new.ts
+++ b/src/commands/new.ts
@@ -195,8 +195,12 @@ export default {
     // #endregion
 
     // #region Project Path
+    const parsePath = (p: string) =>
+      p.startsWith("~") ? path(p.replace("~", filesystem.homedir())) : path(p)
     const defaultTargetPath = path(projectName)
-    let targetPath = useDefault(options.targetPath) ? defaultTargetPath : path(options.targetPath)
+    let targetPath = useDefault(options.targetPath)
+      ? defaultTargetPath
+      : parsePath(options.targetPath)
     if (targetPath === undefined) {
       const targetPathResponse = await prompt.ask(() => ({
         type: "input",


### PR DESCRIPTION
## Please verify the following:

- [x] `yarn ci:test` **jest** tests pass with new tests, if relevant
- [x] `README.md` has been updated with your changes, if relevant

## Describe your PR
Closes https://github.com/infinitered/ignite/issues/2141