### PR TITLE
Add `--use-cache` flag to `new` command test

### DIFF
--- a/test/vanilla/ignite-new.test.ts
+++ b/test/vanilla/ignite-new.test.ts
@@ -23,14 +23,14 @@ describe("ignite new", () => {
     })
   })
 
-  describe(`ignite new ${APP_NAME} --debug --packager=npm --yes`, () => {
+  describe(`ignite new ${APP_NAME} --debug --packager=npm --yes --use-cache`, () => {
     let tempDir: string
     let result: string
     let appPath: string
 
     beforeAll(async () => {
       tempDir = tempy.directory({ prefix: "ignite-" })
-      result = await runIgnite(`new ${APP_NAME} --debug --packager=npm --yes`, {
+      result = await runIgnite(`new ${APP_NAME} --debug --packager=npm --yes --use-cache`, {
         pre: `cd ${tempDir}`,
         post: `cd ${originalDir}`,
       })


### PR DESCRIPTION
## Please verify the following:

- [x] `yarn ci:test` **jest** tests pass with new tests, if relevant
- [x] `README.md` has been updated with your changes, if relevant

## Describe your PR
While we currently have `--use-cache` set to `false` by default for end users, we want to still have cache turned on for CI