### PR TITLE
Add `validateProjectName` guards to prompt

### DIFF
--- a/src/tools/validations.ts
+++ b/src/tools/validations.ts
@@ -1,9 +1,50 @@
-import { GluegunToolbox } from "gluegun"
+import { GluegunToolbox, strings } from "gluegun"
 import { prefix } from "./pretty"
+const { pascalCase } = strings
+
+// #region Error Guards
+type IsError = (str: string) => boolean
+type ErrorMessage = (str?: string) => string
+type ErrorGuard = [IsError, ErrorMessage]
+
+const isIgnite: ErrorGuard = [
+  (str) => str.toLowerCase() === "ignite",
+  (str) => `Hey...that's my name! Please name your project something other than '${str}'.`,
+]
+const isOnlyNumbers: ErrorGuard = [
+  (str) => /^\d+$/.test(str),
+  () => `Please use at least one non-numeric character for your project name`,
+]
+const isKebabCase: ErrorGuard = [
+  (str) => str.includes("-"),
+  (str) =>
+    `Please use 'PascalCase', not 'kebab-case' for your project name. Ex: ${pascalCase(str)}`,
+]
+const isNotAlphaNumeric: ErrorGuard = [
+  (str) => !/^[a-z_][a-z0-9_]+$/i.test(str),
+  () =>
+    `The project name can only contain alphanumeric characters and underscore, but must not begin with a number.`,
+]
+
+const guards: ErrorGuard[] = [isIgnite, isOnlyNumbers, isKebabCase, isNotAlphaNumeric]
+
+/**
+ * check if the value matches any of the error guards
+ * @returns error message from the first guard that matches, or `true` if no guards match
+ */
+const validate = (value: string): true | string => {
+  for (const [isError, errorMessage] of guards) {
+    if (isError(value)) {
+      return errorMessage(value)
+    }
+  }
+  return true
+}
+// #endregion
 
 export async function validateProjectName(toolbox: GluegunToolbox): Promise<string> {
   const { parameters, strings, print } = toolbox
-  const { isBlank, upperFirst, camelCase } = strings
+  const { isBlank } = strings
 
   // grab the project name
   let projectName: string = (parameters.first || "").toString()
@@ -15,6 +56,7 @@ export async function validateProjectName(toolbox: GluegunToolbox): Promise<stri
       type: "input",
       message: "What do you want to call it?",
       prefix,
+      validate,
     }))
     projectName = projectNameResponse.projectName
   }
@@ -24,34 +66,9 @@ export async function validateProjectName(toolbox: GluegunToolbox): Promise<stri
     print.info(`Info: You provided more than one argument for <projectName>. The first one (${projectName}) will be used and the rest are ignored.`) // prettier-ignore
   }
 
-  // guard against `ignite new ignite`
-  if (projectName.toLowerCase() === "ignite") {
-    print.error(
-      `Hey...that's my name! Please name your project something other than '${projectName}'.`,
-    )
-    process.exit(1)
-  }
-
-  // check for kebabs
-  if (`${projectName}`.includes("-")) {
-    // camelCase the project name for user example
-    const projectNameCamel = upperFirst(camelCase(projectName))
-
-    print.error(`Please use camel case for your project name. Ex: ${projectNameCamel}`)
-    process.exit(1)
-  }
-
-  // check for numbers-only names
-  if (/^\d+$/.test(projectName)) {
-    print.error(`Please use at least one non-numeric character for your project name.`)
-    process.exit(1)
-  }
-
-  // check for alphanumeric name, beginning with a letter
-  if (!/^[a-z_][a-z0-9_]+$/i.test(projectName)) {
-    print.error(
-      `The project name can only contain alphanumeric characters and underscore, but must not begin with a number.`,
-    )
+  const error = validate(projectName)
+  if (typeof error === "string") {
+    print.error(error)
     process.exit(1)
   }
 


### PR DESCRIPTION
## Please verify the following:

- [x] `yarn ci:test` **jest** tests pass with new tests, if relevant
- [X] `README.md` has been updated with your changes, if relevant

## Describe your PR
Resolves: https://github.com/infinitered/ignite/issues/2145

Solves the issue by extracting existing `validateBundleIdentifier` validations into guard functions. Now, each guard can be used both by the enquirer prompt and the cli flag arg