### PR TITLE
fix(DrawerIconButton): animate pressible instead of view

### DIFF
--- a/boilerplate/app/screens/DemoComponentsScreen/DrawerIconButton.tsx
+++ b/boilerplate/app/screens/DemoComponentsScreen/DrawerIconButton.tsx
@@ -15,6 +15,8 @@ interface DrawerIconButtonProps extends PressableProps {
   progress: SharedValue<number>
 }
 
+const AnimatedPressible = Animated.createAnimatedComponent(Pressable)
+
 export function DrawerIconButton(props: DrawerIconButtonProps) {
   const { open, progress, ...PressableProps } = props
 
@@ -73,15 +75,13 @@ export function DrawerIconButton(props: DrawerIconButtonProps) {
   }, [open, progress])
 
   return (
-    <Pressable {...PressableProps}>
-      <Animated.View style={[$container, animatedContainerStyles]}>
-        <Animated.View style={[$topBar, animatedTopBarStyles]} />
+    <AnimatedPressible {...PressableProps} style={[$container, animatedContainerStyles]}>
+      <Animated.View style={[$topBar, animatedTopBarStyles]} />
 
-        <Animated.View style={[$middleBar, animatedMiddleBarStyles]} />
+      <Animated.View style={[$middleBar, animatedMiddleBarStyles]} />
 
-        <Animated.View style={[$bottomBar, animatedBottomBarStyles]} />
-      </Animated.View>
-    </Pressable>
+      <Animated.View style={[$bottomBar, animatedBottomBarStyles]} />
+    </AnimatedPressible>
   )
 }
 


### PR DESCRIPTION
## Please verify the following:

- [x] `yarn ci:test` **jest** tests pass with new tests, if relevant
- [x] `README.md` has been updated with your changes, if relevant

## Describe your PR
Resolves https://github.com/infinitered/ignite/issues/2148

After

https://user-images.githubusercontent.com/37849890/190528683-202301ab-dbc4-4ee6-b7cd-9b5df5ae8edc.mp4

