### PR TITLE
fix(cache): copy .xcode.env.local

### DIFF
--- a/src/tools/cache.ts
+++ b/src/tools/cache.ts
@@ -34,7 +34,8 @@ const targets = ({ rootDir, packagerName, platform }: TargetsOptions) => {
     { type: "file", path: path(rootDir, lockFile[packagerName]) },
     { type: "dir", path: path(rootDir, "ios", "Pods"), platform: ["darwin"] },
     { type: "dir", path: path(rootDir, "ios", "build"), platform: ["darwin"] },
-  ].filter((target) => (target.platform ? target.platform.includes(platform) : true))
+    { type: "file", path: path(rootDir, "ios", ".xcode.env.local"), platform: ["darwin"] },
+  ].filter((target) => (target?.platform ? target.platform.includes(platform) : true))
 }
 
 interface CopyOptions {


### PR DESCRIPTION
## Please verify the following:

- [x] `yarn ci:test` **jest** tests pass with new tests, if relevant
- [x] `README.md` has been updated with your changes, if relevant

## Describe your PR

### Problem
```
npx ignite-cli new PizzaApp --use-cache
cd PizzaApp
yarn ios
```

Xcode would throw a build error. It would not throw a build error when the previous commands are run without the `--use-cache` flag.

### Solution
This is fixed by copying the `ios/.xcode.env.local` file generated by Cocopods so it will point to the users Node binary