### PR TITLE
Fix missing "Only Show Favorites" label on Demo Podcast screen

### DIFF
--- a/boilerplate/app/screens/DemoPodcastListScreen.tsx
+++ b/boilerplate/app/screens/DemoPodcastListScreen.tsx
@@ -112,7 +112,7 @@ export const DemoPodcastListScreen = observer(function DemoPodcastListScreen(
           <View style={$heading}>
             <Text preset="heading" tx="demoPodcastListScreen.title" />
             {(episodeStore.favoritesOnly || episodeStore.episodesForList.length > 0) && (
-              <View style={[$rowLayout, $toggle]}>
+              <View style={$toggle}>
                 <Toggle
                   value={episodeStore.favoritesOnly}
                   onValueChange={() =>
@@ -329,8 +329,7 @@ const $rowLayout: ViewStyle = {
 }
 
 const $toggle: ViewStyle = {
-  alignItems: "flex-end",
-  marginTop: spacing.small,
+  marginTop: spacing.medium,
 }
 
 const $labelStyle: TextStyle = {

--- a/boilerplate/app/screens/DemoPodcastListScreen.tsx
+++ b/boilerplate/app/screens/DemoPodcastListScreen.tsx
@@ -324,10 +324,6 @@ const $itemThumbnail: ImageStyle = {
   alignSelf: "flex-start",
 }
 
-const $rowLayout: ViewStyle = {
-  flexDirection: "row",
-}
-
 const $toggle: ViewStyle = {
   marginTop: spacing.medium,
 }


### PR DESCRIPTION
## Please verify the following:

- [x] `yarn test` **jest** tests pass with new tests, if relevant

## Describe your PR
- Closes #2197
- With the toggle getting rework, an old style didn't apply anymore and ended up hiding the text label - now fixed!

| Before   |      After      |
|----------|-------------|
| ![image](https://user-images.githubusercontent.com/374022/191839144-a5bf6c2f-b21e-4cc4-ac32-8d16f180b7c6.png) | ![image](https://user-images.githubusercontent.com/374022/191839262-7a6694a1-462d-43e8-b7e9-31eebba46f03.png) |