### PR TITLE
Remove jetify from post install

### DIFF
--- a/boilerplate/bin/postInstall
+++ b/boilerplate/bin/postInstall
@@ -14,9 +14,6 @@ if (["darwin", "linux"].includes(process.platform)) {
   run('pkill -f "cli.js start" || set exit 0')
 }
 
-// Make sure our Android native modules are androidX-happy
-run("jetify")
-
 // On iOS, make sure CocoaPods are installed
 if (process.platform === "darwin") {
   run('if [ -d "ios" ]; then cd ios && pod install && cd -; fi')

--- a/boilerplate/package.json
+++ b/boilerplate/package.json
@@ -104,7 +104,6 @@
     "jest-circus": "26",
     "jest-environment-node": "26",
     "jest-expo": "^46.0.1",
-    "jetifier": "2.0.0",
     "metro-config": "0.71.1",
     "metro-react-native-babel-preset": "0.71.1",
     "metro-source-map": "0.71.1",


### PR DESCRIPTION
## Please verify the following:

- [x] `yarn ci:test` **jest** tests pass with new tests, if relevant
- [x] `README.md` has been updated with your changes, if relevant

## Describe your PR

We have a couple open issues around calling jetifier post install being deprecated: 
- https://github.com/infinitered/ignite/issues/1978
- https://github.com/infinitered/ignite/issues/2208

Specifically #2208 has some good relevant articles.

It appears that `react-native run-android` now handles using `jetifier`, and most modules should have made the migration to AndroidX by now. 

I've run through the existing android workflows with this PR, and they work for me https://github.com/infinitered/ignite/issues/2135#issuecomment-1256562340