### PR TITLE
fix: post pod install error

### DIFF
--- a/boilerplate/ios/Podfile
+++ b/boilerplate/ios/Podfile
@@ -42,5 +42,6 @@ target 'HelloWorld' do
   post_install do |installer|
     react_native_post_install(installer)
     __apply_Xcode_12_5_M1_post_install_workaround(installer)
+    File.delete("./.xcode.env.local") if File.exist?("./.xcode.env.local")
   end
 end


### PR DESCRIPTION
## Describe your PR

When running `pod install`, it generates `ios/.xcode.env.local` and it's throwing "Command PhaseScriptExecution failed with a nonzero exit code" error when trying to build. With this PR, the `./xcode.env.local` file should be deleted post install.

## Screenshot
![CleanShot 2022-09-23 at 18 56 35](https://user-images.githubusercontent.com/53795920/192073858-83bad737-730f-45f7-87f4-fcc0e3879e40.gif)
