### PR TITLE
fix(cache): remove ios/xcode.env.local copy

### DIFF
--- a/src/tools/cache.ts
+++ b/src/tools/cache.ts
@@ -34,7 +34,6 @@ const targets = ({ rootDir, packagerName, platform }: TargetsOptions) => {
     { type: "file", path: path(rootDir, lockFile[packagerName]) },
     { type: "dir", path: path(rootDir, "ios", "Pods"), platform: ["darwin"] },
     { type: "dir", path: path(rootDir, "ios", "build"), platform: ["darwin"] },
-    { type: "file", path: path(rootDir, "ios", ".xcode.env.local"), platform: ["darwin"] },
   ].filter((target) => (target?.platform ? target.platform.includes(platform) : true))
 }
 


### PR DESCRIPTION
## Please verify the following:

- [x] `yarn test` **jest** tests pass with new tests, if relevant
- [x] `README.md` has been updated with your changes, if relevant

## Describe your PR
[ios/xcode.env.local is removed post](https://github.com/infinitered/ignite/pull/2214) `pod install`, so it's throwing an error when we try to copy a file that doesn't exist