### PR TITLE
Fix: unable to resolve react

### DIFF
--- a/boilerplate/package.json
+++ b/boilerplate/package.json
@@ -66,7 +66,7 @@
     "react-native-screens": "3.15.0",
     "reactotron-mst": "3.1.4",
     "reactotron-react-js": "^3.3.7",
-    "reactotron-react-native": "5.0.2"
+    "reactotron-react-native": "5.0.3"
   },
   "devDependencies": {
     "@babel/core": "^7.18.0",


### PR DESCRIPTION
## Please verify the following:

- [x] `yarn test` **jest** tests pass with new tests, if relevant
- [ ] ~`README.md` has been updated with your changes, if relevant~

## Describe your PR

This is a fix for #2220

Users were experiencing a dependency error only when using npm. It was a dependency issue in reactotron-react-native. That has been fixed, and I verified updating reactotron-react-native from the current 5.0.2 to the new 5.0.3 fixes this issue.