### PR TITLE
fix: 2234 - Remove SafeAreaView in favor of useSafeAreaInsets hook

### DIFF
--- a/boilerplate/app/components/Screen.tsx
+++ b/boilerplate/app/components/Screen.tsx
@@ -213,7 +213,7 @@ export function Screen(props: ScreenProps) {
 
   return (
     <View
-      style={[$containerStyle, { backgroundColor, ...insetPadding }]}
+      style={[$containerStyle, { backgroundColor }, insetPadding ]}
     >
       <StatusBar style={statusBarStyle} {...StatusBarProps} />
 

--- a/boilerplate/app/components/Screen.tsx
+++ b/boilerplate/app/components/Screen.tsx
@@ -11,7 +11,7 @@ import {
   ViewStyle,
 } from "react-native"
 import { StatusBar, StatusBarProps } from "expo-status-bar"
-import { Edge, SafeAreaView, SafeAreaViewProps } from "react-native-safe-area-context"
+import { Edge, useSafeAreaInsets } from "react-native-safe-area-context"
 import { useScrollToTop } from "@react-navigation/native"
 import { colors } from "../theme"
 
@@ -44,10 +44,6 @@ interface BaseScreenProps {
    * By how much should we offset the keyboard? Defaults to 0.
    */
   keyboardOffset?: number
-  /**
-   * Pass any additional props directly to the SafeAreaView component.
-   */
-  SafeAreaViewProps?: SafeAreaViewProps
   /**
    * Pass any additional props directly to the StatusBar component.
    */
@@ -141,6 +137,18 @@ function useAutoPreset(props: AutoScreenProps) {
   }
 }
 
+function useSafeAreaInsetPadding(safeAreaEdges?: Edge[]) {
+  const insets = useSafeAreaInsets()
+
+  const insetStyles: ViewStyle = {}
+  safeAreaEdges?.forEach((edge: Edge) => {
+    const paddingProp = `padding${edge.charAt(0).toUpperCase()}${edge.slice(1)}`
+    insetStyles[paddingProp] = insets[edge]
+  })
+
+  return insetStyles
+}
+
 function ScreenWithoutScrolling(props: ScreenProps) {
   const { style, contentContainerStyle, children } = props
   return (
@@ -197,18 +205,15 @@ export function Screen(props: ScreenProps) {
     KeyboardAvoidingViewProps,
     keyboardOffset = 0,
     safeAreaEdges,
-    SafeAreaViewProps,
     StatusBarProps,
     statusBarStyle = "dark",
   } = props
 
-  const Wrapper = safeAreaEdges?.length ? SafeAreaView : View
+  const insetPadding = useSafeAreaInsetPadding(safeAreaEdges)
 
   return (
-    <Wrapper
-      edges={safeAreaEdges}
-      {...SafeAreaViewProps}
-      style={[$safeAreaStyle, SafeAreaViewProps?.style, { backgroundColor }]}
+    <View
+      style={[$containerStyle, { backgroundColor, ...insetPadding }]}
     >
       <StatusBar style={statusBarStyle} {...StatusBarProps} />
 
@@ -224,11 +229,11 @@ export function Screen(props: ScreenProps) {
           <ScreenWithScrolling {...props} />
         )}
       </KeyboardAvoidingView>
-    </Wrapper>
+    </View>
   )
 }
 
-const $safeAreaStyle: ViewStyle = {
+const $containerStyle: ViewStyle = {
   flex: 1,
   height: "100%",
   width: "100%",


### PR DESCRIPTION
## Please verify the following:

- [x] `yarn test` **jest** tests pass with new tests, if relevant
- [ ] ~`README.md` has been updated with your changes, if relevant~

## Describe your PR

There is an issue with the SafeAreaView from react-native-safe-area-context that causes the top inset to not be set on first render. So you see the content, then it re-renders and jumps down to it's final resting place. The fix is to not use SafeAreaView and use the useSafeAreaInsets hook instead.

This PR changes the Screen component to use the hook and apply the insets as screen padding if they are passed in, which fixes #2234.

### Old behavior

https://user-images.githubusercontent.com/1761434/193369617-27e9df6b-5489-4ee2-bc25-2026ae9e1414.MP4

### New (fixed) behavior

https://user-images.githubusercontent.com/1761434/193369658-838e3a9b-2469-43c5-b4c2-f47e6d5ae0f3.MP4

### Multiple edges passed in (top and bottom)

Ugly, but it shows it still works

<img alt="top-and-bottom" src="https://user-images.githubusercontent.com/1761434/193370514-f5a74fc4-c904-4595-9ae5-0e13d84c4e1c.jpeg" width="400" />
