### PR TITLE
chore(docs): update ignite-cli@next to ignite-cli@latest

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,10 +52,10 @@ Run the CLI:
 
 ```bash
 # Get walked through the prompts for the different options to start your new app
-npx ignite-cli@next new PizzaApp
+npx ignite-cli@latest new PizzaApp
 
 # Accept all the recommended defaults and get straight to coding!
-npx ignite-cli@next new PizzaApp --yes
+npx ignite-cli@latest new PizzaApp --yes
 ```
 
 Once you're up and running, check out our new [Getting Started Guide](https://github.com/infinitered/ignite/blob/master/docs/Guide.md) guide or the rest of our [docs](https://github.com/infinitered/ignite/blob/master/docs).

--- a/docs/Guide.md
+++ b/docs/Guide.md
@@ -11,7 +11,7 @@ In short -- if you use Ignite to start your next React Native project, you're us
 In order to start a new Ignite project, you can use the CLI. No need to install it globally as it works great with `npx`:
 
 ```bash
-npx ignite-cli@next new PizzaApp
+npx ignite-cli@latest new PizzaApp
 ```
 
 It'll walk you through several questions.


### PR DESCRIPTION
## Please verify the following:

- [x] `yarn test` **jest** tests pass with new tests, if relevant
- [x] `README.md` has been updated with your changes, if relevant

## Describe your PR
We have started showing example usage of `ignite-cli` to use `npx ignite-cli@next`. However, we are no longer publishing the latest version using those tags. It appears NPM already has an `@latest` tag applied, so we should update our docs to use the build-in tag