### PR TITLE
fix(package.json): pin "react-error-overlay": "6.0.9"

### DIFF
--- a/boilerplate/package.json
+++ b/boilerplate/package.json
@@ -32,6 +32,9 @@
     "expo:build:detox": "detox build -c ios.sim.expo",
     "expo:test:detox": "./bin/downloadExpoApp.sh && detox test --configuration ios.sim.expo"
   },
+  "overrides": {
+    "react-error-overlay": "6.0.9"
+  },
   "dependencies": {
     "@expo-google-fonts/space-grotesk": "^0.2.2",
     "@expo/webpack-config": "^0.17.0",


### PR DESCRIPTION
## Please verify the following:

- [x] `yarn test` **jest** tests pass with new tests, if relevant
- [x] `README.md` has been updated with your changes, if relevant

## Describe your PR
Resolves #2233. Implements fix for https://github.com/infinitered/ignite/pull/2237, but could not resolve merge conflict