### PR TITLE
Fix expo-cli hermes sanity checks on publish

### DIFF
--- a/boilerplate/android/gradle.properties
+++ b/boilerplate/android/gradle.properties
@@ -34,6 +34,9 @@ expo.webp.enabled=true
 # Enable animated webp support (~3.4 MB increase)
 # Disabled by default because iOS doesn't support animated webp
 expo.webp.animated=false
+# Use hermes as JS engine. To disable remove this line
+expo.jsEngine=hermes
+
 
 # Use this property to specify which architecture you want to build.
 # You can also override it from the CLI using

--- a/boilerplate/ios/Podfile.properties.json
+++ b/boilerplate/ios/Podfile.properties.json
@@ -1,0 +1,3 @@
+{
+	"expo.jsEngine": "hermes"
+}


### PR DESCRIPTION
## Please verify the following:

- [x] `yarn test` **jest** tests pass with new tests, if relevant
- [x] `README.md` has been updated with your changes, if relevant

## Describe your PR
I was trying to publish the app with expo new EAS, and was hitting this issue:
```
sergio@leviathan MyAppProject % yarn eas update                                                                                                                                                                   [4/10/22 | 11:32:44]
yarn run v1.22.11
warning ../package.json: No license field
$ /Users/sergio/Developer/MyAppProject/node_modules/.bin/eas update
Found eas-cli in your project dependencies.
It's recommended to use the "cli.version" field in eas.json to enforce the eas-cli version for your project.
Learn more: https://github.com/expo/eas-cli#enforcing-eas-cli-version-for-your-project

Found eas-cli in your project dependencies.
It's recommended to use the "cli.version" field in eas.json to enforce the eas-cli version for your project.
Learn more: https://github.com/expo/eas-cli#enforcing-eas-cli-version-for-your-project

✔ No branches found. Provide a branch name: … main
✔ Provide an update message. … App boilerplate

[expo-cli] --non-interactive is not supported, use $CI=1 instead
[expo-cli] Error: JavaScript engine configuration is inconsistent between app.json and iOS native project.
[expo-cli] In app.json: Hermes is enabled
[expo-cli] In iOS native project: Hermes is not enabled
[expo-cli] Please check the following files for inconsistencies:
[expo-cli]   - /Users/sergio/Developer/MyAppProject/app.json
[expo-cli]   - /Users/sergio/Developer/MyAppProject/ios/Podfile
[expo-cli]   - /Users/sergio/Developer/MyAppProject/ios/Podfile.properties.json
[expo-cli] Learn more: https://expo.fyi/hermes-ios-config
[expo-cli] Error: JavaScript engine configuration is inconsistent between app.json and iOS native project.
[expo-cli] In app.json: Hermes is enabled
[expo-cli] In iOS native project: Hermes is not enabled
[expo-cli] Please check the following files for inconsistencies:
[expo-cli]   - /Users/sergio/Developer/MyAppProject/app.json
[expo-cli]   - /Users/sergio/Developer/MyAppProject/ios/Podfile
[expo-cli]   - /Users/sergio/Developer/MyAppProject/ios/Podfile.properties.json
[expo-cli] Learn more: https://expo.fyi/hermes-ios-config
```

After checking the code generating these, it seems that they are checking both the Podfile and `boilerplate/ios/Podfile.properties.json`, as well as `gradle.properties` 

It seems this package is using hermes by default, so I think this would be useful for others.  

_Edit: added full command and trace for reference_
