### PR TITLE
Fix typo (casing issue) inside Getting Started Guide causing a 404 when clicking on the Components link

### DIFF
--- a/docs/Guide.md
+++ b/docs/Guide.md
@@ -57,7 +57,7 @@ Ignite comes with some prebuilt, flexible, and customizable components. Unlike m
 
 Ignite works fine with other component libraries, but the built-in component system works the best for custom-designed apps.
 
-Check out the [Components](./components.md) documentation.
+Check out the [Components](./Components.md) documentation.
 
 ### Testing
 


### PR DESCRIPTION
## Please verify the following:

- [x] `yarn test` **jest** tests pass with new tests, if relevant
- [x] `README.md` has been updated with your changes, if relevant

## Describe your PR

Addressing this, when reading the Getting Started Guide form Github at https://github.com/infinitered/ignite/blob/master/docs/Guide.md

<img width="934" alt="Screenshot 2022-10-22 at 9 44 27 am" src="https://user-images.githubusercontent.com/21725/197300241-b1c6e37a-ed2d-4301-b9ba-dd3d8f942325.png">
