### PR TITLE
fix(generators): added withSetPropAction to model gen

### DIFF
--- a/boilerplate/ignite/templates/model/NAME.ts.ejs
+++ b/boilerplate/ignite/templates/model/NAME.ts.ejs
@@ -13,6 +13,7 @@ patches:
     skip: <%= props.skipIndexFile %>
 ---
 import { Instance, SnapshotIn, SnapshotOut, types } from "mobx-state-tree"
+import { withSetPropAction } from "./helpers/withSetPropAction"
 
 /**
  * Model description here for TypeScript hints.
@@ -20,6 +21,7 @@ import { Instance, SnapshotIn, SnapshotOut, types } from "mobx-state-tree"
 export const <%= props.pascalCaseName %>Model = types
   .model("<%= props.pascalCaseName %>")
   .props({})
+  .actions(withSetPropAction)
   .views((self) => ({})) // eslint-disable-line @typescript-eslint/no-unused-vars
   .actions((self) => ({})) // eslint-disable-line @typescript-eslint/no-unused-vars
 

--- a/test/vanilla/ignite-generate.test.ts
+++ b/test/vanilla/ignite-generate.test.ts
@@ -48,6 +48,7 @@ describe("ignite-cli generate", () => {
       `)
       expect(read(`${TEMP_DIR}/app/models/Pizza.ts`)).toMatchInlineSnapshot(`
         "import { Instance, SnapshotIn, SnapshotOut, types } from \\"mobx-state-tree\\"
+        import { withSetPropAction } from \\"./helpers/withSetPropAction\\"
 
         /**
          * Model description here for TypeScript hints.
@@ -55,6 +56,7 @@ describe("ignite-cli generate", () => {
         export const PizzaModel = types
           .model(\\"Pizza\\")
           .props({})
+          .actions(withSetPropAction)
           .views((self) => ({})) // eslint-disable-line @typescript-eslint/no-unused-vars
           .actions((self) => ({})) // eslint-disable-line @typescript-eslint/no-unused-vars
 
@@ -100,6 +102,7 @@ describe("ignite-cli generate", () => {
       `)
       expect(read(`${TEMP_DIR}/app/models/PizzaStore.ts`)).toMatchInlineSnapshot(`
         "import { Instance, SnapshotIn, SnapshotOut, types } from \\"mobx-state-tree\\"
+        import { withSetPropAction } from \\"./helpers/withSetPropAction\\"
 
         /**
          * Model description here for TypeScript hints.
@@ -107,6 +110,7 @@ describe("ignite-cli generate", () => {
         export const PizzaStoreModel = types
           .model(\\"PizzaStore\\")
           .props({})
+          .actions(withSetPropAction)
           .views((self) => ({})) // eslint-disable-line @typescript-eslint/no-unused-vars
           .actions((self) => ({})) // eslint-disable-line @typescript-eslint/no-unused-vars
 


### PR DESCRIPTION
## Please verify the following:

- [x] `yarn test` **jest** tests pass with new tests, if relevant

## Describe your PR
- Closes #2218
- Enhances model generator to include withSetPropAction helper
- Updated test for model gen

```
import { Instance, SnapshotIn, SnapshotOut, types } from "mobx-state-tree"
import { withSetPropAction } from "./helpers/withSetPropAction"

/**
 * Model description here for TypeScript hints.
 */
export const Test4Model = types
  .model("Test4")
  .props({})
  .actions(withSetPropAction)
  .views((self) => ({})) // eslint-disable-line @typescript-eslint/no-unused-vars
  .actions((self) => ({})) // eslint-disable-line @typescript-eslint/no-unused-vars

export interface Test4 extends Instance<typeof Test4Model> {}
export interface Test4SnapshotOut extends SnapshotOut<typeof Test4Model> {}
export interface Test4SnapshotIn extends SnapshotIn<typeof Test4Model> {}
export const createTest4DefaultModel = () => types.optional(Test4Model, {})
```