### PR TITLE
feat(issue-cmd): added new GH issue command

### DIFF
--- a/README.md
+++ b/README.md
@@ -92,6 +92,8 @@ Note:
 
 If you run into problems, first search the issues and discussions in this repository. If you don't find anything, you can come talk to our friendly and active developers in the Infinite Red Community Slack ([community.infinite.red](http://community.infinite.red)).
 
+If you still need help after reaching out to the proper channels, feel free to open a new GitHub issue via `npx ignite-cli issue "Unable to Ignite new app"` (as an example). This will help start writing your issue with the correct diagnostic information included.
+
 ## No time to learn React Native? Hire Infinite Red for your next project
 
 We get it – sometimes there just isn’t enough time on a project to learn the ins and outs of a new framework. Infinite Red’s here to help! Our experienced team of React Native engineers have worked with companies like GasBuddy, Zoom, and Mercari to bring even some of the most complex projects to life.

--- a/src/commands/issue.ts
+++ b/src/commands/issue.ts
@@ -84,7 +84,7 @@ module.exports = {
     // TODO looked into gh cli but not sure that is worth it either
     try {
       p(cyan("Starting GitHub issue..."))
-      system.run(`${START_CMD} ${url}`)
+      await system.run(`${START_CMD} ${url}`)
 
       p(cyan("Paste the following in the comment body and fill out the description:"))
       p()

--- a/src/commands/issue.ts
+++ b/src/commands/issue.ts
@@ -84,7 +84,7 @@ module.exports = {
 
     try {
       p(cyan("Starting GitHub issue, thanks for alerting us!"))
-      await system.run(`${START_CMD} \"${url}?${params.toString()}\"`)
+      await system.run(`${START_CMD} "${url}?${params.toString()}"`)
     } catch (e) {
       p(yellow("Unable to start GitHub issue."))
     }

--- a/src/commands/issue.ts
+++ b/src/commands/issue.ts
@@ -12,6 +12,7 @@ import {
   prettyPrompt,
   prefix,
 } from "../tools/pretty"
+const stripANSI = require("strip-ansi")
 
 const isMac = process.platform === "darwin"
 
@@ -29,7 +30,7 @@ module.exports = {
       prompt,
     } = toolbox
 
-    const { yellow, cyan, white } = colors
+    const { yellow, cyan } = colors
 
     // title for issue
     let title = parameters.first
@@ -65,14 +66,15 @@ module.exports = {
     try {
       const IGNITE = "node " + filesystem.path(__dirname, "..", "..", "bin", "ignite")
 
-      doctorInfo = await system.run(`${IGNITE} doctor`)
+      const doctorANSI = await system.run(`${IGNITE} doctor`)
+      doctorInfo = stripANSI(doctorANSI)
     } catch (e) {
       p(yellow("Unable to gather system and project details."))
     }
     stopSpinner(" Gathering system and project details", "🛠️")
 
     // open up GitHub issue form
-    const header = `\n### Describe the bug\n\n[Fill out bug description here]\n\n### Additional info\nnpx ignite-cli doctor`
+    const header = `\n### Describe the bug\n\n<!--🚨🚨🚨 Fill out bug description here, please provide reproducible steps, repo/code snippets and any other helpful information if available! 🚨🚨🚨-->\n\n### Additional info\nnpx ignite-cli doctor`
     const body = `${header}\n\n\`\`\`\n${doctorInfo}\`\`\``
 
     const url = new URL("https://github.com/infinitered/ignite/issues/new")

--- a/src/commands/issue.ts
+++ b/src/commands/issue.ts
@@ -1,0 +1,98 @@
+/**
+ * This command runs ignite doctor and launches the user's browser
+ * to a new GitHub issue populated with the provided title and doctor command  output
+ */
+import { GluegunToolbox } from "gluegun"
+import {
+  command,
+  p,
+  warning,
+  startSpinner,
+  stopSpinner,
+  prettyPrompt,
+  prefix,
+} from "../tools/pretty"
+
+const isMac = process.platform === "darwin"
+
+const START_CMD = isMac ? "open" : "start"
+
+module.exports = {
+  alias: ["i"],
+  description: "Opens a new GitHub issue for Ignite.",
+  run: async function (toolbox: GluegunToolbox) {
+    const {
+      filesystem,
+      system,
+      print: { colors },
+      parameters,
+      prompt,
+    } = toolbox
+
+    const { yellow, cyan, white } = colors
+
+    // title for issue
+    let title = parameters.first
+
+    if (!title) {
+      warning(`⚠️  Please specify a title for your issue:`)
+      p()
+      command(`ignite i "The issue title here"`)
+      return
+    }
+
+    // do title quote check
+    if (parameters.array.length > 1 && !parameters.first.startsWith('"')) {
+      const suggestedTitle = parameters.array.join(" ")
+
+      let titleResponse = await prompt.ask<{ title: boolean }>(() => ({
+        type: "confirm",
+        name: "title",
+        message: `Received title "${title}" but without quotes, did you mean "${suggestedTitle}"?`,
+        initial: true,
+        format: prettyPrompt.format.boolean,
+        prefix,
+      }))
+
+      if (titleResponse.title) {
+        title = suggestedTitle
+      }
+    }
+
+    // get the `ignite doctor` output
+    let doctorInfo = ""
+    startSpinner(" Gathering system and project details")
+    try {
+      const IGNITE = "node " + filesystem.path(__dirname, "..", "..", "bin", "ignite")
+
+      doctorInfo = await system.run(`${IGNITE} doctor`)
+    } catch (e) {
+      p(yellow("Unable to gather system and project details."))
+    }
+    stopSpinner(" Gathering system and project details", "🛠️")
+
+    // open up GitHub issue form
+    const header = `\n### Describe the bug\n\n[Fill out bug description here]\n\n### Additional info\nnpx ignite-cli doctor`
+    const body = `${header}\n\n\`\`\`\n${doctorInfo}\`\`\``
+
+    const url = new URL("https://github.com/infinitered/ignite/issues/new")
+    url.searchParams.append("title", title)
+
+    // paste the comment body template for the user (unable to set searchParam `body`
+    // to a multiline value)
+    // TODO we could add clipboard support but Gluegun already removed that
+    // TODO looked into gh cli but not sure that is worth it either
+    try {
+      p(cyan("Starting GitHub issue..."))
+      system.run(`${START_CMD} ${url}`)
+
+      p(cyan("Paste the following in the comment body and fill out the description:"))
+      p()
+      p(white(body))
+    } catch (e) {
+      p(yellow("Unable to start GitHub issue."))
+    }
+
+    process.exit(0)
+  },
+}

--- a/src/commands/issue.ts
+++ b/src/commands/issue.ts
@@ -76,19 +76,13 @@ module.exports = {
     const body = `${header}\n\n\`\`\`\n${doctorInfo}\`\`\``
 
     const url = new URL("https://github.com/infinitered/ignite/issues/new")
-    url.searchParams.append("title", title)
+    const params = new URLSearchParams(url.search)
+    params.append("title", title)
+    params.append("body", body)
 
-    // paste the comment body template for the user (unable to set searchParam `body`
-    // to a multiline value)
-    // TODO we could add clipboard support but Gluegun already removed that
-    // TODO looked into gh cli but not sure that is worth it either
     try {
-      p(cyan("Starting GitHub issue..."))
-      await system.run(`${START_CMD} ${url}`)
-
-      p(cyan("Paste the following in the comment body and fill out the description:"))
-      p()
-      p(white(body))
+      p(cyan("Starting GitHub issue, thanks for alerting us!"))
+      await system.run(`${START_CMD} \"${url}?${params.toString()}\"`)
     } catch (e) {
       p(yellow("Unable to start GitHub issue."))
     }

--- a/src/commands/issue.ts
+++ b/src/commands/issue.ts
@@ -45,7 +45,7 @@ module.exports = {
     if (parameters.array.length > 1 && !parameters.first.startsWith('"')) {
       const suggestedTitle = parameters.array.join(" ")
 
-      let titleResponse = await prompt.ask<{ title: boolean }>(() => ({
+      const titleResponse = await prompt.ask<{ title: boolean }>(() => ({
         type: "confirm",
         name: "title",
         message: `Received title "${title}" but without quotes, did you mean "${suggestedTitle}"?`,


### PR DESCRIPTION
## Describe your PR
- Closes #932 
- Adds new `npx ignite-cli issue "my bug title here"` command
- Opens browser window to `https://github.com/infinitered/ignite/issue/new` with title prefilled and prefilled issue body with `npx ignite doctor` output for issue reporter to easily paste
- Fixes title for user if they forget to double quote the title string

Tested
- [x] MacOS
- [x] Windows

![image](https://user-images.githubusercontent.com/374022/200392934-f9e6bd7d-3cf3-4a71-bd0b-c5f4155951df.png)


![image](https://user-images.githubusercontent.com/374022/200393881-7b7a780f-869c-49d3-84ea-74cb71f17e0e.png)

