### PR TITLE
Fix typo in DemoTextField from "props" to "prop"

### DIFF
--- a/boilerplate/app/screens/DemoShowroomScreen/demos/DemoTextField.tsx
+++ b/boilerplate/app/screens/DemoShowroomScreen/demos/DemoTextField.tsx
@@ -102,7 +102,7 @@ export const DemoTextField: Demo = {
 
       <TextField
         label="RightAccessory"
-        helper="This props takes a function that returns a React element."
+        helper="This prop takes a function that returns a React element."
         value="Reprehenderit Lorem magna non consequat ullamco cupidatat."
         RightAccessory={(props) => <Icon icon="ladybug" containerStyle={props.style} size={21} />}
       />
@@ -111,7 +111,7 @@ export const DemoTextField: Demo = {
 
       <TextField
         label="LeftAccessory"
-        helper="This props takes a function that returns a React element."
+        helper="This prop takes a function that returns a React element."
         value="Eiusmod exercitation mollit elit magna occaecat eiusmod Lorem minim veniam."
         LeftAccessory={(props) => <Icon icon="ladybug" containerStyle={props.style} size={21} />}
       />


### PR DESCRIPTION
## Please verify the following:

- [✅] `yarn test` **jest** tests pass with new tests, if relevant
- [✅] `README.md` has been updated with your changes, if relevant

## Describe your PR
In the DemoShowroomScreen, in the DemoTextField, in the Left and Right Accessory it says "This props". Clearly, it was intended to say "This prop" as it is referring to an individual prop. 