### PR TITLE
fix(boilerplate): podfile lock hermes version mismatch

### DIFF
--- a/boilerplate/ios/Podfile.lock
+++ b/boilerplate/ios/Podfile.lock
@@ -96,7 +96,7 @@ PODS:
     - FlipperKit/FlipperKitNetworkPlugin
   - fmt (6.2.1)
   - glog (0.3.5)
-  - hermes-engine (0.69.6)
+  - hermes-engine (0.69.7)
   - libevent (2.1.12)
   - OpenSSL-Universal (1.1.1100)
   - RCT-Folly (2021.06.28.00-v2):


### PR DESCRIPTION
## Describe your PR
- Closes #2301
- For some reason updating the Podfile.lock missed the `hermes-engine` version, causing pod install issues unless `npx pod-install` was run to fix things

### Concerns

The `new` command hits our `pod install` from `bin/postInstall` first which ends up bombing if things aren't correct. We should do one of the following:

1. Copy the guts of `npx pod-install` into our `postInstall` script to automagically fix things
2. Skip our initial pod install and let `npx pod-install` which we already run during `new` take care of business for igniting new apps (see #2284)
3. Remove `pod install` from `postInstall` in favor of `npx pod-install`