### PR TITLE
Adds a useHeader hook for setting a header in a screen

### DIFF
--- a/boilerplate/app/screens/WelcomeScreen.tsx
+++ b/boilerplate/app/screens/WelcomeScreen.tsx
@@ -1,19 +1,16 @@
 import { observer } from "mobx-react-lite"
-import React, {
-  FC,
-  useLayoutEffect, // @demo remove-current-line
-} from "react"
+import React, { FC } from "react"
 import { Image, ImageStyle, TextStyle, View, ViewStyle } from "react-native"
 import { SafeAreaView } from "react-native-safe-area-context"
 import {
   Button, // @demo remove-current-line
-  Header, // @demo remove-current-line
   Text,
 } from "../components"
 import { isRTL } from "../i18n"
 import { useStores } from "../models" // @demo remove-current-line
 import { AppStackScreenProps } from "../navigators" // @demo remove-current-line
 import { colors, spacing } from "../theme"
+import { useHeader } from "../utils/useHeader"
 
 const welcomeLogo = require("../../assets/images/logo.png")
 const welcomeFace = require("../../assets/images/welcome-face.png")
@@ -33,12 +30,10 @@ export const WelcomeScreen: FC<WelcomeScreenProps> = observer(function WelcomeSc
     navigation.navigate("Demo", { screen: "DemoShowroom" })
   }
 
-  useLayoutEffect(() => {
-    navigation.setOptions({
-      headerShown: true,
-      header: () => <Header rightTx="common.logOut" onRightPress={logout} />,
-    })
-  }, [])
+  useHeader({
+    rightTx: "common.logOut",
+    onRightPress: logout,
+  })
   // @demo remove-block-end
 
   return (

--- a/boilerplate/app/utils/useHeader.tsx
+++ b/boilerplate/app/utils/useHeader.tsx
@@ -1,0 +1,18 @@
+import React from "react"
+import { useNavigation } from "@react-navigation/native"
+import { useLayoutEffect } from "react"
+import { Header, HeaderProps } from "../components"
+
+/**
+ * A hook to set the header for a screen.
+ */
+export function useHeader(headerProps: HeaderProps, deps: any[] = []) {
+  const navigation = useNavigation()
+
+  useLayoutEffect(() => {
+    navigation.setOptions({
+      headerShown: true,
+      header: () => <Header {...headerProps} />,
+    })
+  }, deps)
+}


### PR DESCRIPTION
In #2300, there was a discussion about the best way to use the `Header` component. @yulolimum's suggestion was to use the `navigation.setOptions` feature to set your header since that gives you maximum control over the header. This adds a convenience hook to make that a little easier and more understandable.

(If we decide this doesn't belong in Ignite, that's okay -- we can add it to the [Ignite Cookbook](https://infinitered.github.io/ignite-cookbook/).)