### PR TITLE
fix(cli): move rename before install deps

### DIFF
--- a/src/commands/new.ts
+++ b/src/commands/new.ts
@@ -481,18 +481,6 @@ export default {
       stopSpinner(msg, "📦")
     }
 
-    const shouldFreshInstallDeps = installDeps && shouldUseCache === false
-    if (shouldFreshInstallDeps) {
-      const unboxingMessage = `Installing ${packagerName} dependencies (wow these are heavy)`
-      startSpinner(unboxingMessage)
-      await packager.install({ ...packagerOptions, onProgress: log })
-      stopSpinner(unboxingMessage, "🧶")
-    }
-
-    // remove the gitignore template
-    await removeAsync(".gitignore.template")
-    // #endregion
-
     // #region Rename App
     // rename the app using Ignite
     const renameSpinnerMsg = `Getting those last few details perfect`
@@ -507,6 +495,18 @@ export default {
     )
 
     stopSpinner(renameSpinnerMsg, "🎨")
+    // #endregion
+
+    const shouldFreshInstallDeps = installDeps && shouldUseCache === false
+    if (shouldFreshInstallDeps) {
+      const unboxingMessage = `Installing ${packagerName} dependencies (wow these are heavy)`
+      startSpinner(unboxingMessage)
+      await packager.install({ ...packagerOptions, onProgress: log })
+      stopSpinner(unboxingMessage, "🧶")
+    }
+
+    // remove the gitignore template
+    await removeAsync(".gitignore.template")
     // #endregion
 
     // #region Cache dependencies


### PR DESCRIPTION
## Please verify the following:

- [x] `yarn test` **jest** tests pass with new tests, if relevant

## Describe your PR
- Moves renaming of the react-native application to before dependencies are installed
- A bug was masked with `npx pod-install` being run after the rename that helped fix things, so now that we moved it to postInstall, rename must occur first
- This is only relevant to `yarn ios`
