### PR TITLE
fix(demo): fixed stuck drawer icon when releasing drag near 50%

### DIFF
--- a/boilerplate/app/screens/DemoShowroomScreen/DemoShowroomScreen.tsx
+++ b/boilerplate/app/screens/DemoShowroomScreen/DemoShowroomScreen.tsx
@@ -1,7 +1,7 @@
 import React, { FC, ReactElement, useEffect, useRef, useState } from "react"
 import { FlatList, Image, ImageStyle, SectionList, TextStyle, View, ViewStyle } from "react-native"
 import { DrawerLayout, DrawerState } from "react-native-gesture-handler"
-import { useSharedValue } from "react-native-reanimated"
+import { useSharedValue, withTiming } from "react-native-reanimated"
 import { ListItem, Screen, Text } from "../../components"
 import { isRTL } from "../../i18n"
 import { DemoTabScreenProps } from "../../navigators/DemoNavigator"
@@ -82,6 +82,9 @@ export const DemoShowroomScreen: FC<DemoTabScreenProps<"DemoShowroom">> =
         }}
         onDrawerStateChanged={(newState: DrawerState, drawerWillShow: boolean) => {
           if (newState === "Settling") {
+            progress.value = withTiming(drawerWillShow ? 1 : 0, {
+              duration: 250,
+            })
             setOpen(drawerWillShow)
           }
         }}


### PR DESCRIPTION
## Please verify the following:

- [x] `yarn test` **jest** tests pass with new tests, if relevant

## Describe your PR
- Closes #2274 
- Fixes an issue where if the user was dragging the drawer open and let's go without meeting the threshold, the icon could get stuck in a mid animation state
- The same could occur when fully open and beginning to drag it closed but release early where it would remain open

## Videos
| Before | After |
| ------- | ------- |
| <img width="300" src="https://user-images.githubusercontent.com/374022/202740411-721d77b1-8b62-422e-96fa-a73ef4fc4654.gif" /> | <img width="300" src="https://user-images.githubusercontent.com/374022/202740630-e7c2a75e-03ab-4db7-9305-4cf796052fdd.gif" /> |



