### PR TITLE
fix: list item component to take children and add const assertion to colors

### DIFF
--- a/boilerplate/app/components/ListItem.tsx
+++ b/boilerplate/app/components/ListItem.tsx
@@ -144,9 +144,13 @@ export function ListItem(props: ListItemProps) {
           Component={LeftComponent}
         />
 
-        <Text {...TextProps} tx={tx} text={text} txOptions={txOptions} style={$textStyles}>
-          {children}
-        </Text>
+        {!!text || !!tx || typeof children === "string" ? (
+          <Text {...TextProps} tx={tx} text={text} txOptions={txOptions} style={$textStyles}>
+            {children}
+          </Text>
+        ) : (
+          children
+        )}
 
         <ListItemAction
           side="right"

--- a/boilerplate/app/theme/colors.ts
+++ b/boilerplate/app/theme/colors.ts
@@ -35,7 +35,7 @@ const palette = {
 
   overlay20: "rgba(25, 16, 21, 0.2)",
   overlay50: "rgba(25, 16, 21, 0.5)",
-}
+} as const
 
 export const colors = {
   /**


### PR DESCRIPTION
## Describe your PR

- Adds const assertions to the color palette for better types.

<img width="350" alt="CleanShot 2022-12-12 at 11 32 39@2x" src="https://user-images.githubusercontent.com/53795920/207140403-ec9b7e54-2827-43fc-95fe-83d8a591b81c.png">

- When one of our clients was trying to add a nested view to the `ListItem` component, they had issues since the ListItem component was wrapping the children with the Text component with default styling which was messing up the alignment of the list. This PR gives the component more flexibility when it needs to take children without tx or text. Recreated the issue below and shows after the fix: 

|Case A|Case B|Fix|
|-|-|-|
|<img width="350" alt="CleanShot 2022-12-12 at 10 57 22@2x" src="https://user-images.githubusercontent.com/53795920/207141678-e3162022-e04e-4575-9286-9818ab117c8f.png">|<img width="349" alt="CleanShot 2022-12-12 at 10 57 48@2x" src="https://user-images.githubusercontent.com/53795920/207141703-4ece77a5-e9cb-4062-92d9-380069e0dce8.png">|<img width="348" alt="CleanShot 2022-12-12 at 10 54 31@2x" src="https://user-images.githubusercontent.com/53795920/207142207-ce939222-7c76-4e1d-86f9-79b660108dd6.png">|

