### PR TITLE
fix(boilerplate): updated web drawer layout width

### DIFF
--- a/boilerplate/app/screens/DemoShowroomScreen/DemoShowroomScreen.tsx
+++ b/boilerplate/app/screens/DemoShowroomScreen/DemoShowroomScreen.tsx
@@ -162,7 +162,7 @@ export const DemoShowroomScreen: FC<DemoTabScreenProps<"DemoShowroom">> =
     return (
       <DrawerLayout
         ref={drawerRef}
-        drawerWidth={Platform.select({ default: 326, web: Dimensions.get("screen").width * 0.3 })}
+        drawerWidth={Platform.select({ default: 326, web: Dimensions.get("width").width * 0.3 })}
         drawerType={"slide"}
         drawerPosition={isRTL ? "right" : "left"}
         drawerBackgroundColor={colors.palette.neutral100}

--- a/boilerplate/app/screens/DemoShowroomScreen/DemoShowroomScreen.tsx
+++ b/boilerplate/app/screens/DemoShowroomScreen/DemoShowroomScreen.tsx
@@ -162,7 +162,7 @@ export const DemoShowroomScreen: FC<DemoTabScreenProps<"DemoShowroom">> =
     return (
       <DrawerLayout
         ref={drawerRef}
-        drawerWidth={Platform.select({ default: 326, web: Dimensions.get("width").width * 0.3 })}
+        drawerWidth={Platform.select({ default: 326, web: Dimensions.get("window").width * 0.3 })}
         drawerType={"slide"}
         drawerPosition={isRTL ? "right" : "left"}
         drawerBackgroundColor={colors.palette.neutral100}


### PR DESCRIPTION
## Please verify the following:

- [x] `yarn test` **jest** tests pass with new tests, if relevant

## Describe your PR
- On super large displays, the DrawerLayout for web was still covering most of the entire window provided you weren't working with a maximized window. It now is 1/3 of the screen like a normal nav area on web

## Graphics
### Before
![image](https://user-images.githubusercontent.com/374022/207926523-9e258b9a-8815-4df9-b4db-55d767f3fe84.png)

### After
![image](https://user-images.githubusercontent.com/374022/207926442-03340b81-e34b-43b0-8b02-af095ef60c76.png)
