### PR TITLE
fix: adds accessibility label for ios to match android

### DIFF
--- a/boilerplate/app/screens/DemoPodcastListScreen.tsx
+++ b/boilerplate/app/screens/DemoPodcastListScreen.tsx
@@ -177,6 +177,7 @@ const EpisodeCard = observer(function EpisodeCard({
     () =>
       Platform.select<AccessibilityProps>({
         ios: {
+          accessibilityLabel: episode.title,
           accessibilityHint: translate("demoPodcastListScreen.accessibility.cardHint", {
             action: isFavorite ? "unfavorite" : "favorite",
           }),


### PR DESCRIPTION
## Describe your PR

While writing up a recipe for adding Maestro to an Ignite app, I noticed that we added an accessibility label to the android Podcast Card but not for iOS. This is helpful for running e2e tests.