### PR TITLE
fix: sync with latest expo

### DIFF
--- a/boilerplate/ios/HelloWorld/AppDelegate.mm
+++ b/boilerplate/ios/HelloWorld/AppDelegate.mm
@@ -45,7 +45,7 @@ static NSString *const kRNConcurrentRoot = @"concurrentRoot";
 #endif
 
   NSDictionary *initProps = [self prepareInitialProps];
-  UIView *rootView = RCTAppSetupDefaultRootView(bridge, @"HelloWorld", initProps);
+  UIView *rootView = [self.reactDelegate createRootViewWithBridge:bridge moduleName:@"main" initialProperties:nil];
 
   if (@available(iOS 13.0, *)) {
     rootView.backgroundColor = [UIColor systemBackgroundColor];


### PR DESCRIPTION
When trying to build and run a dev-client with latest Ignite, the dev-client crashed.
`EXDevLauncher/ExpoDevLauncherReactDelegateHandler.swift:91: Fatal error: Unexpectedly found nil while unwrapping an Optional value`

Looking at Expo doc's seems like AppDelegate now needs te be different. Tested it, and works no with latest dev-client 

https://github.com/expo/expo/blob/sdk-47/templates/expo-template-bare-minimum/ios/HelloWorld/AppDelegate.mm#L49
