### PR TITLE
Fixed a cast of arguments passed to `navigate`

### DIFF
--- a/boilerplate/app/navigators/navigationUtilities.ts
+++ b/boilerplate/app/navigators/navigationUtilities.ts
@@ -153,7 +153,7 @@ export function useNavigationPersistence(storage: any, persistenceKey: string) {
  */
 export function navigate(name: any, params?: any) {
   if (navigationRef.isReady()) {
-    navigationRef.navigate(...([name, params] as never))
+    ;(navigationRef.navigate as any)(name, params)
   }
 }
 

--- a/boilerplate/app/navigators/navigationUtilities.ts
+++ b/boilerplate/app/navigators/navigationUtilities.ts
@@ -153,7 +153,7 @@ export function useNavigationPersistence(storage: any, persistenceKey: string) {
  */
 export function navigate(name: any, params?: any) {
   if (navigationRef.isReady()) {
-    navigationRef.navigate(name as never, params as never)
+    navigationRef.navigate(...[name, params] as never)
   }
 }
 

--- a/boilerplate/app/navigators/navigationUtilities.ts
+++ b/boilerplate/app/navigators/navigationUtilities.ts
@@ -153,7 +153,7 @@ export function useNavigationPersistence(storage: any, persistenceKey: string) {
  */
 export function navigate(name: any, params?: any) {
   if (navigationRef.isReady()) {
-    navigationRef.navigate(...[name, params] as never)
+    navigationRef.navigate(...([name, params] as never))
   }
 }
 


### PR DESCRIPTION
The previous version was detected as invalid with a nightly version of TS (5.1), you can see the reported error [here](https://github.com/microsoft/TypeScript/issues/53122#issuecomment-1457229048)