### PR TITLE
Fix `yarn expo:web`

### DIFF
--- a/boilerplate/babel.config.js
+++ b/boilerplate/babel.config.js
@@ -6,6 +6,7 @@ const plugins = [
     },
   ],
   ["@babel/plugin-proposal-optional-catch-binding"],
+  "@babel/plugin-proposal-export-namespace-from",
   "react-native-reanimated/plugin", // NOTE: this must be last in the plugins
 ]
 

--- a/boilerplate/ios/Podfile.lock
+++ b/boilerplate/ios/Podfile.lock
@@ -8,19 +8,17 @@ PODS:
     - ExpoModulesCore
   - EXDevice (5.0.0):
     - ExpoModulesCore
-  - EXErrorRecovery (4.0.1):
-    - ExpoModulesCore
   - EXFileSystem (15.1.1):
     - ExpoModulesCore
   - EXFont (11.0.1):
     - ExpoModulesCore
-  - Expo (47.0.10):
+  - Expo (47.0.13):
     - ExpoModulesCore
   - ExpoKeepAwake (11.0.1):
     - ExpoModulesCore
   - ExpoLocalization (14.0.0):
     - ExpoModulesCore
-  - ExpoModulesCore (1.1.0):
+  - ExpoModulesCore (1.1.1):
     - React-Core
     - ReactCommon/turbomodule/core
   - EXSplashScreen (0.17.5):
@@ -445,7 +443,6 @@ DEPENDENCIES:
   - EXApplication (from `../node_modules/expo-application/ios`)
   - EXConstants (from `../node_modules/expo-constants/ios`)
   - EXDevice (from `../node_modules/expo-device/ios`)
-  - EXErrorRecovery (from `../node_modules/expo-error-recovery/ios`)
   - EXFileSystem (from `../node_modules/expo-file-system/ios`)
   - EXFont (from `../node_modules/expo-font/ios`)
   - Expo (from `../node_modules/expo`)
@@ -546,8 +543,6 @@ EXTERNAL SOURCES:
     :path: "../node_modules/expo-constants/ios"
   EXDevice:
     :path: "../node_modules/expo-device/ios"
-  EXErrorRecovery:
-    :path: "../node_modules/expo-error-recovery/ios"
   EXFileSystem:
     :path: "../node_modules/expo-file-system/ios"
   EXFont:
@@ -646,13 +641,12 @@ SPEC CHECKSUMS:
   EXApplication: 034b1c40a8e9fe1bff76a1e511ee90dff64ad834
   EXConstants: 3c86653c422dd77e40d10cbbabb3025003977415
   EXDevice: 734a55d8935ea8e075d12df1919a0497153bf55c
-  EXErrorRecovery: ae43433feb0608a64dc5b1c8363b3e7769a9ea24
   EXFileSystem: 60602b6eefa6873f97172c684b7537c9760b50d6
   EXFont: 319606bfe48c33b5b5063fb0994afdc496befe80
-  Expo: a694d89d2461fdfc6b977bf489bf7d341ed03bca
+  Expo: b9fa98bf260992312ee3c424400819fb9beadafe
   ExpoKeepAwake: 69b59d0a8d2b24de9f82759c39b3821fec030318
   ExpoLocalization: e202d1e2a4950df17ac8d0889d65a1ffd7532d7e
-  ExpoModulesCore: 089e1ac0f0edee4dd0af0eb4e3f7b44d72cc418d
+  ExpoModulesCore: 485dff3a59b036a33b6050c0a5aea3cf1037fdd1
   EXSplashScreen: 3e989924f61a8dd07ee4ea584c6ba14be9b51949
   FBLazyVector: affa4ba1bfdaac110a789192f4d452b053a86624
   FBReactNativeSpec: fe8b5f1429cfe83a8d72dc8ed61dc7704cac8745
@@ -707,6 +701,6 @@ SPEC CHECKSUMS:
   Yoga: eca980a5771bf114c41a754098cd85e6e0d90ed7
   YogaKit: f782866e155069a2cca2517aafea43200b01fd5a
 
-PODFILE CHECKSUM: e994cb819092b90855028e70a600ecb8fc2a4751
+PODFILE CHECKSUM: 0aec3bd15c966160277b868456011f7fa83c13bb
 
-COCOAPODS: 1.11.3
+COCOAPODS: 1.12.0

--- a/boilerplate/package.json
+++ b/boilerplate/package.json
@@ -37,7 +37,7 @@
   },
   "dependencies": {
     "@expo-google-fonts/space-grotesk": "^0.2.2",
-    "@expo/webpack-config": "^0.17.2",
+    "@expo/webpack-config": "^0.17.4",
     "@react-native-async-storage/async-storage": "~1.17.3",
     "@react-navigation/bottom-tabs": "^6.3.2",
     "@react-navigation/native": "~6.0.1",
@@ -74,6 +74,7 @@
   "devDependencies": {
     "@babel/core": "^7.19.3",
     "@babel/plugin-proposal-decorators": "7.18.2",
+    "@babel/plugin-proposal-export-namespace-from": "^7.18.9",
     "@babel/plugin-proposal-optional-catch-binding": "7.16.7",
     "@babel/preset-env": "^7.16.11",
     "@babel/runtime": "^7.18.3",


### PR DESCRIPTION
## Please verify the following:

- [x] `yarn test` **jest** tests pass with new tests, if relevant
- [x] `README.md` has been updated with your changes, if relevant

## Describe your PR

Running `yarn expo:web` was causing the following fatal error in the browser. This PR adds a babel plugin to handle the reanimated on web.

```
log.js:24 [HMR] Waiting for update signal from WDS...
utils.ts:24 Uncaught Error: Module build failed (from ./node_modules/@expo/webpack-config/node_modules/babel-loader/lib/index.js):
SyntaxError: /Users/joshuayoes/Code/ignite/boilerplate/node_modules/react-native-reanimated/lib/index.web.js: Export namespace should be first transformed by `@babel/plugin-proposal-export-namespace-from`.
[0m [90m 4 |[39m [36mexport[39m [33m*[39m [36mfrom[39m [32m'./reanimated1'[39m[33m;[39m[0m
[0m [90m 5 |[39m [36mexport[39m [33m*[39m [36mfrom[39m [32m'./reanimated2'[39m[33m;[39m[0m
[0m[31m[1m>[22m[39m[90m 6 |[39m [36mexport[39m [33m*[39m [36mas[39m [36mdefault[39m [36mfrom[39m [32m'./Animated'[39m[33m;[39m [90m// If this line fails, you probably forgot some installation steps. Check out the installation guide here: https://docs.swmansion.com/react-native-reanimated/docs/fundamentals/installation/ 1) Make sure reanimated's babel plugin is installed in your babel.config.js (you should have 'react-native-reanimated/plugin' listed there - also see the above link for details) 2) Make sure you reset build cache after updating the config, run: yarn start --reset-cache[39m[0m
[0m [90m   |[39m        [31m[1m^[22m[39m[31m[1m^[22m[39m[31m[1m^[22m[39m[31m[1m^[22m[39m[31m[1m^[22m[39m[31m[1m^[22m[39m[31m[1m^[22m[39m[31m[1m^[22m[39m[31m[1m^[22m[39m[31m[1m^[22m[39m[31m[1m^[22m[39m[31m[1m^[22m[39m[0m
[0m [90m 7 |[39m[0m
    at File.buildCodeFrameError (:19006/Users/joshuayoes/Code/ignite/boilerplate/node_modules/@expo/webpack-config/node_modules/@babel/core/lib/transformation/file/file.js:248:12)
    at NodePath.buildCodeFrameError (:19006/Users/joshuayoes/Code/ignite/boilerplate/node_modules/@babel/traverse/lib/path/index.js:106:21)
    at assertExportSpecifier (:19006/Users/joshuayoes/Code/ignite/boilerplate/node_modules/@babel/helper-module-transforms/lib/normalize-and-load-metadata.js:96:16)
    at :19006/Users/joshuayoes/Code/ignite/boilerplate/node_modules/@babel/helper-module-transforms/lib/normalize-and-load-metadata.js:179:9
    at Array.forEach (<anonymous>)
    at :19006/Users/joshuayoes/Code/ignite/boilerplate/node_modules/@babel/helper-module-transforms/lib/normalize-and-load-metadata.js:178:31
    at Array.forEach (<anonymous>)
    at getModuleMetadata (:19006/Users/joshuayoes/Code/ignite/boilerplate/node_modules/@babel/helper-module-transforms/lib/normalize-and-load-metadata.js:129:27)
    at normalizeModuleAndLoadMetadata (:19006/Users/joshuayoes/Code/ignite/boilerplate/node_modules/@babel/helper-module-transforms/lib/normalize-and-load-metadata.js:49:7)
    at rewriteModuleStatementsAndPrepareHeader (:19006/Users/joshuayoes/Code/ignite/boilerplate/node_modules/@babel/helper-module-transforms/lib/index.js:88:54)
    at PluginPass.exit (:19006/Users/joshuayoes/Code/ignite/boilerplate/node_modules/@babel/plugin-transform-modules-commonjs/lib/index.js:159:83)
    at newFn (:19006/Users/joshuayoes/Code/ignite/boilerplate/node_modules/@babel/traverse/lib/visitors.js:159:21)
    at NodePath._call (:19006/Users/joshuayoes/Code/ignite/boilerplate/node_modules/@babel/traverse/lib/path/context.js:46:20)
    at NodePath.call (:19006/Users/joshuayoes/Code/ignite/boilerplate/node_modules/@babel/traverse/lib/path/context.js:36:17)
    at NodePath.visit (:19006/Users/joshuayoes/Code/ignite/boilerplate/node_modules/@babel/traverse/lib/path/context.js:92:8)
    at TraversalContext.visitQueue (:19006/Users/joshuayoes/Code/ignite/boilerplate/node_modules/@babel/traverse/lib/context.js:96:16)
    at TraversalContext.visitSingle (:19006/Users/joshuayoes/Code/ignite/boilerplate/node_modules/@babel/traverse/lib/context.js:72:19)
    at TraversalContext.visit (:19006/Users/joshuayoes/Code/ignite/boilerplate/node_modules/@babel/traverse/lib/context.js:121:19)
    at traverseNode (:19006/Users/joshuayoes/Code/ignite/boilerplate/node_modules/@babel/traverse/lib/traverse-node.js:18:17)
    at traverse (:19006/Users/joshuayoes/Code/ignite/boilerplate/node_modules/@babel/traverse/lib/index.js:50:34)
    at transformFile (:19006/Users/joshuayoes/Code/ignite/boilerplate/node_modules/@expo/webpack-config/node_modules/@babel/core/lib/transformation/index.js:107:29)
    at transformFile.next (<anonymous>)
    at run (:19006/Users/joshuayoes/Code/ignite/boilerplate/node_modules/@expo/webpack-config/node_modules/@babel/core/lib/transformation/index.js:35:12)
    at run.next (<anonymous>)
    at Function.transform (:19006/Users/joshuayoes/Code/ignite/boilerplate/node_modules/@expo/webpack-config/node_modules/@babel/core/lib/transform.js:27:41)
    at transform.next (<anonymous>)
    at step (:19006/Users/joshuayoes/Code/ignite/boilerplate/node_modules/gensync/index.js:261:32)
    at :19006/Users/joshuayoes/Code/ignite/boilerplate/node_modules/gensync/index.js:273:13
    at async.call.result.err.err (:19006/Users/joshuayoes/Code/ignite/boilerplate/node_modules/gensync/index.js:223:11)
    at ./node_modules/react-native-reanimated/lib/index.web.js (utils.ts:24:1)
    at __webpack_require__ (bootstrap:789:1)
    at fn (bootstrap:100:1)
    at ./app/components/Toggle.tsx (Toggle.tsx:15:1)
    at __webpack_require__ (bootstrap:789:1)
    at fn (bootstrap:100:1)
    at ./app/components/index.ts (index.ts:10:1)
    at __webpack_require__ (bootstrap:789:1)
    at fn (bootstrap:100:1)
    at ./app/screens/WelcomeScreen.tsx (WelcomeScreen.tsx:4:1)
    at __webpack_require__ (bootstrap:789:1)
    at fn (bootstrap:100:1)
    at ./app/screens/index.ts (index.ts:1:1)
    at __webpack_require__ (bootstrap:789:1)
    at fn (bootstrap:100:1)
    at ./app/navigators/AppNavigator.tsx (AppNavigator.tsx:20:1)
    at __webpack_require__ (bootstrap:789:1)
    at fn (bootstrap:100:1)
    at ./app/navigators/index.ts (index.ts:1:1)
    at __webpack_require__ (bootstrap:789:1)
    at fn (bootstrap:100:1)
    at ./app/app.tsx (app.tsx:19:1)
    at __webpack_require__ (bootstrap:789:1)
    at fn (bootstrap:100:1)
    at ./App.js (App.js:3:1)
    at __webpack_require__ (bootstrap:789:1)
    at fn (bootstrap:100:1)
    at ./node_modules/expo/AppEntry.js (AppEntry.js:3:1)
    at __webpack_require__ (bootstrap:789:1)
    at fn (bootstrap:100:1)
    at 1 (log.js:59:1)
    at __webpack_require__ (bootstrap:789:1)
    at bootstrap:856:1
    at bootstrap:856:1
VM11:2 Uncaught ReferenceError: process is not defined
    at 4043 (<anonymous>:2:13168)
    at r (<anonymous>:2:306599)
    at 8048 (<anonymous>:2:9496)
    at r (<anonymous>:2:306599)
    at 8641 (<anonymous>:2:1379)
    at r (<anonymous>:2:306599)
    at <anonymous>:2:315627
    at <anonymous>:2:324225
    at <anonymous>:2:324229
    at e.onload (index.js:1:1)
index.js:1 ./node_modules/react-native-reanimated/lib/index.web.js
SyntaxError: /Users/joshuayoes/Code/ignite/boilerplate/node_modules/react-native-reanimated/lib/index.web.js: Export namespace should be first transformed by `@babel/plugin-proposal-export-namespace-from`.
  4 | export * from './reanimated1';
  5 | export * from './reanimated2';
> 6 | export * as default from './Animated'; // If this line fails, you probably forgot some installation steps. Check out the installation guide here: https://docs.swmansion.com/react-native-reanimated/docs/fundamentals/installation/ 1) Make sure reanimated's babel plugin is installed in your babel.config.js (you should have 'react-native-reanimated/plugin' listed there - also see the above link for details) 2) Make sure you reset build cache after updating the config, run: yarn start --reset-cache
    |        ^^^^^^^^^^^^
  7 |
    at Array.forEach (<anonymous>)
    at Array.forEach (<anonymous>)
    at transformFile.next (<anonymous>)
    at run.next (<anonymous>)
    at transform.next (<anonymous>)
console.<computed> @ index.js:1
webpackHotDevClient.js:76 The development server has disconnected.
Refresh the page if necessary.
```

<img width="1703" alt="Screenshot 2023-03-21 at 12 09 16 PM" src="https://user-images.githubusercontent.com/37849890/226720235-8ab6f789-6e99-4dbe-9f5b-853dabfd5b33.png">
