### PR TITLE
feat(generators): enhanced screen gen

### DIFF
--- a/boilerplate/app/navigators/AppNavigator.tsx
+++ b/boilerplate/app/navigators/AppNavigator.tsx
@@ -15,12 +15,9 @@ import { StackScreenProps } from "@react-navigation/stack"
 import { observer } from "mobx-react-lite"
 import React from "react"
 import { useColorScheme } from "react-native"
+import * as Screens from "app/screens"
 import Config from "../config"
 import { useStores } from "../models" // @demo remove-current-line
-import {
-  LoginScreen, // @demo remove-current-line
-  WelcomeScreen,
-} from "../screens"
 import { DemoNavigator, DemoTabParamList } from "./DemoNavigator" // @demo remove-current-line
 import { navigationRef, useBackButtonHandler } from "./navigationUtilities"
 
@@ -42,6 +39,7 @@ export type AppStackParamList = {
   Login: undefined // @demo remove-current-line
   Demo: NavigatorScreenParams<DemoTabParamList> // @demo remove-current-line
   // 🔥 Your screens go here
+  // IGNITE_GENERATOR_ANCHOR_APP_STACK_PARAM_LIST
 }
 
 /**
@@ -74,17 +72,18 @@ const AppStack = observer(function AppStack() {
       {isAuthenticated ? (
         <>
           {/* @demo remove-block-end */}
-          <Stack.Screen name="Welcome" component={WelcomeScreen} />
+          <Stack.Screen name="Welcome" component={Screens.WelcomeScreen} />
           {/* @demo remove-block-start */}
           <Stack.Screen name="Demo" component={DemoNavigator} />
         </>
       ) : (
         <>
-          <Stack.Screen name="Login" component={LoginScreen} />
+          <Stack.Screen name="Login" component={Screens.LoginScreen} />
         </>
       )}
       {/* @demo remove-block-end */}
       {/** 🔥 Your screens go here */}
+      {/* IGNITE_GENERATOR_ANCHOR_APP_STACK_SCREENS */}
     </Stack.Navigator>
   )
 })

--- a/boilerplate/app/navigators/DemoNavigator.tsx
+++ b/boilerplate/app/navigators/DemoNavigator.tsx
@@ -61,7 +61,7 @@ export function DemoNavigator() {
         options={{
           tabBarLabel: translate("demoNavigator.communityTab"),
           tabBarIcon: ({ focused }) => (
-            <Icon icon="components" color={focused && colors.tint} size={30} />
+            <Icon icon="community" color={focused && colors.tint} size={30} />
           ),
         }}
       />
@@ -72,7 +72,7 @@ export function DemoNavigator() {
         options={{
           tabBarLabel: translate("demoNavigator.podcastListTab"),
           tabBarIcon: ({ focused }) => (
-            <Icon icon="components" color={focused && colors.tint} size={30} />
+            <Icon icon="podcast" color={focused && colors.tint} size={30} />
           ),
         }}
       />
@@ -83,7 +83,7 @@ export function DemoNavigator() {
         options={{
           tabBarLabel: translate("demoNavigator.debugTab"),
           tabBarIcon: ({ focused }) => (
-            <Icon icon="components" color={focused && colors.tint} size={30} />
+            <Icon icon="debug" color={focused && colors.tint} size={30} />
           ),
         }}
       />

--- a/boilerplate/ignite/templates/screen/NAMEScreen.tsx.ejs
+++ b/boilerplate/ignite/templates/screen/NAMEScreen.tsx.ejs
@@ -1,28 +1,26 @@
 ---
-patch:
-  path: "app/screens/index.ts"
+patches:
+- path: "app/screens/index.ts"
   append: "export * from \"./<%= props.pascalCaseName %>Screen\"\n"
+  skip: <%= props.skipIndexFile %>
+- path: "app/navigators/AppNavigator.tsx"
+  replace: "// IGNITE_GENERATOR_ANCHOR_APP_STACK_PARAM_LIST"
+  insert: "<%= props.pascalCaseName %>: undefined\n\t// IGNITE_GENERATOR_ANCHOR_APP_STACK_PARAM_LIST"
+- path: "app/navigators/AppNavigator.tsx"
+  replace: "{/* IGNITE_GENERATOR_ANCHOR_APP_STACK_SCREENS */}"
+  insert: "<Stack.Screen name=\"<%= props.pascalCaseName %>\" component={Screens.<%= props.pascalCaseName %>Screen} />\n\t\t\t{/* IGNITE_GENERATOR_ANCHOR_APP_STACK_SCREENS */}"
   skip: <%= props.skipIndexFile %>
 ---
 import React, { FC } from "react"
 import { observer } from "mobx-react-lite"
 import { ViewStyle } from "react-native"
-import { StackScreenProps } from "@react-navigation/stack"
+import { NativeStackScreenProps } from "@react-navigation/native-stack"
 import { AppStackScreenProps } from "app/navigators"
 import { Screen, Text } from "app/components"
 // import { useNavigation } from "@react-navigation/native"
 // import { useStores } from "app/models"
 
-// STOP! READ ME FIRST!
-// To fix the TS error below, you'll need to add the following things in your navigation config:
-// - Add `<%= props.pascalCaseName %>: undefined` to AppStackParamList
-// - Import your screen, and add it to the stack:
-//     `<Stack.Screen name="<%= props.pascalCaseName %>" component={<%= props.pascalCaseName%>Screen} />`
-// Hint: Look for the 🔥!
-
-// REMOVE ME! ⬇️ This TS ignore will not be necessary after you've added the correct navigator param type
-// @ts-ignore
-export const <%= props.pascalCaseName %>Screen: FC<StackScreenProps<AppStackScreenProps, "<%= props.pascalCaseName %>">> = observer(function <%= props.pascalCaseName %>Screen() {
+export const <%= props.pascalCaseName %>Screen: FC<NativeStackScreenProps<AppStackScreenProps<"<%= props.pascalCaseName %>">>> = observer(function <%= props.pascalCaseName %>Screen() {
   // Pull in one of our MST stores
   // const { someStore, anotherStore } = useStores()
 

--- a/boilerplate/ignite/templates/screen/NAMEScreen.tsx.ejs
+++ b/boilerplate/ignite/templates/screen/NAMEScreen.tsx.ejs
@@ -20,7 +20,9 @@ import { Screen, Text } from "app/components"
 // import { useNavigation } from "@react-navigation/native"
 // import { useStores } from "app/models"
 
-export const <%= props.pascalCaseName %>Screen: FC<NativeStackScreenProps<AppStackScreenProps<"<%= props.pascalCaseName %>">>> = observer(function <%= props.pascalCaseName %>Screen() {
+interface <%= props.pascalCaseName %>ScreenProps extends NativeStackScreenProps<AppStackScreenProps<"<%= props.pascalCaseName %>">> {}
+
+export const <%= props.pascalCaseName %>Screen: FC<<%= props.pascalCaseName %>ScreenProps> = observer(function <%= props.pascalCaseName %>Screen() {
   // Pull in one of our MST stores
   // const { someStore, anotherStore } = useStores()
 

--- a/test/vanilla/ignite-new.test.ts
+++ b/test/vanilla/ignite-new.test.ts
@@ -334,7 +334,7 @@ describe("ignite new", () => {
       await run(`npm run test`, runOpts)
       await run(`npm run lint`, runOpts)
       await run(`npm run compile`, runOpts)
-      expect(await run("git diff HEAD", runOpts)).toEqual("")
+      expect(await run("git diff HEAD", runOpts)).toContain("+  Bowser: undefined")
       // #endregion
 
       // we're done!


### PR DESCRIPTION
## Please verify the following:

- [x] `yarn test` **jest** tests pass with new tests, if relevant
- [x] `README.md` has been updated with your changes, if relevant

## Describe your PR
- Fixes DemoNavigator tab icons all being set to component due to #2361 
- Fixes Screen generator with incorrect return Type
  - Opt for NativeStackScreenProps over StackScreenProps for consistency
  - Proper generic param for route
- Updates generator to automate putting screen params in right spots
  - Take care of adding to AppStackParamList
  - and `<Stack.Screen />`  (as long as `--skip-index-file` is not passed)
