### PR TITLE
Strongly type navigationRef, update navigate() utility args type

### DIFF
--- a/boilerplate/app/models/helpers/setupRootStore.ts
+++ b/boilerplate/app/models/helpers/setupRootStore.ts
@@ -10,7 +10,7 @@
  * @refresh reset
  */
 import { applySnapshot, IDisposer, onSnapshot } from "mobx-state-tree"
-import type { RootStore } from "../RootStore"
+import { RootStore, RootStoreSnapshot } from "../RootStore"
 import * as storage from "../../utils/storage"
 
 /**
@@ -23,11 +23,11 @@ const ROOT_STATE_STORAGE_KEY = "root-v1"
  */
 let _disposer: IDisposer
 export async function setupRootStore(rootStore: RootStore) {
-  let restoredState: any
+  let restoredState: RootStoreSnapshot | undefined | null
 
   try {
     // load the last known state from AsyncStorage
-    restoredState = (await storage.load(ROOT_STATE_STORAGE_KEY)) || {}
+    restoredState = (await storage.load(ROOT_STATE_STORAGE_KEY)) as RootStoreSnapshot | null
     applySnapshot(rootStore, restoredState)
   } catch (e) {
     // if there's any problems loading, then inform the dev what happened

--- a/boilerplate/app/navigators/AppNavigator.tsx
+++ b/boilerplate/app/navigators/AppNavigator.tsx
@@ -10,8 +10,7 @@ import {
   NavigationContainer,
   NavigatorScreenParams, // @demo remove-current-line
 } from "@react-navigation/native"
-import { createNativeStackNavigator } from "@react-navigation/native-stack"
-import { StackScreenProps } from "@react-navigation/stack"
+import { createNativeStackNavigator, NativeStackScreenProps } from "@react-navigation/native-stack"
 import { observer } from "mobx-react-lite"
 import React from "react"
 import { useColorScheme } from "react-native"
@@ -50,7 +49,7 @@ export type AppStackParamList = {
  */
 const exitRoutes = Config.exitRoutes
 
-export type AppStackScreenProps<T extends keyof AppStackParamList> = StackScreenProps<
+export type AppStackScreenProps<T extends keyof AppStackParamList> = NativeStackScreenProps<
   AppStackParamList,
   T
 >
@@ -89,7 +88,8 @@ const AppStack = observer(function AppStack() {
   )
 })
 
-interface NavigationProps extends Partial<React.ComponentProps<typeof NavigationContainer>> {}
+export interface NavigationProps
+  extends Partial<React.ComponentProps<typeof NavigationContainer>> {}
 
 export const AppNavigator = observer(function AppNavigator(props: NavigationProps) {
   const colorScheme = useColorScheme()

--- a/boilerplate/app/navigators/navigationUtilities.ts
+++ b/boilerplate/app/navigators/navigationUtilities.ts
@@ -10,6 +10,16 @@ import * as storage from "../utils/storage"
 
 type Storage = typeof storage
 
+/**
+ * Reference to the root App Navigator.
+ *
+ * If needed, you can use this to access the navigation object outside of a
+ * `NavigationContainer` context. However, it's recommended to use the `useNavigation` hook whenever possible.
+ * @see https://reactnavigation.org/docs/navigating-without-navigation-prop/
+ *
+ * The types on this reference will only let you reference top level navigators. If you have
+ * nested navigators, you'll need to use the `useNavigation` with the stack navigator's ParamList type.
+ */
 export const navigationRef = createNavigationContainerRef<AppStackParamList>()
 
 /**
@@ -140,7 +150,7 @@ export function useNavigationPersistence(storage: Storage, persistenceKey: strin
 /**
  * use this to navigate without the navigation
  * prop. If you have access to the navigation prop, do not use this.
- * More info: https://reactnavigation.org/docs/navigating-without-navigation-prop/
+ * @see https://reactnavigation.org/docs/navigating-without-navigation-prop/
  */
 export function navigate(...args: Parameters<typeof navigationRef.navigate>) {
   if (navigationRef.isReady()) {
@@ -148,14 +158,25 @@ export function navigate(...args: Parameters<typeof navigationRef.navigate>) {
   }
 }
 
+/**
+ * This function is used to go back in a navigation stack, if it's possible to go back.
+ * If the navigation stack can't go back, nothing happens.
+ * The navigationRef variable is a React ref that references a navigation object.
+ * The navigationRef variable is set in the App component.
+ */
 export function goBack() {
   if (navigationRef.isReady() && navigationRef.canGoBack()) {
     navigationRef.goBack()
   }
 }
 
-export function resetRoot(params = { index: 0, routes: [] }) {
+/**
+ * resetRoot will reset the root navigation state to the given params.
+ */
+export function resetRoot(
+  state: Parameters<typeof navigationRef.resetRoot>[0] = { index: 0, routes: [] },
+) {
   if (navigationRef.isReady()) {
-    navigationRef.resetRoot(params)
+    navigationRef.resetRoot(state)
   }
 }

--- a/boilerplate/app/navigators/navigationUtilities.ts
+++ b/boilerplate/app/navigators/navigationUtilities.ts
@@ -9,6 +9,7 @@ import {
 import Config from "../config"
 import type { PersistNavigationConfig } from "../config/config.base"
 import { useIsMounted } from "../utils/useIsMounted"
+import type { AppStackParamList } from "./AppNavigator"
 
 /* eslint-disable */
 export const RootNavigation = {
@@ -22,7 +23,7 @@ export const RootNavigation = {
 }
 /* eslint-enable */
 
-export const navigationRef = createNavigationContainerRef()
+export const navigationRef = createNavigationContainerRef<AppStackParamList>()
 
 /**
  * Gets the current screen from any navigation state.
@@ -151,9 +152,9 @@ export function useNavigationPersistence(storage: any, persistenceKey: string) {
  * prop. If you have access to the navigation prop, do not use this.
  * More info: https://reactnavigation.org/docs/navigating-without-navigation-prop/
  */
-export function navigate(name: any, params?: any) {
+export function navigate(...args: Parameters<typeof navigationRef.navigate>) {
   if (navigationRef.isReady()) {
-    ;(navigationRef.navigate as any)(name, params)
+    navigationRef.navigate(...args)
   }
 }
 

--- a/boilerplate/app/services/reactotron/reactotron.ts
+++ b/boilerplate/app/services/reactotron/reactotron.ts
@@ -18,7 +18,7 @@ import { ArgType } from "reactotron-core-client"
 import AsyncStorage from "@react-native-async-storage/async-storage"
 import { onSnapshot } from "mobx-state-tree"
 import { mst } from "reactotron-mst"
-import { RootStore } from "../../models/RootStore"
+import { RootStore, RootStoreSnapshot } from "../../models/RootStore"
 import { clear } from "../../utils/storage"
 import { ReactotronConfig, DEFAULT_REACTOTRON_CONFIG } from "./reactotronConfig"
 import { goBack, resetRoot, navigate } from "../../navigators/navigationUtilities"
@@ -59,7 +59,7 @@ const config = DEFAULT_REACTOTRON_CONFIG
  *
  * @param rootStore The root store
  */
-export function setReactotronRootStore(rootStore: RootStore, initialData: any) {
+export function setReactotronRootStore(rootStore: RootStore, initialData: RootStoreSnapshot) {
   if (__DEV__) {
     const { logInitialState, logSnapshots } = config
     const name = "ROOT STORE"

--- a/boilerplate/app/utils/crashReporting.ts
+++ b/boilerplate/app/utils/crashReporting.ts
@@ -49,7 +49,7 @@ export enum ErrorType {
 /**
  * Manually report a handled error.
  */
-export const reportCrash = (error: any, type: ErrorType = ErrorType.FATAL) => {
+export const reportCrash = (error: Error, type: ErrorType = ErrorType.FATAL) => {
   if (__DEV__) {
     // Log to console and Reactotron in development
     const message = error.message || "Unknown"

--- a/boilerplate/app/utils/storage/storage.ts
+++ b/boilerplate/app/utils/storage/storage.ts
@@ -34,7 +34,7 @@ export async function saveString(key: string, value: string): Promise<boolean> {
  *
  * @param key The key to fetch.
  */
-export async function load(key: string): Promise<any | null> {
+export async function load(key: string): Promise<unknown | null> {
   try {
     const almostThere = await AsyncStorage.getItem(key)
     return JSON.parse(almostThere)
@@ -49,7 +49,7 @@ export async function load(key: string): Promise<any | null> {
  * @param key The key to fetch.
  * @param value The value to store.
  */
-export async function save(key: string, value: any): Promise<boolean> {
+export async function save(key: string, value: unknown): Promise<boolean> {
   try {
     await AsyncStorage.setItem(key, JSON.stringify(value))
     return true

--- a/boilerplate/app/utils/useHeader.tsx
+++ b/boilerplate/app/utils/useHeader.tsx
@@ -7,7 +7,10 @@ import { Header, HeaderProps } from "../components"
  *
  * - [Documentation and Examples](https://github.com/infinitered/ignite/blob/master/docs/Utils-useHeader.md)
  */
-export function useHeader(headerProps: HeaderProps, deps: any[] = []) {
+export function useHeader(
+  headerProps: HeaderProps,
+  deps: Parameters<typeof useLayoutEffect>[1] = [],
+) {
   const navigation = useNavigation()
 
   useLayoutEffect(() => {


### PR DESCRIPTION
## Please verify the following:

- [x] `yarn test` **jest** tests pass with new tests, if relevant
- [x] `README.md` has been updated with your changes, if relevant

## Describe your PR

This PR strongly types our `navigationRef` with our actual app stack types, and updates the `navigate` utility function to have the correct type. 

This also addresses the typescript 5.1 error described in this PR: https://github.com/infinitered/ignite/pull/2393

Additionally, this PR also removes explicit `any` type usages for Ignite 🥳 