### PR TITLE
Android Only - Navigation Bar Background Color

### DIFF
--- a/boilerplate/app/navigators/AppNavigator.tsx
+++ b/boilerplate/app/navigators/AppNavigator.tsx
@@ -19,6 +19,7 @@ import Config from "../config"
 import { useStores } from "../models" // @demo remove-current-line
 import { DemoNavigator, DemoTabParamList } from "./DemoNavigator" // @demo remove-current-line
 import { navigationRef, useBackButtonHandler } from "./navigationUtilities"
+import { colors } from "app/theme"
 
 /**
  * This type allows TypeScript to know what routes are defined in this navigator
@@ -64,7 +65,7 @@ const AppStack = observer(function AppStack() {
   // @demo remove-block-end
   return (
     <Stack.Navigator
-      screenOptions={{ headerShown: false }}
+      screenOptions={{ headerShown: false, navigationBarColor: colors.background }}
       initialRouteName={isAuthenticated ? "Welcome" : "Login"} // @demo remove-current-line
     >
       {/* @demo remove-block-start */}


### PR DESCRIPTION
This uses the colors of the app to set the background
color of the software navigation bar buttons for Android.

## Please verify the following:

- [x] `yarn test` **jest** tests pass with new tests, if relevant
- [ ] `README.md` has been updated with your changes, if relevant

## Describe your PR
On Android, the navigation bar background color can be set to match the background color of the app. This PR uses the background color from `colors.background` and uses it as the background color of the navigation bar software buttons.