### PR TITLE
fix(boilerplate): update Text sizeStyles to use satisfies

### DIFF
--- a/boilerplate/app/components/Text.tsx
+++ b/boilerplate/app/components/Text.tsx
@@ -73,13 +73,13 @@ export function Text(props: TextProps) {
 }
 
 const $sizeStyles = {
-  xxl: { fontSize: 36, lineHeight: 44 } as TextStyle,
-  xl: { fontSize: 24, lineHeight: 34 } as TextStyle,
-  lg: { fontSize: 20, lineHeight: 32 } as TextStyle,
-  md: { fontSize: 18, lineHeight: 26 } as TextStyle,
-  sm: { fontSize: 16, lineHeight: 24 } as TextStyle,
-  xs: { fontSize: 14, lineHeight: 21 } as TextStyle,
-  xxs: { fontSize: 12, lineHeight: 18 } as TextStyle,
+  xxl: { fontSize: 36, lineHeight: 44 } satisfies TextStyle,
+  xl: { fontSize: 24, lineHeight: 34 } satisfies TextStyle,
+  lg: { fontSize: 20, lineHeight: 32 } satisfies TextStyle,
+  md: { fontSize: 18, lineHeight: 26 } satisfies TextStyle,
+  sm: { fontSize: 16, lineHeight: 24 } satisfies TextStyle,
+  xs: { fontSize: 14, lineHeight: 21 } satisfies TextStyle,
+  xxs: { fontSize: 12, lineHeight: 18 } satisfies TextStyle,
 }
 
 const $fontWeightStyles = Object.entries(typography.primary).reduce((acc, [weight, fontFamily]) => {

--- a/boilerplate/package.json
+++ b/boilerplate/package.json
@@ -112,7 +112,7 @@
     "reactotron-core-client": "^2.8.10",
     "regenerator-runtime": "^0.13.4",
     "ts-jest": "29",
-    "typescript": "^4.8.4"
+    "typescript": "^5.0.4"
   },
   "resolutions": {
     "@types/react": "^18",


### PR DESCRIPTION
## Please verify the following:

- [ ] `yarn test` **jest** tests pass with new tests, if relevant
- [ ] `README.md` has been updated with your changes, if relevant

## Describe your PR
- Closes #2309 
- Upgrades TS version to match latest VS Code internal version for now

## Images

Now you get typechecking:
<img width="768" alt="image" src="https://github.com/infinitered/ignite/assets/374022/c22e5aca-07fd-4526-a02d-fed829b75aef">

And still typeahead (whicih `as TextStyle` originally accomplished)
<img width="624" alt="image" src="https://github.com/infinitered/ignite/assets/374022/8206f9cb-d531-4dbe-ac70-40448569f5f6">



