### PR TITLE
Fix: Error Boundary Infinite Loop

### DIFF
--- a/boilerplate/app/screens/ErrorScreen/ErrorBoundary.tsx
+++ b/boilerplate/app/screens/ErrorScreen/ErrorBoundary.tsx
@@ -25,6 +25,10 @@ export class ErrorBoundary extends Component<Props, State> {
 
   // If an error in a child is encountered, this will run
   componentDidCatch(error: Error, errorInfo: ErrorInfo) {
+    // Only set errors if enabled
+    if (!this.isEnabled()) {
+      return
+    }
     // Catch errors in any components below and re-render with error message
     this.setState({
       error,


### PR DESCRIPTION
Co-authored-by: yulolimum <yulian@infinite.red>

## Please verify the following:

- [x] `yarn test` **jest** tests pass with new tests, if relevant
- [ ] `README.md` has been updated with your changes, if relevant

## Describe your PR

When you use the `ErrorBoundary` with the `catchErrors` prop set to `never`, this will cause the application to infinitely render. This is due to setting the `error` and `errorInfo` state, but not checking whether catch is enabled. This causes the render function to re-render the children that will then trigger another exception, the `componentShouldUpdate` passes because it is a new error, and start the process again.

Special thanks to @yulolimum for helping me come up with a simple solution.