### PR TITLE
fix(devtools): remove reactotron error swap

### DIFF
--- a/boilerplate/app/devtools/ReactotronConfig.ts
+++ b/boilerplate/app/devtools/ReactotronConfig.ts
@@ -155,16 +155,6 @@ console.warn = (...args: Parameters<typeof console.warn>) => {
   Reactotron.warn(args[0])
 }
 
-const ogConsoleError = console.error
-console.error = (...args: Parameters<typeof console.error>) => {
-  ogConsoleError(...args)
-  if (args[0] instanceof Error) {
-    Reactotron.error(args[0].message, args[0].stack)
-  } else {
-    Reactotron.error(args[0], args[1])
-  }
-}
-
 const ogConsoleDebug = console.debug
 console.debug = (...args: Parameters<typeof console.debug>) => {
   ogConsoleDebug(...args)


### PR DESCRIPTION
## Please verify the following:

- [x] `yarn test` **jest** tests pass with new tests, if relevant
- [x] `README.md` has been updated with your changes, if relevant

## Describe your PR

Reactotron's `trackGlobalError` core plugin already listens to errors reported LogBox, so this PR removes double reporting from Reactotron error.
