### PR TITLE
Fix: Error while converting `null` to `RootStore`

### DIFF
--- a/boilerplate/app/models/helpers/setupRootStore.ts
+++ b/boilerplate/app/models/helpers/setupRootStore.ts
@@ -27,7 +27,7 @@ export async function setupRootStore(rootStore: RootStore) {
 
   try {
     // load the last known state from AsyncStorage
-    restoredState = ((await storage.load(ROOT_STATE_STORAGE_KEY)) ?? {}) as RootStoreSnapshot | null
+    restoredState = ((await storage.load(ROOT_STATE_STORAGE_KEY)) ?? {}) as RootStoreSnapshot
     applySnapshot(rootStore, restoredState)
   } catch (e) {
     // if there's any problems loading, then inform the dev what happened

--- a/boilerplate/app/models/helpers/setupRootStore.ts
+++ b/boilerplate/app/models/helpers/setupRootStore.ts
@@ -27,7 +27,7 @@ export async function setupRootStore(rootStore: RootStore) {
 
   try {
     // load the last known state from AsyncStorage
-    restoredState = (await storage.load(ROOT_STATE_STORAGE_KEY)) as RootStoreSnapshot | null
+    restoredState = ((await storage.load(ROOT_STATE_STORAGE_KEY)) ?? {}) as RootStoreSnapshot | null
     applySnapshot(rootStore, restoredState)
   } catch (e) {
     // if there's any problems loading, then inform the dev what happened


### PR DESCRIPTION
Fixes the following issue:

[mobx-state-tree] Error while converting `null` to `RootStore`: value `null` is not assignable to type: `RootStore` (Value is not a plain object).

## Please verify the following:

- [ ] `yarn test` **jest** tests pass with new tests, if relevant
- [ ] `README.md` has been updated with your changes, if relevant

## Describe your PR
