### PR TITLE
(boilerplate): Merge useEffect calls in LoginScreen for clarity

### DIFF
--- a/boilerplate/app/screens/LoginScreen.tsx
+++ b/boilerplate/app/screens/LoginScreen.tsx
@@ -24,6 +24,12 @@ export const LoginScreen: FC<LoginScreenProps> = observer(function LoginScreen(_
     // and pre-fill the form fields.
     setAuthEmail("ignite@infinite.red")
     setAuthPassword("ign1teIsAwes0m3")
+
+    // Return a "cleanup" function that React will run when the component unmounts
+    return () => {
+      setAuthPassword("")
+      setAuthEmail("")
+    }
   }, [])
 
   const error = isSubmitted ? validationError : ""
@@ -59,13 +65,6 @@ export const LoginScreen: FC<LoginScreenProps> = observer(function LoginScreen(_
       },
     [isAuthPasswordHidden],
   )
-
-  useEffect(() => {
-    return () => {
-      setAuthPassword("")
-      setAuthEmail("")
-    }
-  }, [])
 
   return (
     <Screen


### PR DESCRIPTION
## Please verify the following:

- [x] `yarn test` **jest** tests pass with new tests, if relevant
- [x] `README.md` has been updated with your changes, if relevant

## Describe your PR
The current LoginScreen has two separate useEffect calls: one for form pre-fill and one for cleanup. I found the separation confusing.

In this PR, I've merged these calls to make their relationship clearer. Maybe this change could help future users navigate the boilerplate a little bit easier?

Cheers,
- gaida