### PR TITLE
feat(boilerplate): config plugin scaffolding

### DIFF
--- a/boilerplate/app.config.ts
+++ b/boilerplate/app.config.ts
@@ -1,0 +1,25 @@
+import { ExpoConfig, ConfigContext } from "@expo/config"
+
+/**
+ * Use ts-node here so we can use TypeScript for our Config Plugins
+ * and not have to compile them to JavaScript
+ */
+require("ts-node/register")
+
+/**
+ * @param config ExpoConfig coming from the static config app.json if it exists
+ * 
+ * You can read more about Expo's Configuration Resolution Rules here:
+ * https://docs.expo.dev/workflow/configuration/#configuration-resolution-rules
+ */
+module.exports = ({ config }: ConfigContext): Partial<ExpoConfig> => {
+  const existingPlugins = config.plugins ?? []
+
+  return {
+    ...config,
+    plugins: [
+      ...existingPlugins,
+      require("./plugins/withSplashScreen").withSplashScreen,
+    ],
+  }
+}

--- a/boilerplate/package.json
+++ b/boilerplate/package.json
@@ -100,6 +100,7 @@
     "reactotron-react-native": "5.0.4-beta.7",
     "regenerator-runtime": "^0.13.4",
     "ts-jest": "^29.1.1",
+    "ts-node": "^10.9.1",
     "typescript": "^5.1.3"
   },
   "expo": {

--- a/boilerplate/plugins/withSplashScreen.ts
+++ b/boilerplate/plugins/withSplashScreen.ts
@@ -1,0 +1,74 @@
+import {
+  ConfigPlugin,
+  withStringsXml,
+  AndroidConfig,
+  withAndroidStyles,
+} from "expo/config-plugins"
+
+/**
+ * 
+ * Expo Config Plugin to help address the double splash screen issue with `expo-splash-screen`
+ * See more information about this issue here: https://github.com/expo/expo/issues/16084
+ * 
+ * How it works: 
+ *   1) Replace the default splash screen with a transparent screen
+ *   2) Set the splash screen status bar to translucent
+ */
+export const withSplashScreen: ConfigPlugin = (config) => {
+  config = withAndroidSplashScreen(config)
+  return config
+}
+
+/**
+ * Android implementation of the config plugin - the only platform needed for this plugin.
+ * However, it is good practice to break up your config plugins from the exported
+ * function into parts by platform. For example, if it was needed, we would also
+ * add `withIosSplashScreen` for the iOS implementation.
+ */
+const withAndroidSplashScreen: ConfigPlugin = (config) => {
+  config = withCustomStylesXml(config)
+  config = withCustomStringsXml(config)
+  return config
+}
+
+/**
+ * Modifies the `android/app/src/main/res/values/strings.xml` file to add the following string:
+ * 
+ * <string name="expo_splash_screen_status_bar_translucent" translatable="false">true</string>
+ */
+const withCustomStringsXml: ConfigPlugin = (config) =>
+  withStringsXml(config, (modConfig) => {
+    modConfig.modResults = AndroidConfig.Strings.setStringItem(
+      [
+        {
+          _: "true",
+          $: {
+            name: "expo_splash_screen_status_bar_translucent",
+            translatable: "false",
+          },
+        },
+      ],
+      modConfig.modResults,
+    )
+    return modConfig
+  })
+
+/**
+ * Modifies the `android/app/src/main/res/values/styles.xml` file to append the
+ * the following to the Theme.App.SplashScreen style:
+ * 
+ * <item name="android:windowIsTranslucent">true</item>
+ */
+const withCustomStylesXml: ConfigPlugin = (config) =>
+  withAndroidStyles(config, async (modConfig) => {
+    modConfig.modResults = AndroidConfig.Styles.assignStylesValue(modConfig.modResults, {
+      add: true,
+      name: "android:windowIsTranslucent",
+      value: "true",
+      parent: {
+        name: "Theme.App.SplashScreen",
+        parent: "AppTheme",
+      },
+    })
+    return modConfig
+  })

--- a/boilerplate/tsconfig.json
+++ b/boilerplate/tsconfig.json
@@ -23,6 +23,14 @@
     }
   },
   "extends": "expo/tsconfig.base",
-  "include": ["index.js", "App.tsx", "app", "types"],
+  "ts-node": {
+    "compilerOptions": {
+      // compilerOptions specified here will override those declared above,
+      // but *only* in ts-node.  Useful if you want ts-node and tsc to use
+      // different options with a single tsconfig.json.
+      "module": "commonjs"
+    }
+  },
+  "include": ["index.js", "App.tsx", "app", "types", "plugins", "app.config.ts"],
   "exclude": ["node_modules", "test/**/*"]
 }

--- a/docs/Expo-and-Ignite.md
+++ b/docs/Expo-and-Ignite.md
@@ -13,19 +13,19 @@ If you're not familiar with [Expo](https://expo.dev), it's an open-source platfo
 
 ## Overview
 
-In previous versions of Ignite (versions 6 and 7), you could pass in a `--expo` flag to make the resulting generated app "Expo-ready". In version 8 (code-named "Maverick") we made the boilerplate "Expo-ready" by default -- but without locking you into using Expo Go or Expo's services if you don't want to. Every new Ignited app is ready to run with Expo CLI or with "vanilla" React Native CLI right out of the box.
+In previous versions of Ignite (versions 6 and 7), you could pass in a `--expo` flag to make the resulting generated app "Expo-ready". In version 8 (code-named "Maverick") we made the boilerplate "Expo-ready" by default -- but without locking you into using Expo Go or Expo's services if you don't want to.
+
+Now in version 9 (code-named "Exp[ress]o") we let Expo drive the native template initially. If you want to take over the native template and maintain all native code yourself, you are free to do so! However, if you want to opt-in to [Continuous Native Generation](https://docs.expo.dev/workflow/continuous-native-generation/) you can modify/extend the native template via Expo's [Config Plugins](https://docs.expo.dev/guides/config-plugins/). The Ignite template includes a Config Plugin that adds in a bug fix for `expo-splash-screen` when on Android 12.
 
 ```
 # Spin up a new app
 npx ignite-cli new PizzaApp
 cd PizzaApp
 
-# Expo CLI / Expo Go
-yarn expo:start
-yarn expo:ios
-yarn expo:android
+# Expo Go
+yarn start
 
-# React Native CLI
+# Expo Prebuild and DIY
 yarn ios
 yarn android
 ```

--- a/docs/Folder-Structure.md
+++ b/docs/Folder-Structure.md
@@ -25,6 +25,10 @@ ignite-project
 │   ├── setup.ts
 ├── ignite
 │   └── templates
+├── plugins
+│   └── withSplashScreen.ts
+├── app.config.ts
+├── app.json
 ├── App.tsx
 ├── package.json
 └── README.md
@@ -96,13 +100,21 @@ Here lives the theme for your application, including spacing, colors, and typogr
 
 This is a great place to put miscellaneous helpers and utilities. Things like date helpers, formatters, etc. are often found here. However, it should only be used for things that are truely shared across your application. If a helper or utility is only used by a specific component or model, consider co-locating your helper with that component or model.
 
-**app.tsx**
+**app.json/app.config.ts**
+
+These are the configuration files for your application. `app.json` contains the static configuration which will be fed into the dynamic configuration in `app.config.ts`, where Expo builds it's final configuration for the app.
+
+**App.tsx**
 
 This is the entry point to your app. This is where you will find the main App component which renders the rest of the application.
 
 ### ./ignite directory
 
 The `ignite` directory stores all things Ignite, including generator templates.
+
+### ./plugins directory
+
+The `plugins` directory stores any custom Expo Config Plugins you want to be applied during the prebuild process when generating the native code for the project.
 
 ### ./test directory
 

--- a/docs/Guide.md
+++ b/docs/Guide.md
@@ -31,7 +31,6 @@ Your new Ignite project (whether you start with Expo or not) comes with a full s
 - TypeScript
 - AsyncStorage (integrated with MST for restoring state)
 - apisauce (to talk to REST servers)
-- Flipper-ready
 - Reactotron-ready (and pre-integrated with MST)
 - Supports Expo (and Expo web) out of the box
 - About a dozen prebuilt [components](./Components.md) to build out your UI with


### PR DESCRIPTION
## Please verify the following:

- [x] `yarn test` **jest** tests pass with new tests, if relevant
- [x] `README.md` has been updated with your changes, if relevant

## Describe your PR
- Adds scaffolding for writing TypeScript Expo Config Plugins (via `ts-node`) within your project without needing to transpile to JS
- Adds documented Config Plugin, `withSplashScreen`, to address Android 12 issues with `expo-splash-screen`
- Updates some documentation related to Expo and Ignite