### PR TITLE
Correct cd command when targetPath has changed

### DIFF
--- a/src/commands/new.ts
+++ b/src/commands/new.ts
@@ -652,7 +652,7 @@ export default {
     hr()
     p2()
     p2("Now get cooking! 🍽")
-    command(`cd ${projectName}`)
+    command(`cd ${targetPath}`)
     if (!installDeps) command(packager.installCmd({ packagerName }))
     command(`${packagerName} start`)
 


### PR DESCRIPTION

## Please verify the following:

- [x] `yarn test` **jest** tests pass with new tests, if relevant
- [x] `README.md` has been updated with your changes, if relevant

## Describe your PR

The `cd` output on a new project uses the `projectName`, but you can override the default `targetPath`, making that command incorrect.  This changes to use the `targetPath` so you can copy/paste if you changed the path and it will work
