### PR TITLE
fix(rename): change oldBundleIdentifier from AndroidManifest's package to app/build.gradle's namespace

### DIFF
--- a/src/commands/rename.ts
+++ b/src/commands/rename.ts
@@ -20,13 +20,13 @@ module.exports = {
       return
     }
 
-    // then, get the package name from Android
-    const manifest = await filesystem.readAsync(
-      `${process.cwd()}/android/app/src/main/AndroidManifest.xml`,
+    // then, get the package name from app/build.gradle
+    const buildGradle = await filesystem.readAsync(
+      `${process.cwd()}/android/app/build.gradle`,
     )
 
-    // match <manifest package="name" to get the bundle id
-    const oldBundleIdentifier = manifest.match(/package="([^"]+)"/)[1]
+    // match namespace "name" to get the bundle id
+    const oldBundleIdentifier = buildGradle.match(/namespace "([^"]+)"/)[1]
 
     // do some validations here
 


### PR DESCRIPTION
## Please verify the following:

- [ ] `yarn test` **jest** tests pass with new tests, if relevant
- [ ] `README.md` has been updated with your changes, if relevant

## Describe your PR
- Fixed Issues https://github.com/infinitered/ignite/issues/2491
- fix not getting oldBundleIdentifier from AndroidManifest.xml, move to app/build.gradle 's namespace. 

Previously throw error on getting oldBundleId, problem: package remove from AndroidManifest since Ignite 8.8.2 to latest 8.8.7.