### PR TITLE
Specifies version of @expo/webpack-config to avoid dependency failure

### DIFF
--- a/boilerplate/ios/Podfile.lock
+++ b/boilerplate/ios/Podfile.lock
@@ -10,7 +10,7 @@ PODS:
     - ExpoModulesCore
   - EXFont (11.1.1):
     - ExpoModulesCore
-  - Expo (48.0.15):
+  - Expo (48.0.20):
     - ExpoModulesCore
   - ExpoDevice (5.2.1):
     - ExpoModulesCore
@@ -18,7 +18,7 @@ PODS:
     - ExpoModulesCore
   - ExpoLocalization (14.1.1):
     - ExpoModulesCore
-  - ExpoModulesCore (1.2.6):
+  - ExpoModulesCore (1.2.7):
     - React-Core
     - React-RCTAppDelegate
     - ReactCommon/turbomodule/core
@@ -688,11 +688,11 @@ SPEC CHECKSUMS:
   EXConstants: f348da07e21b23d2b085e270d7b74f282df1a7d9
   EXFileSystem: 844e86ca9b5375486ecc4ef06d3838d5597d895d
   EXFont: 6ea3800df746be7233208d80fe379b8ed74f4272
-  Expo: 62bba165c9cd30a2983176e7d975ae688b6334b6
+  Expo: b7d2843b0a0027d0ce76121a63085764355a16ed
   ExpoDevice: e0bebf68f978b3d353377ce42e73c20c0a070215
   ExpoKeepAwake: 69f5f627670d62318410392d03e0b5db0f85759a
   ExpoLocalization: f26cd431ad9ea3533c5b08c4fabd879176a794bb
-  ExpoModulesCore: 6e0259511f4c4341b6b8357db393624df2280828
+  ExpoModulesCore: 653958063a301098b541ae4dfed1ac0b98db607b
   EXSplashScreen: 0e0a9ba0cf7553094e93213099bd7b42e6e237e9
   FBLazyVector: a89a0525bc7ca174675045c2b492b5280d5a2470
   FBReactNativeSpec: 7714e6bc1e9ea23df6c4cb42f0b2fd9c6a3a559c
@@ -749,4 +749,4 @@ SPEC CHECKSUMS:
 
 PODFILE CHECKSUM: f15b66725516213cd823a247a090a0a0b96a8331
 
-COCOAPODS: 1.12.1
+COCOAPODS: 1.12.0

--- a/boilerplate/package.json
+++ b/boilerplate/package.json
@@ -33,7 +33,7 @@
   "dependencies": {
     "@expo-google-fonts/space-grotesk": "^0.2.2",
     "@expo/metro-config": "^0.7.1",
-    "@expo/webpack-config": "^18.0.1",
+    "@expo/webpack-config": "18.1.2",
     "@react-native-async-storage/async-storage": "1.17.11",
     "@react-navigation/bottom-tabs": "^6.3.2",
     "@react-navigation/native": "^6.0.2",


### PR DESCRIPTION
Fixes #2500.

Expo bumped `@expo/webpack-config` to require Expo 49 in this PR, which broke our tests. https://github.com/expo/expo-cli/pull/4747

This freezes the version of `@expo/webpack-config` to [18.1.2](https://www.npmjs.com/package/@expo/webpack-config/v/18.1.2) to bring it back to Expo 48.

Note that in Ignite v9, `@expo/webpack-config` will be entirely removed (we'll be using Metro on web), so this is just a temporary patch.
