### PR TITLE
feat(boilerplate): add french to i18n

### DIFF
--- a/boilerplate/app/i18n/fr.ts
+++ b/boilerplate/app/i18n/fr.ts
@@ -1,0 +1,129 @@
+import { Translations } from "./en"
+
+const fr: Translations = {
+  common: {
+    ok: "OK !",
+    cancel: "Annuler",
+    back: "Retour",
+    logOut: "Déconnexion", // @demo remove-current-line
+  },
+  welcomeScreen: {
+    postscript:
+      "psst  — Ce n'est probablement pas à quoi ressemble votre application. (À moins que votre designer ne vous ait donné ces écrans, dans ce cas, mettez la en prod !)",
+    readyForLaunch: "Votre application, presque prête pour le lancement !",
+    exciting: "(ohh, c'est excitant !)",
+    letsGo: "Allons-y !", // @demo remove-current-line
+  },
+  errorScreen: {
+    title: "Quelque chose s'est mal passé !",
+    friendlySubtitle:
+      "C'est l'écran que vos utilisateurs verront en production lorsqu'une erreur sera lancée. Vous voudrez personnaliser ce message (situé dans `app/i18n/fr.ts`) et probablement aussi la mise en page (`app/screens/ErrorScreen`). Si vous voulez le supprimer complètement, vérifiez `app/app.tsx` pour le composant <ErrorBoundary>.",
+    reset: "RÉINITIALISER L'APPLICATION",
+    traceTitle: "Erreur depuis %{name}", // @demo remove-current-line
+  },
+  emptyStateComponent: {
+    generic: {
+      heading: "Si vide... si triste",
+      content:
+        "Aucune donnée trouvée pour le moment. Essayez de cliquer sur le bouton pour rafraîchir ou recharger l'application.",
+      button: "Essayons à nouveau",
+    },
+  },
+  // @demo remove-block-start
+  errors: {
+    invalidEmail: "Adresse e-mail invalide.",
+  },
+  loginScreen: {
+    signIn: "Se connecter",
+    enterDetails:
+      "Entrez vos informations ci-dessous pour débloquer des informations top secrètes. Vous ne devinerez jamais ce que nous avons en attente. Ou peut-être que vous le ferez ; ce n'est pas de la science spatiale ici.",
+    emailFieldLabel: "E-mail",
+    passwordFieldLabel: "Mot de passe",
+    emailFieldPlaceholder: "Entrez votre adresse e-mail",
+    passwordFieldPlaceholder: "Mot de passe super secret ici",
+    tapToSignIn: "Appuyez pour vous connecter !",
+    hint: "Astuce : vous pouvez utiliser n'importe quelle adresse e-mail et votre mot de passe préféré :)",
+  },
+  demoNavigator: {
+    componentsTab: "Composants",
+    debugTab: "Débogage",
+    communityTab: "Communauté",
+    podcastListTab: "Podcasts",
+  },
+  demoCommunityScreen: {
+    title: "Connectez-vous avec la communauté",
+    tagLine:
+      "Rejoignez la communauté d'ingénieurs React Native d'Infinite Red et améliorez votre développement d'applications avec nous !",
+    joinUsOnSlackTitle: "Rejoignez-nous sur Slack",
+    joinUsOnSlack:
+      "Vous souhaitez vous connecter avec des ingénieurs React Native du monde entier ? Rejoignez la conversation dans la communauté Slack d'Infinite Red ! Notre communauté en pleine croissance est un espace sûr pour poser des questions, apprendre des autres et développer votre réseau.",
+    joinSlackLink: "Rejoindre la communauté Slack",
+    makeIgniteEvenBetterTitle: "Rendre Ignite encore meilleur",
+    makeIgniteEvenBetter:
+      "Vous avez une idée pour rendre Ignite encore meilleur ? Nous sommes heureux de l'entendre ! Nous cherchons toujours des personnes qui veulent nous aider à construire les meilleurs outils React Native. Rejoignez-nous sur GitHub pour nous aider à construire l'avenir d'Ignite.",
+    contributeToIgniteLink: "Contribuer à Ignite",
+    theLatestInReactNativeTitle: "Les dernières nouvelles de React Native",
+    theLatestInReactNative:
+      "Nous sommes là pour vous tenir au courant de tout ce que React Native a à offrir.",
+    reactNativeRadioLink: "React Native Radio",
+    reactNativeNewsletterLink: "React Native Newsletter",
+    reactNativeLiveLink: "React Native Live",
+    chainReactConferenceLink: "Conférence Chain React",
+    hireUsTitle: "Engagez Infinite Red pour votre prochain projet",
+    hireUs:
+      "Que ce soit pour gérer un projet complet ou pour former des équipes à notre formation pratique, Infinite Red peut vous aider pour presque tous les projets React Native.",
+    hireUsLink: "Envoyez-nous un message",
+  },
+  demoShowroomScreen: {
+    jumpStart: "Composants pour démarrer votre projet !",
+    lorem2Sentences:
+      "Nulla cupidatat deserunt amet quis aliquip nostrud do adipisicing. Adipisicing excepteur elit laborum Lorem adipisicing do duis.",
+    demoHeaderTxExample: "Yay",
+    demoViaTxProp: "Via la propriété `tx`",
+    demoViaSpecifiedTxProp: "Via la propriété `{{prop}}Tx` spécifiée",
+  },
+  demoDebugScreen: {
+    howTo: "COMMENT FAIRE",
+    title: "Débugage",
+    tagLine:
+      "Félicitations, vous avez un modèle d'application React Native très avancé ici. Profitez de cette base de code !",
+    reactotron: "Envoyer à Reactotron",
+    reportBugs: "Signaler des bugs",
+    demoList: "Liste de démonstration",
+    demoPodcastList: "Liste de podcasts de démonstration",
+    androidReactotronHint:
+      "Si cela ne fonctionne pas, assurez-vous que l'application de bureau Reactotron est en cours d'exécution, exécutez adb reverse tcp:9090 tcp:9090 à partir de votre terminal, puis rechargez l'application.",
+    iosReactotronHint:
+      "Si cela ne fonctionne pas, assurez-vous que l'application de bureau Reactotron est en cours d'exécution, puis rechargez l'application.",
+    macosReactotronHint:
+      "Si cela ne fonctionne pas, assurez-vous que l'application de bureau Reactotron est en cours d'exécution, puis rechargez l'application.",
+    webReactotronHint:
+      "Si cela ne fonctionne pas, assurez-vous que l'application de bureau Reactotron est en cours d'exécution, puis rechargez l'application.",
+    windowsReactotronHint:
+      "Si cela ne fonctionne pas, assurez-vous que l'application de bureau Reactotron est en cours d'exécution, puis rechargez l'application.",
+  },
+  demoPodcastListScreen: {
+    title: "Épisodes de Radio React Native",
+    onlyFavorites: "Afficher uniquement les favoris",
+    favoriteButton: "Favori",
+    unfavoriteButton: "Non favori",
+    accessibility: {
+      cardHint:
+        "Double-cliquez pour écouter l'épisode. Double-cliquez et maintenez pour {{action}} cet épisode.",
+      switch: "Activez pour afficher uniquement les favoris",
+      favoriteAction: "Basculer en favori",
+      favoriteIcon: "Épisode non favori",
+      unfavoriteIcon: "Épisode favori",
+      publishLabel: "Publié le {{date}}",
+      durationLabel: "Durée : {{hours}} heures {{minutes}} minutes {{seconds}} secondes",
+    },
+    noFavoritesEmptyState: {
+      heading: "C'est un peu vide ici",
+      content:
+        "Aucun favori n'a été ajouté pour le moment. Appuyez sur le cœur d'un épisode pour l'ajouter à vos favoris !",
+    },
+  },
+  // @demo remove-block-end
+}
+
+export default fr

--- a/boilerplate/app/i18n/i18n.ts
+++ b/boilerplate/app/i18n/i18n.ts
@@ -6,6 +6,7 @@ import { I18nManager } from "react-native"
 import en, { Translations } from "./en"
 import ar from "./ar"
 import ko from "./ko"
+import fr from "./fr"
 
 i18n.fallbacks = true
 /**
@@ -13,7 +14,7 @@ i18n.fallbacks = true
  * the language code is the suffixed with "-US". i.e. if a device is set to English ("en"),
  * if you change to another language and then return to English language code is now "en-US".
  */
-i18n.translations = { ar, en, "en-US": en, ko }
+i18n.translations = { ar, en, "en-US": en, ko, fr }
 
 i18n.locale = Localization.locale
 

--- a/test/vanilla/__snapshots__/ignite-remove-demo.test.ts.snap
+++ b/test/vanilla/__snapshots__/ignite-remove-demo.test.ts.snap
@@ -7,6 +7,7 @@ exports[`ignite-cli remove-demo should print the expected response 1`] = `
    Found '@demo remove-file' in /user/home/ignite/.maestro/Login.yaml
    Found '@demo remove-current-line', '@demo remove-block-start', '@demo remove-block-end' in /user/home/ignite/app/i18n/ar.ts
    Found '@demo remove-current-line', '@demo remove-block-start', '@demo remove-block-end' in /user/home/ignite/app/i18n/en.ts
+   Found '@demo remove-current-line', '@demo remove-block-start', '@demo remove-block-end' in /user/home/ignite/app/i18n/fr.ts
    Found '@demo remove-current-line', '@demo remove-block-start', '@demo remove-block-end' in /user/home/ignite/app/i18n/ko.ts
    Found '@demo remove-file' in /user/home/ignite/app/models/AuthenticationStore.ts
    Found '@demo remove-file' in /user/home/ignite/app/models/Episode.test.ts


### PR DESCRIPTION
## Please verify the following:

- [x] `yarn test` **jest** tests pass with new tests, if relevant
- [x] `README.md` has been updated with your changes, if relevant

## Describe your PR

I am writing slides for a talk about the power of GitHub copilot. 
One feature is the translation
https://davidl.fr/courses/copilot.html#89

I needed an example 
So let's ship a real feature 🚀 


here is the prompt I used (and I double-checked if it makes sense in 🇫🇷)
> transform this translation file to `fr.ts`
> translate the text to french, except for the property