### PR TITLE
chore(boilerplate) Update react-native to 0.72.5

### DIFF
--- a/boilerplate/package.json
+++ b/boilerplate/package.json
@@ -52,7 +52,7 @@
     "mobx-state-tree": "5.1.5",
     "react": "18.2.0",
     "react-dom": "18.2.0",
-    "react-native": "0.72.4",
+    "react-native": "0.72.5",
     "react-native-gesture-handler": "~2.12.0",
     "react-native-reanimated": "~3.3.0",
     "react-native-safe-area-context": "4.6.3",


### PR DESCRIPTION
## Please verify the following:

- [x] `yarn test` **jest** tests pass with new tests, if relevant
- [x] `README.md` has been updated with your changes, if relevant

## Describe your PR

This updates the `@next` version of react-native to the latest 0.72.5, getting rid of the warning: 

```
Some dependencies are incompatible with the installed expo version:
  react-native@0.72.4 - expected version: 0.72.5
Your project may not work correctly until you install the correct versions of the packages.
```

PR made against this PR: #2446