### PR TITLE
fix: ios compiling issue when the user specifies the new architecture

### DIFF
--- a/src/commands/new.ts
+++ b/src/commands/new.ts
@@ -620,9 +620,16 @@ module.exports = {
     if (experimentalNewArch === true) {
       startSpinner(" Enabling New Architecture")
       try {
-        let appJsonRaw = read("app.json")
-        appJsonRaw = appJsonRaw.replace(/"newArchEnabled": false/g, '"newArchEnabled": true')
+        const appJsonRaw = read("app.json")
+
         const appJson = JSON.parse(appJsonRaw)
+        appJson.expo.plugins[1][1].ios.newArchEnabled = true
+        appJson.expo.plugins[1][1].android.newArchEnabled = true
+
+        // Adding the "deploymentTarget" key is required for
+        // @react-native-async-storage/async-storage to work in the new architecture
+        appJson.expo.plugins[1][1].ios.deploymentTarget = "13.4"
+
         write("./app.json", appJson)
       } catch (e) {
         log(e)


### PR DESCRIPTION
## Please verify the following:

- [x] `yarn test` **jest** tests pass with new tests, if relevant
- [x] `README.md` has been updated with your changes, if relevant

## Describe your PR

This is pulling out a commit from #2513 so that we can get this fix in for the new architecture with that PR stalled for now.

`@react-native-async-storage/async-storage` requires ios 13.4 as a minimum deployment target when using the new architecture.