### PR TITLE
fix: `Localization.isRTL` is deprecated.

### DIFF
--- a/boilerplate/app/i18n/i18n.ts
+++ b/boilerplate/app/i18n/i18n.ts
@@ -17,7 +17,18 @@ i18n.fallbacks = true
 i18n.translations = { ar, en, "en-US": en, ko, fr }
 
 const locales = Localization.getLocales() // This method is guaranteed to return at least one array item.
-const preferredLanguage = locales[0] // The preferred language is the first element in the array.
+// The preferred language is the first element in the array, however, we fallback to en-US, especially for tests.
+const preferredLanguage: Localization.Locale = locales[0] || {
+  languageTag: "en-US",
+  languageCode: "en",
+  textDirection: "ltr",
+  digitGroupingSeparator: ",",
+  decimalSeparator: ".",
+  measurementSystem: "us",
+  currencyCode: "USD",
+  currencySymbol: "$",
+  regionCode: "US",
+}
 i18n.locale = preferredLanguage.languageTag
 
 // handle RTL languages

--- a/boilerplate/app/i18n/i18n.ts
+++ b/boilerplate/app/i18n/i18n.ts
@@ -18,16 +18,11 @@ i18n.translations = { ar, en, "en-US": en, ko, fr }
 
 const locales = Localization.getLocales() // This method is guaranteed to return at least one array item.
 // The preferred language is the first element in the array, however, we fallback to en-US, especially for tests.
-const preferredLanguage: Localization.Locale = locales[0] || {
+const preferredLanguage:
+  | Localization.Locale
+  | { languageTag: string; textDirection: "ltr" | "rtl" } = locales[0] || {
   languageTag: "en-US",
-  languageCode: "en",
   textDirection: "ltr",
-  digitGroupingSeparator: ",",
-  decimalSeparator: ".",
-  measurementSystem: "us",
-  currencyCode: "USD",
-  currencySymbol: "$",
-  regionCode: "US",
 }
 i18n.locale = preferredLanguage.languageTag
 

--- a/boilerplate/app/i18n/i18n.ts
+++ b/boilerplate/app/i18n/i18n.ts
@@ -16,10 +16,12 @@ i18n.fallbacks = true
  */
 i18n.translations = { ar, en, "en-US": en, ko, fr }
 
-i18n.locale = Localization.locale
+const locales = Localization.getLocales() // This method is guaranteed to return at least one array item.
+const preferredLanguage = locales[0] // The preferred language is the first element in the array.
+i18n.locale = preferredLanguage.languageTag
 
 // handle RTL languages
-export const isRTL = Localization.isRTL
+export const isRTL = preferredLanguage.textDirection === "rtl"
 I18nManager.allowRTL(isRTL)
 I18nManager.forceRTL(isRTL)
 


### PR DESCRIPTION
## Please verify the following:

- [x] `yarn test` **jest** tests pass with new tests, if relevant
- [x] `README.md` has been updated with your changes, if relevant

## Describe your PR

`Localization.isRTL` is deprecated.

![Screenshot 2023-10-10 at 3 26 04 PM](https://github.com/infinitered/ignite/assets/139261/24c29b9a-dda6-4117-aa3c-ee2f569ebeba)

The deprecation notice for `expo-localization`'s `Localization.isRTL` is the synchronous function call `Localization.getLocales()`. This gets an array of the user’s preferred languages with the first element in the array being their preferred language. This array object contains everything we need to determine their `i18n.locale` and if the language is `rtl` or `ltr`.

As you can see in this video, I'm switching back and forth between English and Arabic (with a little debug notice alert that is not included in this PR, just so we can see what's going on) and the `isRTL` functionality remains the same.

Debug code for my little alert:

```tsx
Alert.alert(
  "Preferred Languages:",
  locales.map((l) => `${l.languageTag} (${l.textDirection})`).join(", "),
)
```
![9F29BB84-DC31-499A-9257-86787891FE90-54927-0002E20E3E751C3F](https://github.com/infinitered/ignite/assets/139261/10e9d2c9-302c-42f4-b432-1795767166e2)

