### PR TITLE
fix(boilerplate): inherit default metro from expo

### DIFF
--- a/boilerplate/metro.config.js
+++ b/boilerplate/metro.config.js
@@ -1,10 +1,14 @@
-module.exports = {
-  transformer: {
-    getTransformOptions: async () => ({
-      transform: {
-        experimentalImportSupport: false,
-        inlineRequires: true,
-      },
-    }),
+// Learn more https://docs.expo.io/guides/customizing-metro
+const { getDefaultConfig } = require('expo/metro-config');
+
+/** @type {import('expo/metro-config').MetroConfig} */
+const config = getDefaultConfig(__dirname);
+
+config.transformer.getTransformOptions = async () => ({
+  transform: {
+    experimentalImportSupport: false,
+    inlineRequires: true,
   },
-}
+});
+
+module.exports = config;


### PR DESCRIPTION
## Please verify the following:

- [ ] `yarn test` **jest** tests pass with new tests, if relevant
- [ ] `README.md` has been updated with your changes, if relevant

## Describe your PR

- As reported on #2446, the `metro.config.js` was not baselined with the Expo default config
- https://github.com/infinitered/ignite/pull/2446#issuecomment-1761352677