### PR TITLE
fix(jest): map ts paths

### DIFF
--- a/boilerplate/jest.config.js
+++ b/boilerplate/jest.config.js
@@ -11,4 +11,5 @@ module.exports = {
   testPathIgnorePatterns: ["<rootDir>/node_modules/", "<rootDir>/.maestro/", "@react-native"],
   testEnvironment: "jsdom",
   setupFiles: ["<rootDir>/test/setup.ts"],
+  moduleNameMapper: { "^app/(.*)$": "<rootDir>/app/$1", "^assets/(.*)$": "<rootDir>/assets/$1" },
 }


### PR DESCRIPTION
## Please verify the following:

- [ ] `yarn test` **jest** tests pass with new tests, if relevant
- [ ] `README.md` has been updated with your changes, if relevant

## Describe your PR

- Closes #2490
- Jest config needed to know about the TS path aliases to utilize them within the tests

You can now import like so without jest breaking:

```
import { delay } from "app/utils/delay"
```