### PR TITLE
fix(cli): win EOL conversion for gen templates

### DIFF
--- a/docs/Generators.md
+++ b/docs/Generators.md
@@ -151,3 +151,9 @@ You may want to update your generators to the latest version of Ignite.
 Just run `npx ignite-cli update <type>` or `npx ignite-cli update --all` from the root folder of your project to copy over the latest generators from Ignite to your project.
 
 ⚠️ Note that this will remove any customizations you've made, so make sure to make a commit first so you can roll it back!
+
+## A Note About Windows
+
+If you are noticing upon using the generator for a source file (such as a screen or model) that frontmatter is not removed from the newly created file, it could be that the End of Line Sequence is misconfigured. Ignite tries to take care of this on its own, but sometimes your machine will not have a proper CLI utility such as `unix2dos` installed (this usually comes with Git).
+
+In this case, you can open VS Code (or another IDE) and convert the EOL characters for all `ejs` files in the `ignite/templates` directory. Then run the generator command again and it should create the new files properly.

--- a/src/commands/new.ts
+++ b/src/commands/new.ts
@@ -324,6 +324,7 @@ export default {
 
     const packagerOptions = { packagerName }
 
+    const isWindows = process.platform === "win32"
     const ignitePath = path(`${meta.src}`, "..")
     const boilerplatePath = path(ignitePath, "boilerplate")
     const boilerplate = (...pathParts: string[]) => path(boilerplatePath, ...pathParts)
@@ -552,13 +553,48 @@ export default {
     }
     // #endregion
 
+    // #region Format generator templates EOL for Windows
+    let warnAboutEOL = false
+    if (isWindows) {
+      // find unix2dos to help convert EOL, usually installed with git, ie:  C:\Program Files\Git\usr\bin\unix2dos.EXE
+      const unixToDosPath = await system.exec("which unix2dos")
+      // find all templates Ignite provides by default
+      const templates = filesystem.find(`${targetPath}/ignite/templates`, {
+        directories: false,
+        files: true,
+        matching: "*.ts*.ejs",
+      })
+
+      log(`unix2dos path: ${unixToDosPath}`)
+      log(`templates to change EOL: ${templates}`)
+      if (unixToDosPath) {
+        // running the output from `which` result above seems to not work, so just pop the binary name
+        const unixToDosCmd = unixToDosPath.split("/").pop()
+        const results = await Promise.allSettled(
+          templates.map(async (file) => {
+            log(`Converting EOL for ${file}`)
+            await system.run(`${unixToDosCmd} ${file}`)
+          }),
+        )
+
+        // inspect the results of conversion and log
+        results.forEach((result) => {
+          if (result.status === "rejected") {
+            warnAboutEOL = true
+            log(`Error converting EOL: ${JSON.stringify(result.reason)}`)
+          }
+        })
+      } else {
+        warnAboutEOL = true
+      }
+    }
+    // #endregion
+
     // #region Create Git Repository and Initial Commit
     // commit any changes
     if (git === true) {
       startSpinner(" Backing everything up in source control")
       try {
-        const isWindows = process.platform === "win32"
-
         // The separate commands works on Windows, but not Mac OS
         if (isWindows) {
           await system.run(log("git init"))
@@ -639,6 +675,15 @@ export default {
       p2("To run in Android, make sure you've followed the latest")
       p2(`react-native setup instructions. You reference them at:`)
       p2(`${link("https://reactnative.dev/docs/environment-setup")}`)
+      p2()
+    }
+
+    if (warnAboutEOL) {
+      hr()
+      p2()
+      p2(yellow(`Generator templates could not be converted to Windows EOL.`))
+      p2(yellow(`You may want to update these manually with your code editor, more info at:`))
+      p2(`${link("https://docs.infinite.red/ignite/concept/generators#windows")}`)
       p2()
     }
 

--- a/src/commands/new.ts
+++ b/src/commands/new.ts
@@ -683,7 +683,7 @@ export default {
       p2()
       p2(yellow(`Generator templates could not be converted to Windows EOL.`))
       p2(yellow(`You may want to update these manually with your code editor, more info at:`))
-      p2(`${link("https://docs.infinite.red/ignite/concept/generators#windows")}`)
+      p2(`${link("https://github.com/infinitered/ignite/blob/master/docs/Generators.md#windows")}`)
       p2()
     }
 

--- a/src/commands/new.ts
+++ b/src/commands/new.ts
@@ -562,7 +562,7 @@ export default {
       const templates = filesystem.find(`${targetPath}/ignite/templates`, {
         directories: false,
         files: true,
-        matching: "*.ts*.ejs",
+        matching: "*.ejs",
       })
 
       log(`unix2dos path: ${unixToDosPath}`)


### PR DESCRIPTION
## Please verify the following:

- [x] `Generators.md` has been updated with changes

## Describe your PR

- Closes #2253
- This attempts to autocorrect an EOL issue with the generator template files by doing the following:
  - Checks to see if running on Windows
  - Looks for the `unix2dos` cli utility
  - If found, applies this to each of the template files found from the boilerplate
  - If not found or application fails, will output a warning at the end of terminal output to check the EOL in templates
  - Added extra debug logging
- Updated documentation to make note about this issue with Windows

## Testing

This was manually tested by doing the following:
1. Clone `ignite-cli` project on a Windows machine
2. Convert `boilerplate\ignite\templates\**\*.ts*.ejs` files EOL to LF on purpose (likely CRLF after cloning)
3. Generate a new Pizza App locally, ie:
  `node bin/ignite new PizzaWin --overwrite --debug --install-deps=false --targetPath="C:\temp\PizzaWin" --git --bundle=com.pizzawin --remove-demo=false --packager=yarn`
5. Observe that the files in the project path's `ignite\templates` has the template files with the CRLF EOL

## Screenshots

### Terminal Warning Upon Failure

![image](https://github.com/infinitered/ignite/assets/374022/4393a391-6403-4499-bab9-4661b73a82ac)

### Extra Debug Logging

![image](https://github.com/infinitered/ignite/assets/374022/da091743-78d5-4756-9656-0bba2f534a8b)
