### PR TITLE
chore: remove bunfig disabling peer install

### DIFF
--- a/boilerplate/bunfig.toml
+++ b/boilerplate/bunfig.toml
@@ -1,2 +1,0 @@
-[install]
-peer = false

--- a/src/commands/new.ts
+++ b/src/commands/new.ts
@@ -601,10 +601,6 @@ module.exports = {
 
     // remove the gitignore template
     await removeAsync(".gitignore.template")
-    // remove bunfig.toml if not using bun
-    if (packagerName !== "bun") {
-      await removeAsync("bunfig.toml")
-    }
     // #endregion
 
     // #region Cache dependencies


### PR DESCRIPTION
## Describe your PR

- Related to #2522
- `bun` version 1.0.10 no longer has any peer dep install issues, so removing this `bunfig.toml` and related cli `new.ts` code (for removal when not utilizing `bun` as the package manager) for easier maintenance 
