### PR TITLE
fix(boilerplate): Podfile accounts for spaces in path

### DIFF
--- a/boilerplate/ios/Podfile
+++ b/boilerplate/ios/Podfile
@@ -1,8 +1,6 @@
-pod_folder = Pathname.new(__FILE__).dirname.realpath
-
-require File.join(File.dirname(`cd #{pod_folder} && node --print "require.resolve('expo/package.json')"`), "scripts/autolinking")
-require File.join(File.dirname(`cd #{pod_folder} && node --print "require.resolve('react-native/package.json')"`), "scripts/react_native_pods")
-require File.join(File.dirname(`cd #{pod_folder} && node --print "require.resolve('@react-native-community/cli-platform-ios/package.json')"`), "native_modules")
+require File.join(File.dirname(`node --print "require.resolve('expo/package.json')"`), "scripts/autolinking")
+require File.join(File.dirname(`node --print "require.resolve('react-native/package.json')"`), "scripts/react_native_pods")
+require File.join(File.dirname(`node --print "require.resolve('@react-native-community/cli-platform-ios/package.json')"`), "native_modules")
 
 require 'json'
 podfile_properties = JSON.parse(File.read(File.join(__dir__, 'Podfile.properties.json'))) rescue {}


### PR DESCRIPTION
## Please verify the following:

- [ ] `yarn test` **jest** tests pass with new tests, if relevant
- [ ] `README.md` has been updated with your changes, if relevant

## Describe your PR

- Closes #2493
- After some testing, you will encounter the error in the attached screenshot when there is a space in the pathname of the project directory on macOS
- This adjusts the `Podfile` to fix that issue

## Screenshots

![image](https://github.com/infinitered/ignite/assets/374022/2af3dc27-a1c4-4ef3-bb01-a3c05f245621)
