### PR TITLE
chore: update rn version, expo compat

### DIFF
--- a/boilerplate/app.json
+++ b/boilerplate/app.json
@@ -72,6 +72,6 @@
     }
   },
   "ignite": {
-    "version": "9.0.0"
+    "version": "UNKNOWN"
   }
 }

--- a/boilerplate/app.json
+++ b/boilerplate/app.json
@@ -70,5 +70,8 @@
     "experiments": {
       "tsconfigPaths": true
     }
+  },
+  "ignite": {
+    "version": "9.0.0"
   }
 }

--- a/boilerplate/package.json
+++ b/boilerplate/package.json
@@ -39,7 +39,7 @@
     "@shopify/flash-list": "^1.6.1",
     "apisauce": "3.0.1",
     "date-fns": "^2.30.0",
-    "expo": "^49.0.16",
+    "expo": "^49.0.18",
     "expo-application": "~5.4.0",
     "expo-build-properties": "~0.8.3",
     "expo-font": "~11.6.0",

--- a/src/commands/new.ts
+++ b/src/commands/new.ts
@@ -482,7 +482,8 @@ module.exports = {
       p()
 
       const pkg = pkgColor(packagerName)
-      p(` █ Creating ${em(projectName)} using ${em(`Ignite ${meta.version()}`)}`)
+      const igniteVersion = meta.version()
+      p(` █ Creating ${em(projectName)} using ${em(`Ignite ${igniteVersion}`)}`)
       p(` █ Powered by ${ir(" ∞ Infinite Red ")} (${link("https://infinite.red")})`)
       p(` █ Package Manager: ${pkg(print.colors.bold(packagerName))}`)
       p(` █ Bundle identifier: ${em(bundleIdentifier)}`)
@@ -644,26 +645,31 @@ module.exports = {
       }
       // #endregion
 
-      // #region Enable New Architecture if requested (must happen before prebuild)
-      if (experimentalNewArch === true) {
-        startSpinner(" Enabling New Architecture")
-        try {
-          const appJsonRaw = read("app.json")
-          const appJson = JSON.parse(appJsonRaw)
+      // #region Configure app.json
+      // Enable New Architecture if requested (must happen before prebuild)
+      startSpinner(" Configuring app.json")
+      try {
+        const appJsonRaw = read("app.json")
+        const appJson = JSON.parse(appJsonRaw)
+
+        // Inject ignite version to app.json
+        appJson.ignite.version = igniteVersion
+
+        if (experimentalNewArch === true) {
           appJson.expo.plugins[1][1].ios.newArchEnabled = true
           appJson.expo.plugins[1][1].android.newArchEnabled = true
 
           // Adding the "deploymentTarget" key is required for
           // @react-native-async-storage/async-storage to work in the new architecture
           appJson.expo.plugins[1][1].ios.deploymentTarget = "13.4"
-
-          write("./app.json", appJson)
-        } catch (e) {
-          log(e)
-          p(yellow("Unable to enable New Architecture."))
         }
-        stopSpinner(" Enabling New Architecture", "🆕")
+
+        write("./app.json", appJson)
+      } catch (e) {
+        log(e)
+        p(yellow("Unable to configure app.json."))
       }
+      stopSpinner(" Configuring app.json", "")
       // #endregion
 
       // #region Run Format

--- a/src/tools/expoGoCompatibility.ts
+++ b/src/tools/expoGoCompatibility.ts
@@ -8,7 +8,6 @@ export const expoGoCompatExpectedVersions = {
   "expo-font": "~11.4.0",
   "expo-localization": "~14.3.0",
   "@shopify/flash-list": "1.4.3",
-  "react-native": "0.72.5",
 }
 
 // This function takes a package.json file as a string and updates the versions of the


### PR DESCRIPTION
## Please verify the following:

- [ ] `yarn test` **jest** tests pass with new tests, if relevant
- [ ] `README.md` has been updated with your changes, if relevant

## Describe your PR
- add ignite version in `app.json` (this needs to become automated if possible)
- latest expo version has go compatible with rn 72.6 so we bump to that