### PR TITLE
fix(cli): remove demo markup if keeping demo files

### DIFF
--- a/src/commands/new.ts
+++ b/src/commands/new.ts
@@ -682,21 +682,21 @@ module.exports = {
       // #endregion
 
       // #region Remove Demo code
-      if (removeDemo === true) {
-        startSpinner(" Removing fancy demo code")
-        try {
-          const IGNITE = "node " + filesystem.path(__dirname, "..", "..", "bin", "ignite")
+      const removeDemoPart = removeDemo === true ? "code" : "markup"
+      startSpinner(` Removing fancy demo ${removeDemoPart}`)
+      try {
+        const IGNITE = "node " + filesystem.path(__dirname, "..", "..", "bin", "ignite")
+        const CMD = removeDemo === true ? "remove-demo" : "remove-demo-markup"
 
-          log(`Ignite bin path: ${IGNITE}`)
-          await system.run(`${IGNITE} remove-demo ${targetPath}`, {
-            onProgress: log,
-          })
-        } catch (e) {
-          log(e)
-          p(yellow("Unable to remove demo code."))
-        }
-        stopSpinner(" Removing fancy demo code", "🛠️")
+        log(`Ignite bin path: ${IGNITE}`)
+        await system.run(`${IGNITE} ${CMD} ${targetPath}`, {
+          onProgress: log,
+        })
+      } catch (e) {
+        log(e)
+        p(yellow(`Unable to remove demo ${removeDemoPart}.`))
       }
+      stopSpinner(` Removing fancy demo ${removeDemoPart}`, "🛠️")
       // #endregion
 
       // #region Format generator templates EOL for Windows

--- a/src/commands/remove-demo-markup.ts
+++ b/src/commands/remove-demo-markup.ts
@@ -47,7 +47,7 @@ module.exports = {
 
     // Run prettier at the end to clean up any spacing issues
     if (!dryRun) {
-      await system.run(`npx prettier@2.6.2 --write "./app/**/*.{js,jsx,json,md,ts,tsx}"`, {
+      await system.run(`npx prettier@2.8.1 --write "./app/**/*.{js,jsx,json,md,ts,tsx}"`, {
         trim: true,
       })
     }


### PR DESCRIPTION
## Describe your PR
- @jamonholmgren was looking to remove demo markup automatically if keeping the demo in place
- turns out `remove-demo-markup` never removed `remove-file` comments but now it does :D
