### PR TITLE
fix(boilerplate): TS version lock

### DIFF
--- a/boilerplate/package.json
+++ b/boilerplate/package.json
@@ -100,7 +100,7 @@
     "regenerator-runtime": "^0.13.4",
     "ts-jest": "^29.1.1",
     "ts-node": "^10.9.1",
-    "typescript": "^5.2.2"
+    "typescript": "5.2.2"
   },
   "expo": {
     "install": {


### PR DESCRIPTION
## Describe your PR
- Closes #2564 until TS Node fixes their issue with TypeScript 5.3.2
- We know TS 5.2.2 worked fine as that's the version we tested Ignite 9 on for months