### PR TITLE
feat(cli): remove unused deps upon demo removal

### DIFF
--- a/src/commands/new.ts
+++ b/src/commands/new.ts
@@ -30,6 +30,7 @@ import {
   expoGoCompatExpectedVersions,
   findAndUpdateDependencyVersions,
 } from "../tools/expoGoCompatibility"
+import { demoDependenciesToRemove, findAndRemoveDemoDependencies } from "../tools/demo"
 
 type Workflow = "expo" | "prebuild" | "manual"
 
@@ -564,6 +565,12 @@ module.exports = {
           packageJsonRaw,
           expoGoCompatExpectedVersions,
         )
+      }
+
+      // - If we're removing the demo code, clean up some dependencies that are no longer needed
+      if (removeDemo) {
+        log(`Removing demo dependencies... ${demoDependenciesToRemove.join(", ")}`)
+        packageJsonRaw = findAndRemoveDemoDependencies(packageJsonRaw)
       }
 
       // - Then write it back out.

--- a/src/tools/demo.ts
+++ b/src/tools/demo.ts
@@ -208,3 +208,22 @@ export const demo = {
   find,
   update,
 } as const
+
+export const demoDependenciesToRemove = [
+  "@react-navigation/bottom-tabs",
+  "expo-application",
+  "react-native-drawer-layout",
+]
+
+// This function takes a package.json file as a string and removes the dependencies
+// specified in demoDependenciesToRemove and returns the updated package.json as a string.
+export function findAndRemoveDemoDependencies(packageJsonRaw: string): string {
+  let updatedPackageJson = packageJsonRaw
+
+  demoDependenciesToRemove.forEach((depName) => {
+    const regex = new RegExp(`"${depName}"\\s*:\\s*"[^"]+",?`, "g")
+    updatedPackageJson = updatedPackageJson.replace(regex, "")
+  })
+
+  return updatedPackageJson
+}


### PR DESCRIPTION
## Describe your PR
- Closes #2544
- If the user decides to remove the demo application, there are a handful of dependencies that we can clean up out of the way that go unused with just the basic Welcome screen