### PR TITLE
fix: remove host from Reactotron.configure

### DIFF
--- a/boilerplate/app/devtools/ReactotronConfig.ts
+++ b/boilerplate/app/devtools/ReactotronConfig.ts
@@ -16,7 +16,6 @@ import { Reactotron } from "./ReactotronClient"
 
 const reactotron = Reactotron.configure({
   name: require("../../package.json").name,
-  host: "localhost",
   onConnect: () => {
     /** since this file gets hot reloaded, let's clear the past logs every time we connect */
     Reactotron.clear()


### PR DESCRIPTION
## Please verify the following:

- [x] `yarn test` **jest** tests pass with new tests, if relevant
- [x] `README.md` has been updated with your changes, if relevant

## Describe your PR

This PR removes `host: "localhost"` from the Reactotron configuration so that we can take advantage of this PR to automatically connect on Android https://github.com/infinitered/reactotron/pull/1311