### PR TITLE
fix(boilerplate): add expo-dev-client

### DIFF
--- a/boilerplate/package.json
+++ b/boilerplate/package.json
@@ -42,6 +42,7 @@
     "expo": "^49.0.21",
     "expo-application": "~5.4.0",
     "expo-build-properties": "~0.8.3",
+    "expo-dev-client": "~2.4.12",
     "expo-font": "~11.6.0",
     "expo-linking": "~5.0.2",
     "expo-localization": "~14.5.0",


### PR DESCRIPTION
## Describe your PR
- Adds `expo-dev-client` to boilerplate deps to get Expo's dev menu, build ready for EAS dev client builds etc