### PR TITLE
feat: add props for disabled styles in Button component

### DIFF
--- a/boilerplate/app/components/Button.tsx
+++ b/boilerplate/app/components/Button.tsx
@@ -70,6 +70,10 @@ export interface ButtonProps extends PressableProps {
    * https://reactnative.dev/docs/pressable#disabled
    */
   disabled?: boolean
+  /**
+   * An optional style override for the disabled state
+   */
+  disabledStyle?: StyleProp<ViewStyle>
 }
 
 /**
@@ -91,6 +95,7 @@ export function Button(props: ButtonProps) {
     RightAccessory,
     LeftAccessory,
     disabled,
+    disabledStyle,
     ...rest
   } = props
 
@@ -100,7 +105,7 @@ export function Button(props: ButtonProps) {
       $viewPresets[preset],
       $viewStyleOverride,
       !!pressed && [$pressedViewPresets[preset], $pressedViewStyleOverride],
-      disabled && { opacity: 0.5 },
+      disabled && disabledStyle,
     ]
   }
   function $textStyle({ pressed }: PressableStateCallbackType) {

--- a/boilerplate/app/components/Button.tsx
+++ b/boilerplate/app/components/Button.tsx
@@ -123,7 +123,13 @@ export function Button(props: ButtonProps) {
   }
 
   return (
-    <Pressable style={$viewStyle} accessibilityRole="button" {...rest} disabled={disabled}>
+    <Pressable
+      style={$viewStyle}
+      accessibilityRole="button"
+      accessibilityState={{ disabled: !!disabled }}
+      {...rest}
+      disabled={disabled}
+    >
       {(state) => (
         <>
           {!!LeftAccessory && <LeftAccessory style={$leftAccessoryStyle} pressableState={state} />}

--- a/boilerplate/app/components/Button.tsx
+++ b/boilerplate/app/components/Button.tsx
@@ -65,6 +65,10 @@ export interface ButtonProps extends PressableProps {
    * Children components.
    */
   children?: React.ReactNode
+  /**
+   * disabled prop, accessed directly for styling reasons.
+   */
+  disabled?: boolean
 }
 
 /**
@@ -85,6 +89,7 @@ export function Button(props: ButtonProps) {
     children,
     RightAccessory,
     LeftAccessory,
+    disabled,
     ...rest
   } = props
 
@@ -94,6 +99,7 @@ export function Button(props: ButtonProps) {
       $viewPresets[preset],
       $viewStyleOverride,
       !!pressed && [$pressedViewPresets[preset], $pressedViewStyleOverride],
+      disabled && { opacity: 0.5 },
     ]
   }
   function $textStyle({ pressed }: PressableStateCallbackType) {
@@ -105,7 +111,7 @@ export function Button(props: ButtonProps) {
   }
 
   return (
-    <Pressable style={$viewStyle} accessibilityRole="button" {...rest}>
+    <Pressable style={$viewStyle} accessibilityRole="button" {...rest} disabled={disabled}>
       {(state) => (
         <>
           {!!LeftAccessory && <LeftAccessory style={$leftAccessoryStyle} pressableState={state} />}

--- a/boilerplate/app/components/Button.tsx
+++ b/boilerplate/app/components/Button.tsx
@@ -15,6 +15,7 @@ type Presets = keyof typeof $viewPresets
 export interface ButtonAccessoryProps {
   style: StyleProp<any>
   pressableState: PressableStateCallbackType
+  disabled?: boolean
 }
 
 export interface ButtonProps extends PressableProps {

--- a/boilerplate/app/components/Button.tsx
+++ b/boilerplate/app/components/Button.tsx
@@ -48,6 +48,10 @@ export interface ButtonProps extends PressableProps {
    */
   pressedTextStyle?: StyleProp<TextStyle>
   /**
+   * An optional style override for the button text when in the "disabled" state.
+   */
+  disabledTextStyle?: StyleProp<TextStyle>
+  /**
    * One of the different types of button presets.
    */
   preset?: Presets
@@ -91,6 +95,7 @@ export function Button(props: ButtonProps) {
     pressedStyle: $pressedViewStyleOverride,
     textStyle: $textStyleOverride,
     pressedTextStyle: $pressedTextStyleOverride,
+    disabledTextStyle: $disabledTextStyleOverride,
     children,
     RightAccessory,
     LeftAccessory,
@@ -113,6 +118,7 @@ export function Button(props: ButtonProps) {
       $textPresets[preset],
       $textStyleOverride,
       !!pressed && [$pressedTextPresets[preset], $pressedTextStyleOverride],
+      disabled && $disabledTextStyleOverride,
     ]
   }
 

--- a/boilerplate/app/components/Button.tsx
+++ b/boilerplate/app/components/Button.tsx
@@ -100,7 +100,7 @@ export function Button(props: ButtonProps) {
     RightAccessory,
     LeftAccessory,
     disabled,
-    disabledStyle,
+    disabledStyle: $disabledViewStyleOverride,
     ...rest
   } = props
 
@@ -110,7 +110,7 @@ export function Button(props: ButtonProps) {
       $viewPresets[preset],
       $viewStyleOverride,
       !!pressed && [$pressedViewPresets[preset], $pressedViewStyleOverride],
-      disabled && disabledStyle,
+      !!disabled && $disabledViewStyleOverride,
     ]
   }
   function $textStyle({ pressed }: PressableStateCallbackType) {
@@ -118,7 +118,7 @@ export function Button(props: ButtonProps) {
       $textPresets[preset],
       $textStyleOverride,
       !!pressed && [$pressedTextPresets[preset], $pressedTextStyleOverride],
-      disabled && $disabledTextStyleOverride,
+      !!disabled && $disabledTextStyleOverride,
     ]
   }
 

--- a/boilerplate/app/components/Button.tsx
+++ b/boilerplate/app/components/Button.tsx
@@ -66,7 +66,8 @@ export interface ButtonProps extends PressableProps {
    */
   children?: React.ReactNode
   /**
-   * disabled prop, accessed directly for styling reasons.
+   * disabled prop, accessed directly for declarative styling reasons.
+   * https://reactnative.dev/docs/pressable#disabled
    */
   disabled?: boolean
 }

--- a/boilerplate/app/components/Button.tsx
+++ b/boilerplate/app/components/Button.tsx
@@ -132,14 +132,20 @@ export function Button(props: ButtonProps) {
     >
       {(state) => (
         <>
-          {!!LeftAccessory && <LeftAccessory style={$leftAccessoryStyle} pressableState={state} />}
+          {!!LeftAccessory && (
+            <LeftAccessory style={$leftAccessoryStyle} pressableState={state} disabled={disabled} />
+          )}
 
           <Text tx={tx} text={text} txOptions={txOptions} style={$textStyle(state)}>
             {children}
           </Text>
 
           {!!RightAccessory && (
-            <RightAccessory style={$rightAccessoryStyle} pressableState={state} />
+            <RightAccessory
+              style={$rightAccessoryStyle}
+              pressableState={state}
+              disabled={disabled}
+            />
           )}
         </>
       )}

--- a/boilerplate/app/screens/DemoShowroomScreen/demos/DemoButton.tsx
+++ b/boilerplate/app/screens/DemoShowroomScreen/demos/DemoButton.tsx
@@ -27,6 +27,12 @@ const $customButtonRightAccessoryStyle: ViewStyle = {
 }
 const $customButtonPressedRightAccessoryStyle: ImageStyle = { tintColor: colors.palette.neutral100 }
 
+const $disabledOpacity: ViewStyle = { opacity: 0.5 }
+const $disabledButtonTextStyle: TextStyle = {
+  color: colors.palette.neutral100,
+  textDecorationColor: colors.palette.neutral100,
+}
+
 export const DemoButton: Demo = {
   name: "Button",
   description:
@@ -134,6 +140,71 @@ export const DemoButton: Demo = {
         )}
       >
         Style Pressed State - fugiat anim
+      </Button>
+    </DemoUseCase>,
+
+    <DemoUseCase
+      name="Disabling"
+      description="The component can be disabled, and styled based on that. Press behavior will be disabled."
+    >
+      <Button
+        disabled
+        disabledStyle={$disabledOpacity}
+        pressedStyle={$customButtonPressedStyle}
+        pressedTextStyle={$customButtonPressedTextStyle}
+      >
+        Disabled - standard
+      </Button>
+      <DemoDivider />
+
+      <Button
+        disabled
+        preset="filled"
+        disabledStyle={$disabledOpacity}
+        pressedStyle={$customButtonPressedStyle}
+        pressedTextStyle={$customButtonPressedTextStyle}
+      >
+        Disabled - filled
+      </Button>
+      <DemoDivider />
+
+      <Button
+        disabled
+        preset="reversed"
+        disabledStyle={$disabledOpacity}
+        pressedStyle={$customButtonPressedStyle}
+        pressedTextStyle={$customButtonPressedTextStyle}
+      >
+        Disabled - reversed
+      </Button>
+      <DemoDivider />
+
+      <Button
+        disabled
+        pressedStyle={$customButtonPressedStyle}
+        pressedTextStyle={$customButtonPressedTextStyle}
+        RightAccessory={(props) => (
+          <View
+            style={
+              props.disabled
+                ? [$customButtonRightAccessoryStyle, $disabledOpacity]
+                : $customButtonPressedRightAccessoryStyle
+            }
+          />
+        )}
+      >
+        Disabled accessory style
+      </Button>
+      <DemoDivider />
+
+      <Button
+        disabled
+        preset="filled"
+        disabledTextStyle={[$customButtonTextStyle, $disabledButtonTextStyle]}
+        pressedStyle={$customButtonPressedStyle}
+        pressedTextStyle={$customButtonPressedTextStyle}
+      >
+        Disabled text style
       </Button>
     </DemoUseCase>,
   ],

--- a/docs/boilerplate/components/Button.md
+++ b/docs/boilerplate/components/Button.md
@@ -100,6 +100,14 @@ The `pressedTextStyle` prop is optional. This can be used to style text in the b
 <Button pressedTextStyle={{ fontSize: 20, color: "#a51111" }} />
 ```
 
+### `disabledTextStyle`
+
+The `disabledTextStyle` prop is optional. It can be used to style text in the button when the `disabled` prop is set. Values here will override anything set in the preset.
+
+```tsx
+<Button disabled disabledTextStyle={{ fontSize: 20, color: "#000000" }} />
+```
+
 ### `style`
 
 The `style` prop is optional. This can be used to style the `Pressable` component of the `Button`. Values passed here will override anything set in the preset.
@@ -114,6 +122,14 @@ The `pressedStyle` prop is optional. This can be used to style the `Pressable` c
 
 ```tsx
 <Button pressedStyle={{ backgroundColor: "red" }} />
+```
+
+### `disabledStyle`
+
+The `disabledStyle` prop is optional. This can be used to style the `Pressable` component of the `Button` when the `disabled` prop is truthy. Values passed here will voerride anything set in the preset.
+
+```tsx
+<Button disabledStyle={{ opacity: 0.5 }} />
 ```
 
 ### `LeftAccessory` and `RightAccessory`
@@ -149,3 +165,9 @@ If the accessories flicker when some prop or state changes, you can memoize the 
   )}
 />
 ```
+
+### `disabled`
+
+The `disabled` prop is optional. It gets passed to the underlying `Pressable` component. When truthy, it will [disable the press behavior on the pressable](https://reactnative.dev/docs/pressable#disabled). It will also update the [`accessibilityState`](https://reactnative.dev/docs/0.72/touchablewithoutfeedback#accessibilitystate) of the `Pressable` when set.
+
+This prop will be passed down to the `LeftAccessory` and `RightAccessory` components, if they exist, and will cause the `disabledStyle` and `disabledTextStyle` props to be used, if they have been set.

--- a/docs/boilerplate/components/Button.md
+++ b/docs/boilerplate/components/Button.md
@@ -126,7 +126,7 @@ The `pressedStyle` prop is optional. This can be used to style the `Pressable` c
 
 ### `disabledStyle`
 
-The `disabledStyle` prop is optional. This can be used to style the `Pressable` component of the `Button` when the `disabled` prop is truthy. Values passed here will voerride anything set in the preset.
+The `disabledStyle` prop is optional. This can be used to style the `Pressable` component of the `Button` when the `disabled` prop is truthy. Values passed here will override anything set in the preset.
 
 ```tsx
 <Button disabledStyle={{ opacity: 0.5 }} />


### PR DESCRIPTION
## Please verify the following:

- [x] `yarn test` **jest** tests pass with new tests, if relevant (one failure, I'll post details in the PR description)
- [x] `README.md` has been updated with your changes, if relevant (I don't think it's relevant for this one)

## Describe your PR

I was copying Ignite's `Button` component into my own codebase and wanted to have a disabled `Button` visually indicated with some custom styles. This change was really helpful for me, so I wanted to propose it to y'all while I wait for my CI to pass haha.

No worries if you're not interested, I imagine folks could style this from outside by syncing up some conditional styles with any conditions they use to set the `disabled` prop, but I kind of like that this reads the `disabled` prop directly at author-time and behaves as expected.

Let me know what ya think. Happy to rework anything you'd like. Thanks one way or another!

## Test failures

I had one set of test failures, but I don't think they're related to this change. I get the same results on the `master` branch in my fork.

<details>
Output: 

```sh
in ~/forked-ignite on feat/add-disabled-styles-to-ignite-button λ yarn test
yarn run v1.22.11
$ TS_JEST_DISABLE_VER_CHECKER=true jest
 PASS  src/tools/demo.test.ts
 PASS  src/tools/packager.test.ts
 PASS  test/vanilla/ignite-help.test.ts (9.151 s)
 PASS  test/vanilla/ignite-remove-demo.test.ts (9.492 s)
 PASS  test/vanilla/ignite-generate.test.ts (31.918 s)
 FAIL  test/vanilla/ignite-new.test.ts (277.184 s)
  ● ignite new › ignite new Foo --debug --packager=bun --yes › should be able to use `generate` command and have pass output pass bun run test, bun run lint, and bun run compile scripts

    Command failed: cd /private/var/folders/4y/6gtftfw936v8f4p7tzjdxl900000gn/T/ignite-e58e9255968265d5869ac97b0bed02d4/Foo && bun run test && cd /Users/tylerwilliams/forked-ignite
    $ jest
     FAIL  test/i18n.test.ts
      ● Test suite failed to run

        TypeError: Cannot redefine property: performance

          at Object.<anonymous> (node_modules/react-native/jest/setup.js:410:20)

     FAIL  app/models/Episode.test.ts
      ● Test suite failed to run

        TypeError: Cannot redefine property: performance

          at Object.<anonymous> (node_modules/react-native/jest/setup.js:410:20)

     FAIL  app/utils/storage/storage.test.ts
      ● Test suite failed to run

        TypeError: Cannot redefine property: performance

          at Object.<anonymous> (node_modules/react-native/jest/setup.js:410:20)

     FAIL  app/models/ModTest.test.ts
      ● Test suite failed to run

        TypeError: Cannot redefine property: performance

          at Object.<anonymous> (node_modules/react-native/jest/setup.js:410:20)

     FAIL  app/services/api/apiProblem.test.ts
      ● Test suite failed to run

        TypeError: Cannot redefine property: performance

          at Object.<anonymous> (node_modules/react-native/jest/setup.js:410:20)

    Test Suites: 5 failed, 5 total
    Tests:       0 total
    Snapshots:   0 total
    Time:        5.374 s
    Ran all test suites.
    error: script "test" exited with code 1 (SIGHUP)



Test Suites: 1 failed, 5 passed, 6 total
Tests:       1 failed, 33 passed, 34 total
Snapshots:   31 passed, 31 total
Time:        278.093 s
Ran all test suites.
error Command failed with exit code 1.
info Visit https://yarnpkg.com/en/docs/cli/run for documentation about this command.
tylerwilliams in ~/forked-ignite on feat/add-disabled-styles-to-ignite-button λ 
```
</details>