### PR TITLE
fixes #2596 back button error on web

### DIFF
--- a/boilerplate/app/navigators/navigationUtilities.ts
+++ b/boilerplate/app/navigators/navigationUtilities.ts
@@ -44,8 +44,8 @@ export function getActiveRouteName(state: NavigationState | PartialState<Navigat
  * the navigation or allows exiting the app.
  */
 export function useBackButtonHandler(canExit: (routeName: string) => boolean) {
-  // ignore if iOS ... no back button!
-  if (Platform.OS === "ios") return
+  // ignore unless android... no back button!
+  if (Platform.OS !== "android") return
 
   // The reason we're using a ref here is because we need to be able
   // to update the canExit function without re-setting up all the listeners


### PR DESCRIPTION
`BackButton` is only on android, so instead of checking if the platform isn't iOS, check that it isn't android

## Please verify the following:

- [x] `yarn test` **jest** tests pass with new tests, if relevant
- [ ] `README.md` has been updated with your changes, if relevant

## Describe your PR
Fixes #2596 