### PR TITLE
fix(cli): remove expo-dev-client for Expo Go

### DIFF
--- a/src/tools/expoGoCompatibility.ts
+++ b/src/tools/expoGoCompatibility.ts
@@ -27,5 +27,8 @@ export function findAndUpdateDependencyVersions(
     updatedPackageJson = updatedPackageJson.replace(regex, `"${depName}": "${desiredVersion}"`)
   })
 
+  // Make sure `expo-dev-client` is removed
+  updatedPackageJson = updatedPackageJson.replace(/"expo-dev-client"\s*:\s*"[^"]+",?/g, "")
+
   return updatedPackageJson
 }


### PR DESCRIPTION
## Describe your PR
- Closes #2600 
- Removes `expo-dev-client` from the package.json in the spot where we look to revert later dependencies to the Expo Go compatible ones

## Tested locally with:

```
ignite/bin/ignite new ignite-dev-client --yes
cd ignite-dev-client
# nothing found here
cat package.json|grep "expo-dev-client"
# boots up without error
yarn ios
```