### PR TITLE
feat(only-use-internal-diff)

### DIFF
--- a/test/vanilla/ignite-new.test.ts
+++ b/test/vanilla/ignite-new.test.ts
@@ -262,7 +262,7 @@ describe("ignite new", () => {
       await run(`bun run test`, runOpts)
       await run(`bun run lint`, runOpts)
       await run(`bun run compile`, runOpts)
-      expect(await run("git diff HEAD", runOpts)).toContain("+  Bowser: undefined")
+      expect(await run("git diff HEAD --no-ext-diff", runOpts)).toContain("+  Bowser: undefined")
       // #endregion
 
       // we're done!


### PR DESCRIPTION
## Please verify the following:

- [x] `yarn test` **jest** tests pass with new tests, if relevant
- [ ] ~`README.md` has been updated with your changes, if relevant~

## Describe your PR
If you have your `git diff` configured with an external diff tool, the tests will not pass because it relies on the output of the internal `git diff` command. This updates  the command lines arguments for consistency to force `git` to use the internal diff tool always for the spec. (Docs: https://git-scm.com/docs/git-diff#Documentation/git-diff.txt---no-ext-diff)
