### PR TITLE
feat(cli): split expo workflow decision tree, use 'cng' instead of 'prebuild'

### DIFF
--- a/docs/cli/Ignite-CLI.md
+++ b/docs/cli/Ignite-CLI.md
@@ -101,8 +101,8 @@ Starts the interactive prompt for generating a new Ignite project. Any options n
 - `--useCache` flag specifying to use dependency cache for quicker installs
 - `--no-timeout` flag to disable the timeout protection (useful for slow internet connections)
 - `--yes` accept all prompt defaults
-- `--workflow` string, one of `expo`, `prebuild` or `manual` for project initialization
-- `--experimental` comma separated string, indicates experimental features (which may or may not be stable) to turn on during installation. **A prebuild workflow is require for these flags** `--workflow=prebuild`
+- `--workflow` string, one of `expo`, `cng` or `manual` for project initialization
+- `--experimental` comma separated string, indicates experimental features (which may or may not be stable) to turn on during installation. **A CNG workflow is require for these flags** `--workflow=cng`
   - `new-arch` enables [The New Architecture](https://reactnative.dev/docs/new-architecture-intro)
   - `expo-canary` uses Expo's highly experimental canary release instead of the la test stable SDK
   - `expo-beta` uses Expo's latest beta SDK available instead of the latest stable SDK

--- a/test/vanilla/ignite-new.test.ts
+++ b/test/vanilla/ignite-new.test.ts
@@ -269,14 +269,14 @@ describe("ignite new", () => {
     })
   })
 
-  describe(`ignite new ${APP_NAME} --debug --packager=bun --workflow=prebuild --yes`, () => {
+  describe(`ignite new ${APP_NAME} --debug --packager=bun --workflow=cng --yes`, () => {
     let tempDir: string
     let result: string
     let appPath: string
 
     beforeAll(async () => {
       tempDir = tempy.directory({ prefix: "ignite-" })
-      result = await runIgnite(`new ${APP_NAME} --debug --packager=bun --workflow=prebuild --yes`, {
+      result = await runIgnite(`new ${APP_NAME} --debug --packager=bun --workflow=cng --yes`, {
         pre: `cd ${tempDir}`,
         post: `cd ${originalDir}`,
       })


### PR DESCRIPTION
## Please verify the following:

- [x] `yarn test` **jest** tests pass with new tests, if relevant
- [x] `README.md` has been updated with your changes, if relevant

## Describe your PR
- Adds an extra step in the decision tree for `ignite-cli new`: `Do you want to use Expo?`
- Adds `cng` workflow type to replace `prebuild`, to match [Expo's naming](https://docs.expo.dev/workflow/continuous-native-generation/). Deprecated `prebuild` for potential future removal. 

Note: References new Ignite Cookbook recipe from https://github.com/infinitered/ignite-cookbook/pull/116

## Screenshots
<img width="1016" alt="image" src="https://github.com/infinitered/ignite/assets/5148640/268e85c1-51e0-4a91-9726-02a20e877aad">

<img width="1383" alt="image" src="https://github.com/infinitered/ignite/assets/5148640/f3b3cece-5b5e-4a8b-8a43-c0e8af1bb815">
