### PR TITLE
Fixed doc link inside `useSafeAreaInsetsStyle`

### DIFF
--- a/boilerplate/app/utils/useSafeAreaInsetsStyle.ts
+++ b/boilerplate/app/utils/useSafeAreaInsetsStyle.ts
@@ -20,7 +20,7 @@ const edgeInsetMap: Record<string, Edge> = {
 /**
  * A hook that can be used to create a safe-area-aware style object that can be passed directly to a View.
  *
- * - [Documentation and Examples](https://github.com/infinitered/ignite/blob/master/docs/Utils-useSafeAreaInsetsStyle.md)
+ * - [Documentation and Examples](https://github.com/infinitered/ignite/blob/master/docs/boilerplate/utility/useSafeAreaInsetsStyle.md)
  */
 export function useSafeAreaInsetsStyle(
   safeAreaEdges: ExtendedEdge[] = [],


### PR DESCRIPTION
## Please verify the following:

- [x] `yarn test` **jest** tests pass with new tests, if relevant
- [x] `README.md` has been updated with your changes, if relevant

## Describe your PR

Simple one updating the docs link inside `useSafeAreaInsetsStyle.ts`.

|  Before 😢 | After 🙂 |
| --|--|
| ![before](https://github.com/infinitered/ignite/assets/47733004/31ab5917-be7e-4eba-85a0-2720a7bea147) | ![after](https://github.com/infinitered/ignite/assets/47733004/d0dc2347-a883-42ad-8bdf-af2ee72575a0) |


