### PR TITLE
fix(typescript): useInitialRootStore callback should be optional

### DIFF
--- a/boilerplate/app/models/helpers/useStores.ts
+++ b/boilerplate/app/models/helpers/useStores.ts
@@ -47,7 +47,7 @@ export const useStores = () => useContext(RootStoreContext)
  * and then rehydrates it. It connects everything with Reactotron
  * and then lets the app know that everything is ready to go.
  */
-export const useInitialRootStore = (callback: () => void | Promise<void>) => {
+export const useInitialRootStore = (callback?: () => void | Promise<void>) => {
   const rootStore = useStores()
   const [rehydrated, setRehydrated] = useState(false)
 


### PR DESCRIPTION
## Please verify the following:

- [x] `yarn test` **jest** tests pass with new tests, if relevant
- [x] `README.md` has been updated with your changes, if relevant

## Describe your PR

`useInitialRootStore` callback should be optional for cases where the callback isn't needed. 
Discovered after Igniting new project for use with Expo Router: 

```
  const { rehydrated } = useInitialRootStore() // TS error
  if (!rehydrated) {
    return null
  }
```
