### PR TITLE
fix(maestro): update maestro test dynamically select a podcast

### DIFF
--- a/boilerplate/.maestro/FavoritePodcast.yaml
+++ b/boilerplate/.maestro/FavoritePodcast.yaml
@@ -2,7 +2,6 @@
 
 appId: com.helloworld
 env:
-  TITLE: "RNR 286 - What's New in React Native 0.73"
   FAVORITES_TEXT: "Switch on to only show favorites"
 
 ---
@@ -16,14 +15,14 @@ env:
     text: ${FAVORITES_TEXT}
     # https://maestro.mobile.dev/troubleshooting/known-issues#android-accidental-double-tap
     retryTapIfNoChange: false
-- scrollUntilVisible:
-    element:
-      text: ${TITLE}
-    direction: DOWN
-    timeout: 50000
-    speed: 40
-    visibilityPercentage: 100
-- longPressOn: ${TITLE}
+- repeat:
+    times: 2
+    commands:
+      - scroll
+- copyTextFrom:
+    text: "^RNR.*" # assumes all podcast titles start with RNR
+    index: 1 # grab the second one, the first one might not be fully visible
+- longPressOn: ${maestro.copiedText}
 - scrollUntilVisible:
     element:
       text: ${FAVORITES_TEXT}
@@ -33,6 +32,5 @@ env:
     visibilityPercentage: 100
 - tapOn:
     text: ${FAVORITES_TEXT}
-- assertVisible: ${TITLE}
-
+- assertVisible: ${maestro.copiedText}
 # @demo remove-file

--- a/boilerplate/.maestro/FavoritePodcast.yaml
+++ b/boilerplate/.maestro/FavoritePodcast.yaml
@@ -2,7 +2,7 @@
 
 appId: com.helloworld
 env:
-  TITLE: "RNR 257 - META RESPONDS! How can we improve React Native, part 2"
+  TITLE: "RNR 286 - What's New in React Native 0.73"
   FAVORITES_TEXT: "Switch on to only show favorites"
 
 ---


### PR DESCRIPTION
## Please verify the following:

- [x] `yarn test` **jest** tests pass with new tests, if relevant
- [x] `yarn lint` **eslint** checks pass with new code, if relevant
- [x] `yarn format:check` **prettier** checks pass with new code, if relevant
- [x] `README.md` (or relevant documentation) has been updated with your changes

## Describe your PR
Demo app only returns 10 most recent podcasts from the API call. 
Our Maestro test was failing because it was searching for a podcast episode further back, which wasn't displayed. 

Rather than hardcoding an episode title, which would go out-of-date every few months, I updated the test to scroll down a bit and dynamically grab a visible episode. 