### PR TITLE
fix(jest): remove jest.useFakeTimers in setup

### DIFF
--- a/boilerplate/test/setup.ts
+++ b/boilerplate/test/setup.ts
@@ -41,7 +41,6 @@ jest.mock("expo-localization", () => ({
 
 declare const tron // eslint-disable-line @typescript-eslint/no-unused-vars
 
-jest.useFakeTimers()
 declare global {
   let __TEST__: boolean
 }


### PR DESCRIPTION
## Please verify the following:

- [x] `yarn test` **jest** tests pass with new tests, if relevant
- [x] `yarn lint` **eslint** checks pass with new code, if relevant
- [x] `yarn format:check` **prettier** checks pass with new code, if relevant
- [x] `README.md` (or relevant documentation) has been updated with your changes

## Describe your PR
This line was breaking potential React Native Testing Library support, and isn't needed for the original boilerplate test anymore. 

Bye, felicia!