### PR TITLE
fix (localization): Guard against i18n errors for older Android platforms

### DIFF
--- a/boilerplate/app/i18n/i18n.ts
+++ b/boilerplate/app/i18n/i18n.ts
@@ -13,9 +13,9 @@ i18n.fallbacks = true
 // to use regional locales use { "en-US": enUS } etc
 i18n.translations = { ar, en, "en-US": en, ko, fr }
 
-const fallbackLocale = "en"
+const fallbackLocale = "en-US"
 const systemLocale = Localization.getLocales()[0]
-const systemLocaleTag = systemLocale.languageTag
+const systemLocaleTag = systemLocale?.languageTag ?? "en-US"
 
 if (Object.prototype.hasOwnProperty.call(i18n.translations, systemLocaleTag)) {
   // if specific locales like en-FI or en-US is available, set it
@@ -31,7 +31,7 @@ if (Object.prototype.hasOwnProperty.call(i18n.translations, systemLocaleTag)) {
 }
 
 // handle RTL languages
-export const isRTL = systemLocale.textDirection === "rtl"
+export const isRTL = systemLocale?.textDirection === "rtl"
 I18nManager.allowRTL(isRTL)
 I18nManager.forceRTL(isRTL)
 


### PR DESCRIPTION


## Please verify the following:

- [x] `yarn test` **jest** tests pass with new tests, if relevant
- [x] `yarn lint` **eslint** checks pass with new code, if relevant
- [x] `yarn format:check` **prettier** checks pass with new code, if relevant
- [x] `README.md` (or relevant documentation) has been updated with your changes

## Describe your PR

On certain older platforms, the `systemLocale` returned by `expo-localization` might be invalid, leading to a crash when `systemLocale.languageTag` or `systemLocale.textDirection` are referenced. This PR just adds optional chaining for these references and defaults to `en-US` if there is a problem.

Also changed the default locale from `en` to `en-US` to fix an Apple TV issue, but this may have already been dealt with in #2622 .

Reviewers: if desired, we could add `console.warn()` calls if this condition is encountered, but `expo-localization` is already writing Android logcats if there are errors.
