### PR TITLE
fix(boilerplate): jest.config.js remove jsdom test env

### DIFF
--- a/boilerplate/jest.config.js
+++ b/boilerplate/jest.config.js
@@ -25,7 +25,6 @@ module.exports = {
     "jest-runner",
   ],
   testPathIgnorePatterns: ["<rootDir>/node_modules/", "<rootDir>/.maestro/", "@react-native"],
-  testEnvironment: "jsdom",
   setupFiles: ["<rootDir>/test/setup.ts"],
   transform:{
     '^.+\\.test.tsx?$': ['ts-jest', {


### PR DESCRIPTION
## Please verify the following:

- [x] `yarn test` **jest** tests pass with new tests, if relevant
- [x] `yarn lint` **eslint** checks pass with new code, if relevant
- [x] `yarn format:check` **prettier** checks pass with new code, if relevant
- [x] `README.md` (or relevant documentation) has been updated with your changes

## Describe your PR
- Closes #2605
- Better RNTL support out of box
- testEnvironment `jsdom` should only be used for web (which although we support, isn't our main target)