### PR TITLE
fix(boilerplate): remove `yarn prebuild` script in favor of clean

### DIFF
--- a/boilerplate/package.json
+++ b/boilerplate/package.json
@@ -27,8 +27,7 @@
     "web": "npx expo start --web",
     "bundle:web": "npx expo export --platform web",
     "serve:web": "npx server dist",
-    "prebuild:clean": "npx expo prebuild --clean",
-    "prebuild": "npx expo prebuild"
+    "prebuild:clean": "npx expo prebuild --clean"
   },
   "dependencies": {
     "@expo-google-fonts/space-grotesk": "^0.2.2",

--- a/docs/boilerplate/android.md
+++ b/docs/boilerplate/android.md
@@ -5,7 +5,7 @@ sidebar_position: 20
 
 # `android`
 
-If you choose the `DIY` option when spinning up a new app (or you run `yarn prebuild`) you'll get an `android` (and probably [`ios`](./ios.md)) folder in your project root. This folder contains your native Android / Android Studio project, which has been pre-configured to work with React Native.
+If you choose the `DIY` option when spinning up a new app (or you run `yarn prebuild:clean`) you'll get an `android` (and probably [`ios`](./ios.md)) folder in your project root. This folder contains your native Android / Android Studio project, which has been pre-configured to work with React Native.
 
 We generally recommend using the [Expo CNG (continuous native generation)](../expo/CNG.md) workflow, but if you need to customize your native code manually, you can do so here.
 

--- a/docs/boilerplate/ios.md
+++ b/docs/boilerplate/ios.md
@@ -5,7 +5,7 @@ sidebar_position: 20
 
 # `ios` folder
 
-If you choose the `DIY` option when spinning up a new app (or you run `yarn prebuild`) you'll get an `ios` (and probably [`android`](./android.md)) folder in your project root. This folder contains your native iOS / Xcode project, which has been pre-configured to work with React Native.
+If you choose the `DIY` option when spinning up a new app (or you run `yarn prebuild:clean`) you'll get an `ios` (and probably [`android`](./android.md)) folder in your project root. This folder contains your native iOS / Xcode project, which has been pre-configured to work with React Native.
 
 We generally recommend using the [Expo CNG (continuous native generation)](../expo/CNG.md) workflow, but if you need to customize your native code manually, you can do so here.
 


### PR DESCRIPTION
## Please verify the following:

- [x] `yarn test` **jest** tests pass with new tests, if relevant
- [x] `yarn lint` **eslint** checks pass with new code, if relevant
- [x] `yarn format:check` **prettier** checks pass with new code, if relevant
- [x] `README.md` (or relevant documentation) has been updated with your changes

## Describe your PR
- Removes `yarn prebuild` script in favor of just using the clean one, no real need for it, and likely will run into more problems using it than without