### PR TITLE
fix(components): switch animation slide on web

### DIFF
--- a/boilerplate/app/components/Toggle.tsx
+++ b/boilerplate/app/components/Toggle.tsx
@@ -3,6 +3,7 @@ import {
   GestureResponderEvent,
   Image,
   ImageStyle,
+  Platform,
   StyleProp,
   SwitchProps,
   TextInputProps,
@@ -456,14 +457,17 @@ function Switch(props: ToggleInputProps) {
       $switchInner?.paddingRight ||
       0) as number
 
+    // For RTL support:
+    // - web flip input range to [1,0]
+    // - outputRange doesn't want rtlAdjustment
     const rtlAdjustment = isRTL ? -1 : 1
+    const inputRange = Platform.OS === "web" ? (isRTL ? [1, 0] : [0, 1]) : [0, 1]
+    const outputRange =
+      Platform.OS === "web"
+        ? [offsetLeft, +(knobWidth || 0) + offsetRight]
+        : [rtlAdjustment * offsetLeft, rtlAdjustment * (+(knobWidth || 0) + offsetRight)]
 
-    const translateX = interpolate(
-      on ? 1 : 0,
-      [0, 1],
-      [rtlAdjustment * offsetLeft, rtlAdjustment * (+(knobWidth || 0) + offsetRight)],
-      Extrapolation.CLAMP,
-    )
+    const translateX = interpolate(on ? 1 : 0, inputRange, outputRange, Extrapolation.CLAMP)
 
     return { transform: [{ translateX: withTiming(translateX) }] }
   }, [on, knobWidth])

--- a/boilerplate/app/components/Toggle.tsx
+++ b/boilerplate/app/components/Toggle.tsx
@@ -13,10 +13,16 @@ import {
   ViewProps,
   ViewStyle,
 } from "react-native"
-import Animated, { useAnimatedStyle, withTiming } from "react-native-reanimated"
+import Animated, {
+  Extrapolation,
+  interpolate,
+  useAnimatedStyle,
+  withTiming,
+} from "react-native-reanimated"
 import { colors, spacing } from "../theme"
 import { iconRegistry, IconTypes } from "./Icon"
 import { Text, TextProps } from "./Text"
+import { isRTL } from "app/i18n"
 
 type Variants = "checkbox" | "switch" | "radio"
 
@@ -450,10 +456,14 @@ function Switch(props: ToggleInputProps) {
       $switchInner?.paddingRight ||
       0) as number
 
-    const start = withTiming(on ? "100%" : "0%")
-    const marginStart = withTiming(on ? -(knobWidth || 0) - offsetRight : 0 + offsetLeft)
+    const translateX = interpolate(
+      on ? 1 : 0,
+      isRTL ? [1, 0] : [0, 1],
+      [0 + offsetLeft, +(knobWidth || 0) + offsetRight],
+      Extrapolation.CLAMP,
+    )
 
-    return { start, marginStart }
+    return { transform: [{ translateX: withTiming(translateX) }] }
   }, [on, knobWidth])
 
   return (

--- a/boilerplate/app/components/Toggle.tsx
+++ b/boilerplate/app/components/Toggle.tsx
@@ -456,10 +456,12 @@ function Switch(props: ToggleInputProps) {
       $switchInner?.paddingRight ||
       0) as number
 
+    const rtlAdjustment = isRTL ? -1 : 1
+
     const translateX = interpolate(
       on ? 1 : 0,
-      isRTL ? [1, 0] : [0, 1],
-      [0 + offsetLeft, +(knobWidth || 0) + offsetRight],
+      [0, 1],
+      [rtlAdjustment * offsetLeft, rtlAdjustment * (+(knobWidth || 0) + offsetRight)],
       Extrapolation.CLAMP,
     )
 


### PR DESCRIPTION
## Please verify the following:

- [x] `yarn test` **jest** tests pass with new tests, if relevant
- [x] `yarn lint` **eslint** checks pass with new code, if relevant
- [x] `yarn format:check` **prettier** checks pass with new code, if relevant
- [x] `README.md` (or relevant documentation) has been updated with your changes

## Describe your PR
- Closes #2637
- Replaces usage of `marginStart` for where to put the knob in favor of `translateX`

## Screenshots

### Web

![toggle-fix-web](https://github.com/infinitered/ignite/assets/374022/331e43ae-0a38-4805-ba65-530144dc740c)


### iOS example (and RTL)

https://github.com/infinitered/ignite/assets/374022/4bfa3b07-f3c9-442e-9603-57f2272b49f3




