### PR TITLE
fix(boilerplate): web hmr fixes

### DIFF
--- a/boilerplate/App.tsx
+++ b/boilerplate/App.tsx
@@ -1,6 +1,7 @@
-import App from "./app/app"
+import "@expo/metro-runtime"
 import React from "react"
 import * as SplashScreen from "expo-splash-screen"
+import App from "./app/app"
 
 SplashScreen.preventAutoHideAsync()
 

--- a/boilerplate/package.json
+++ b/boilerplate/package.json
@@ -32,7 +32,7 @@
   },
   "dependencies": {
     "@expo-google-fonts/space-grotesk": "^0.2.2",
-    "@expo/metro-runtime": "^3.1.1",
+    "@expo/metro-runtime": "~3.1.3",
     "@react-native-async-storage/async-storage": "^1.21.0",
     "@react-navigation/bottom-tabs": "^6.3.2",
     "@react-navigation/native": "^6.0.2",


### PR DESCRIPTION
## Please verify the following:

- [x] `yarn test` **jest** tests pass with new tests, if relevant
- [x] `yarn lint` **eslint** checks pass with new code, if relevant
- [x] `yarn format:check` **prettier** checks pass with new code, if relevant
- [x] `README.md` (or relevant documentation) has been updated with your changes

## Describe your PR
- Fixes an issue where hot reloading doesn't work on web due to using metro bundler (to prep for expo-router), which requires an explicit import to enable it
- Related issue at Expo: https://github.com/expo/expo/issues/23104#issuecomment-1689566248
- Discussed in partner channel, it cannot be included by default because it breaks webpack support