### PR TITLE
fix(cli): prebuild via npx over alias

### DIFF
--- a/src/commands/new.ts
+++ b/src/commands/new.ts
@@ -730,7 +730,7 @@ module.exports = {
         if (needsPrebuild) {
           const prebuildMessage = ` Generating native template via Expo Prebuild`
           startSpinner(prebuildMessage)
-          await packager.run("prebuild:clean", { ...packagerOptions, onProgress: log })
+          await system.run("npx expo prebuild --clean", { onProgress: log })
           stopSpinner(prebuildMessage, "🛠️")
         }
         // Make sure all our modifications are formatted nicely


### PR DESCRIPTION
## Please verify the following:

- [x] `yarn test` **jest** tests pass with new tests, if relevant
- [x] `yarn lint` **eslint** checks pass with new code, if relevant
- [x] `yarn format:check` **prettier** checks pass with new code, if relevant
- [x] `README.md` (or relevant documentation) has been updated with your changes

## Describe your PR
- Fixes an issue found by @lindboe that `xcode.env.local` gets a temporary ref to npm/yarn executables when prebuild is run by an alias over the `npx` variation

