### PR TITLE
fix(boilerplate): fix deep link not working with navigation persist

### DIFF
--- a/boilerplate/app/navigators/navigationUtilities.ts
+++ b/boilerplate/app/navigators/navigationUtilities.ts
@@ -1,5 +1,5 @@
 import { useState, useEffect, useRef } from "react"
-import { BackHandler, Platform } from "react-native"
+import { BackHandler, Linking, Platform } from "react-native"
 import {
   NavigationState,
   PartialState,
@@ -147,8 +147,13 @@ export function useNavigationPersistence(storage: Storage, persistenceKey: strin
 
   const restoreState = async () => {
     try {
-      const state = (await storage.load(persistenceKey)) as NavigationProps["initialState"] | null
-      if (state) setInitialNavigationState(state)
+      const initialUrl = await Linking.getInitialURL()
+
+      // Only restore the state if app has not started from a deep link
+      if (!initialUrl) {
+        const state = (await storage.load(persistenceKey)) as NavigationProps["initialState"] | null
+        if (state) setInitialNavigationState(state)
+      }
     } finally {
       if (isMounted()) setIsRestored(true)
     }


### PR DESCRIPTION
## Please verify the following:

- [X] `yarn test` **jest** tests pass with new tests, if relevant
- [X] `yarn lint` **eslint** checks pass with new code, if relevant
- [X] `yarn format:check` **prettier** checks pass with new code, if relevant
- [X] `README.md` (or relevant documentation) has been updated with your changes

## Describe your PR

On the dev env, if you try to start the app from a deep link because the navigation persists, it will get ignored by the navigation