### PR TITLE
fix(metro): Add support for cjs extension in metro.config.js

### DIFF
--- a/boilerplate/app/app.tsx
+++ b/boilerplate/app/app.tsx
@@ -11,9 +11,9 @@
  * if you're interested in adding screens and navigators.
  */
 if (__DEV__) {
-  // Load Reactotron configuration in development. We don't want to
-  // include this in our production bundle, so we are using `if (__DEV__)`
-  // to only execute this in development.
+  // Load Reactotron in development only.
+  // Note that you must be using metro's `inlineRequires` for this to work.
+  // If you turn it off in metro.config.js, you'll have to manually import it.
   require("./devtools/ReactotronConfig.ts")
 }
 import "./i18n"

--- a/boilerplate/metro.config.js
+++ b/boilerplate/metro.config.js
@@ -6,9 +6,19 @@ const config = getDefaultConfig(__dirname);
 
 config.transformer.getTransformOptions = async () => ({
   transform: {
+    // TODO: Document why we added this
     experimentalImportSupport: false,
+
+    // Inline requires are very useful for deferring loading of large
+    // dependencies / components. However, they come with some gotchas.
+    // Read more here: https://reactnative.dev/docs/optimizing-javascript-loading
+    // And here: https://github.com/expo/expo/issues/27279#issuecomment-1971610698
     inlineRequires: true,
   },
 });
+
+// This helps support certain popular third-party libraries
+// such as Firebase that use the extension cjs.
+config.resolver.sourceExts.push("cjs")
 
 module.exports = config;

--- a/boilerplate/metro.config.js
+++ b/boilerplate/metro.config.js
@@ -6,9 +6,6 @@ const config = getDefaultConfig(__dirname);
 
 config.transformer.getTransformOptions = async () => ({
   transform: {
-    // TODO: Document why we added this
-    experimentalImportSupport: false,
-
     // Inline requires are very useful for deferring loading of large dependencies/components.
     // For example, we use it in app.tsx to conditionally load Reactotron.
     // However, this comes with some gotchas.

--- a/boilerplate/metro.config.js
+++ b/boilerplate/metro.config.js
@@ -9,8 +9,9 @@ config.transformer.getTransformOptions = async () => ({
     // TODO: Document why we added this
     experimentalImportSupport: false,
 
-    // Inline requires are very useful for deferring loading of large
-    // dependencies / components. However, they come with some gotchas.
+    // Inline requires are very useful for deferring loading of large dependencies/components.
+    // For example, we use it in app.tsx to conditionally load Reactotron.
+    // However, this comes with some gotchas.
     // Read more here: https://reactnative.dev/docs/optimizing-javascript-loading
     // And here: https://github.com/expo/expo/issues/27279#issuecomment-1971610698
     inlineRequires: true,


### PR DESCRIPTION
This tweaks the metro config to add support for .cjs so we support Firebase.js out of the box with no other config changes.

Also adds some comments for inline requires.