### PR TITLE
Update `react-native` in the boilerplate to v0.73.6

### DIFF
--- a/boilerplate/package.json
+++ b/boilerplate/package.json
@@ -54,7 +54,7 @@
     "mobx-state-tree": "5.3.0",
     "react": "18.2.0",
     "react-dom": "18.2.0",
-    "react-native": "0.73.4",
+    "react-native": "0.73.6",
     "react-native-drawer-layout": "4.0.0-alpha.1",
     "react-native-gesture-handler": "~2.14.0",
     "react-native-reanimated": "~3.6.0",


### PR DESCRIPTION
## Please verify the following:

- [x] `yarn test` **jest** tests pass with new tests, if relevant
- [x] `yarn lint` **eslint** checks pass with new code, if relevant
- [x] `yarn format:check` **prettier** checks pass with new code, if relevant
- [x] `README.md` (or relevant documentation) has been updated with your changes

## Describe your PR

I created a new project recently using `npx ignite-cli@latest new ...` and when running it, I got the following warning message in the console:

```
The following packages should be updated for best compatibility with the installed expo version:
  react-native@0.73.4 - expected version: 0.73.6
Your project may not work correctly until you install the correct versions of the packages.
```

Updating the version for `react-native` fixes this
