### PR TITLE
Fix icon alignment on DemoCommunityScreen

### DIFF
--- a/boilerplate/app/screens/DemoCommunityScreen.tsx
+++ b/boilerplate/app/screens/DemoCommunityScreen.tsx
@@ -126,6 +126,7 @@ const $logoContainer: ViewStyle = {
   flexDirection: "row",
   flexWrap: "wrap",
   alignContent: "center",
+  alignSelf: "stretch",
 }
 
 const $logo: ImageStyle = {


### PR DESCRIPTION
## Please verify the following:

- [x] `yarn test` **jest** tests pass with new tests, if relevant
- [x] `yarn lint` **eslint** checks pass with new code, if relevant
- [ ] `yarn format:check` **prettier** checks pass with new code, if relevant
- [x] `README.md` (or relevant documentation) has been updated with your changes

## Describe your PR
This PR fixes a small alignment issue on the DemoCommunityScreen where icons are not vertically centered in their rows. Tested in Expo Go, iOS 17.5 , with the [Expo 51 patch](https://github.com/infinitered/ignite/pull/2683) applied.
| Before | After|
|-|-|
| <img width=250 src="https://github.com/infinitered/ignite/assets/7883508/0144bf52-e038-49f5-8c5b-86891afda8f3" /> | <img width=250 src="https://github.com/infinitered/ignite/assets/7883508/85450a7b-027c-42b9-8197-690214467ce6" /> |
