### PR TITLE
fix(log-in): sign in -> log in for consistency with filename

### DIFF
--- a/boilerplate/.maestro/Login.yaml
+++ b/boilerplate/.maestro/Login.yaml
@@ -9,9 +9,9 @@ appId: com.helloworld # the app id of the app we want to test
 ---
 - clearState # clears the state of our app (navigation and authentication)
 - launchApp # launches the app
-- assertVisible: "Sign In"
+- assertVisible: "Log In"
 - tapOn:
-    text: "Tap to sign in!"
+    text: "Tap to Log in!"
 - assertVisible: "Your app, almost ready for launch!"
 - tapOn:
     text: "Let's go!"

--- a/boilerplate/app/i18n/ar.ts
+++ b/boilerplate/app/i18n/ar.ts
@@ -33,14 +33,14 @@ const ar: Translations = {
     invalidEmail: "عنوان البريد الالكتروني غير صالح",
   },
   loginScreen: {
-    signIn: "تسجيل الدخول",
+    logIn: "تسجيل الدخول",
     enterDetails:
       ".ادخل التفاصيل الخاصة بك ادناه لفتح معلومات سرية للغاية. لن تخمن ابداً ما الذي ننتظره. او ربما ستفعل انها انها ليست علم الصواريخ",
     emailFieldLabel: "البريد الالكتروني",
     passwordFieldLabel: "كلمة السر",
     emailFieldPlaceholder: "ادخل بريدك الالكتروني",
     passwordFieldPlaceholder: "كلمة السر هنا فائقة السر",
-    tapToSignIn: "انقر لتسجيل الدخول!",
+    tapToLogIn: "انقر لتسجيل الدخول!",
     hint: "(: تلميح: يمكنك استخدام اي عنوان بريد الكتروني وكلمة السر المفضلة لديك",
   },
   demoNavigator: {

--- a/boilerplate/app/i18n/en.ts
+++ b/boilerplate/app/i18n/en.ts
@@ -31,14 +31,14 @@ const en = {
     invalidEmail: "Invalid email address.",
   },
   loginScreen: {
-    signIn: "Sign In",
+    logIn: "Log In",
     enterDetails:
       "Enter your details below to unlock top secret info. You'll never guess what we've got waiting. Or maybe you will; it's not rocket science here.",
     emailFieldLabel: "Email",
     passwordFieldLabel: "Password",
     emailFieldPlaceholder: "Enter your email address",
     passwordFieldPlaceholder: "Super secret password here",
-    tapToSignIn: "Tap to sign in!",
+    tapToLogIn: "Tap to log in!",
     hint: "Hint: you can use any email address and your favorite password :)",
   },
   demoNavigator: {

--- a/boilerplate/app/i18n/fr.ts
+++ b/boilerplate/app/i18n/fr.ts
@@ -34,14 +34,14 @@ const fr: Translations = {
     invalidEmail: "Adresse e-mail invalide.",
   },
   loginScreen: {
-    signIn: "Se connecter",
+    logIn: "Se connecter",
     enterDetails:
       "Entrez vos informations ci-dessous pour débloquer des informations top secrètes. Vous ne devinerez jamais ce que nous avons en attente. Ou peut-être que vous le ferez ; ce n'est pas de la science spatiale ici.",
     emailFieldLabel: "E-mail",
     passwordFieldLabel: "Mot de passe",
     emailFieldPlaceholder: "Entrez votre adresse e-mail",
     passwordFieldPlaceholder: "Mot de passe super secret ici",
-    tapToSignIn: "Appuyez pour vous connecter !",
+    tapToLogIn: "Appuyez pour vous connecter!",
     hint: "Astuce : vous pouvez utiliser n'importe quelle adresse e-mail et votre mot de passe préféré :)",
   },
   demoNavigator: {

--- a/boilerplate/app/i18n/ko.ts
+++ b/boilerplate/app/i18n/ko.ts
@@ -33,14 +33,14 @@ const ko: Translations = {
     invalidEmail: "잘못된 이메일 주소 입니다.",
   },
   loginScreen: {
-    signIn: "로그인",
+    logIn: "로그인",
     enterDetails:
       "일급비밀 정보를 해제하기 위해 상세 정보를 입력하세요. 무엇이 기다리고 있는지 절대 모를겁니다. 혹은 알 수 있을지도 모르겠군요. 엄청 복잡한 뭔가는 아닙니다.",
     emailFieldLabel: "이메일",
     passwordFieldLabel: "비밀번호",
     emailFieldPlaceholder: "이메일을 입력하세요",
     passwordFieldPlaceholder: "엄청 비밀스러운 암호를 입력하세요",
-    tapToSignIn: "눌러서 로그인 하기!",
+    tapToLogIn: "눌러서 로그인 하기!",
     hint: "힌트: 가장 좋아하는 암호와 아무런 아무 이메일 주소나 사용할 수 있어요 :)",
   },
   demoNavigator: {

--- a/boilerplate/app/screens/LoginScreen.tsx
+++ b/boilerplate/app/screens/LoginScreen.tsx
@@ -72,7 +72,7 @@ export const LoginScreen: FC<LoginScreenProps> = observer(function LoginScreen(_
       contentContainerStyle={$screenContentContainer}
       safeAreaEdges={["top", "bottom"]}
     >
-      <Text testID="login-heading" tx="loginScreen.signIn" preset="heading" style={$signIn} />
+      <Text testID="login-heading" tx="loginScreen.logIn" preset="heading" style={$logIn} />
       <Text tx="loginScreen.enterDetails" preset="subheading" style={$enterDetails} />
       {attemptsCount > 2 && <Text tx="loginScreen.hint" size="sm" weight="light" style={$hint} />}
 
@@ -108,7 +108,7 @@ export const LoginScreen: FC<LoginScreenProps> = observer(function LoginScreen(_
 
       <Button
         testID="login-button"
-        tx="loginScreen.tapToSignIn"
+        tx="loginScreen.tapToLogIn"
         style={$tapButton}
         preset="reversed"
         onPress={login}
@@ -122,7 +122,7 @@ const $screenContentContainer: ViewStyle = {
   paddingHorizontal: spacing.lg,
 }
 
-const $signIn: TextStyle = {
+const $logIn: TextStyle = {
   marginBottom: spacing.sm,
 }
 


### PR DESCRIPTION
## Please verify the following:

- [ ] `yarn test` **jest** tests pass with new tests, if relevant
- [ ] `yarn lint` **eslint** checks pass with new code, if relevant
- [ ] `yarn format:check` **prettier** checks pass with new code, if relevant
- [ ] `README.md` (or relevant documentation) has been updated with your changes

## Describe your PR
- Changes `Sign In` copy to `Log In` so it's consistent with the screen filename, `Login.tsx`
- When viewing `Sign In` running the app your first instinct is to cmd+p for `Signin.tsx` but it doesn't exist

## Todo
- We might need to check the translations for ko, ar and fr - but I guess the filenames are in English so maybe doesn't make a difference