### PR TITLE
Fix entrypoint for SDK 51. Update babel transforms

### DIFF
--- a/boilerplate/babel.config.js
+++ b/boilerplate/babel.config.js
@@ -1,7 +1,6 @@
 /** @type {import('@babel/core').TransformOptions['plugins']} */
-const plugins = [
-  /** react-native-reanimated web support @see https://docs.swmansion.com/react-native-reanimated/docs/fundamentals/installation/#web */
-  "@babel/plugin-proposal-export-namespace-from",
+const plugins = [  
+  "@babel/plugin-transform-export-namespace-from",
 ]
 
 /** @type {import('@babel/core').TransformOptions} */

--- a/boilerplate/babel.config.js
+++ b/boilerplate/babel.config.js
@@ -1,5 +1,6 @@
 /** @type {import('@babel/core').TransformOptions['plugins']} */
 const plugins = [  
+  /** react-native-reanimated web support @see https://docs.swmansion.com/react-native-reanimated/docs/guides/web-support/ */
   "@babel/plugin-transform-export-namespace-from",
 ]
 

--- a/boilerplate/package.json
+++ b/boilerplate/package.json
@@ -65,9 +65,6 @@
   "devDependencies": {
     "@babel/core": "^7.20.0",
     "@babel/plugin-transform-arrow-functions": "^7.0.0",
-    "@babel/plugin-transform-export-namespace-from": "^7.24.7",
-    "@babel/plugin-transform-nullish-coalescing-operator": "^7.24.7",
-    "@babel/plugin-transform-optional-chaining": "^7.24.7",
     "@babel/plugin-transform-shorthand-properties": "^7.0.0",
     "@babel/plugin-transform-template-literals": "^7.0.0",
     "@babel/preset-env": "^7.20.0",

--- a/boilerplate/package.json
+++ b/boilerplate/package.json
@@ -2,7 +2,7 @@
   "name": "hello-world",
   "version": "0.0.1",
   "private": true,
-  "main": "node_modules/expo/AppEntry.js",
+  "main": "expo/AppEntry.js",
   "scripts": {
     "compile": "tsc --noEmit -p . --pretty",
     "format": "prettier --write \"app/**/*.{js,jsx,json,md,ts,tsx}\"",
@@ -64,10 +64,10 @@
   },
   "devDependencies": {
     "@babel/core": "^7.20.0",
-    "@babel/plugin-proposal-export-namespace-from": "^7.18.9",
-    "@babel/plugin-proposal-nullish-coalescing-operator": "^7.0.0",
-    "@babel/plugin-proposal-optional-chaining": "^7.0.0",
     "@babel/plugin-transform-arrow-functions": "^7.0.0",
+    "@babel/plugin-transform-export-namespace-from": "^7.24.7",
+    "@babel/plugin-transform-nullish-coalescing-operator": "^7.24.7",
+    "@babel/plugin-transform-optional-chaining": "^7.24.7",
     "@babel/plugin-transform-shorthand-properties": "^7.0.0",
     "@babel/plugin-transform-template-literals": "^7.0.0",
     "@babel/preset-env": "^7.20.0",


### PR DESCRIPTION
## Please verify the following:

- [X] `yarn test` **jest** tests pass with new tests, if relevant
- [ ] `yarn lint` **eslint** checks pass with new code, if relevant
- [X] `yarn format:check` **prettier** checks pass with new code, if relevant
- [X] `README.md` (or relevant documentation) has been updated with your changes

## Describe your PR
Since my upgrade to Expo 51.0.17 my EAS local build for iOS didn't work anymore. I had to change the entrypoint in the package.json. A brand new Expo project had it configured that way, instead of the old reference to node_modules
Along the way I saw the babel-proposal being incorporated into babel, so changed the devDependencies.