### PR TITLE
feature: add Japanese translation to boilerplate

### DIFF
--- a/boilerplate/app/i18n/i18n.ts
+++ b/boilerplate/app/i18n/i18n.ts
@@ -7,11 +7,12 @@ import en, { Translations } from "./en"
 import ar from "./ar"
 import ko from "./ko"
 import fr from "./fr"
+import jp from "./jp"
 
 i18n.fallbacks = true
 
 // to use regional locales use { "en-US": enUS } etc
-i18n.translations = { ar, en, "en-US": en, ko, fr }
+i18n.translations = { ar, en, "en-US": en, ko, fr, jp }
 
 const fallbackLocale = "en-US"
 const systemLocale = Localization.getLocales()[0]

--- a/boilerplate/app/i18n/jp.ts
+++ b/boilerplate/app/i18n/jp.ts
@@ -1,0 +1,127 @@
+import { Translations } from "./en"
+
+const jp: Translations = {
+  common: {
+    ok: "OK",
+    cancel: "キャンセル",
+    back: "戻る",
+    logOut: "ログアウト", // @demo remove-current-line
+  },
+  welcomeScreen: {
+    postscript:
+      "注目！ — このアプリはお好みの見た目では無いかもしれません(デザイナーがこのスクリーンを送ってこない限りは。もしそうなら公開しちゃいましょう！)",
+    readyForLaunch: "このアプリはもう少しで公開できます！",
+    exciting: "(楽しみですね！)",
+    letsGo: "レッツゴー！", // @demo remove-current-line
+  },
+  errorScreen: {
+    title: "問題が発生しました",
+    friendlySubtitle:
+      "本番では、エラーが投げられた時にこのページが表示されます。もし使うならこのメッセージに変更を加えてください(`app/i18n/jp.ts`)レイアウトはこちらで変更できます(`app/screens/ErrorScreen`)。もしこのスクリーンを取り除きたい場合は、`app/app.tsx`にある<ErrorBoundary>コンポーネントをチェックしてください",
+    reset: "リセット",
+    traceTitle: "エラーのスタック: %{name}", // @demo remove-current-line
+  },
+  emptyStateComponent: {
+    generic: {
+      heading: "静かだ...悲しい。",
+      content:
+        "データが見つかりません。ボタンを押してアプリをリロード、またはリフレッシュしてください。",
+      button: "もう一度やってみよう",
+    },
+  },
+  // @demo remove-block-start
+  errors: {
+    invalidEmail: "有効なメールアドレスを入力してください.",
+  },
+  loginScreen: {
+    signIn: "サインイン",
+    enterDetails:
+      "ここにあなたの情報を入力してトップシークレットをアンロックしましょう。何が待ち構えているか予想もつかないはずです。はたまたそうでも無いかも - ロケットサイエンスほど複雑なものではありません。",
+    emailFieldLabel: "メールアドレス",
+    passwordFieldLabel: "パスワード",
+    emailFieldPlaceholder: "メールアドレスを入力してください",
+    passwordFieldPlaceholder: "パスワードを入力してください",
+    tapToSignIn: "タップしてサインインしよう！",
+    hint: "ヒント: お好みのメールアドレスとパスワードを使ってください :)",
+  },
+  demoNavigator: {
+    componentsTab: "コンポーネント",
+    debugTab: "デバッグ",
+    communityTab: "コミュニティ",
+    podcastListTab: "ポッドキャスト",
+  },
+  demoCommunityScreen: {
+    title: "コミュニティと繋がろう",
+    tagLine:
+      "Infinite RedのReact Nativeエンジニアコミュニティに接続して、一緒にあなたのアプリ開発をレベルアップしましょう！",
+    joinUsOnSlackTitle: "私たちのSlackに参加しましょう",
+    joinUsOnSlack:
+      "世界中のReact Nativeエンジニアと繋がりたいを思いませんか？Infinite RedのコミュニティSlackに参加しましょう！私達のコミュニティは安全に質問ができ、お互いから学び、あなたのネットワークを広げることができます。",
+    joinSlackLink: "Slackコミュニティに参加する",
+    makeIgniteEvenBetterTitle: "Igniteをより良くする",
+    makeIgniteEvenBetter:
+      "Igniteをより良くする為のアイデアはありますか? そうであれば聞きたいです！ 私たちはいつでも最良のReact Nativeのツールを開発する為に助けを求めています。GitHubで私たちと一緒にIgniteの未来を作りましょう。",
+    contributeToIgniteLink: "Igniteにコントリビュートする",
+    theLatestInReactNativeTitle: "React Nativeの今",
+    theLatestInReactNative: "React Nativeの現在をあなたにお届けします。",
+    reactNativeRadioLink: "React Native Radio",
+    reactNativeNewsletterLink: "React Native Newsletter",
+    reactNativeLiveLink: "React Native Live",
+    chainReactConferenceLink: "Chain React Conference",
+    hireUsTitle: "あなたの次のプロジェクトでInfinite Redと契約する",
+    hireUs:
+      "それがプロジェクト全体でも、チームにトレーニングをしてあげたい時でも、Infinite RedはReact Nativeのことであればなんでもお手伝いができます。",
+    hireUsLink: "メッセージを送る",
+  },
+  demoShowroomScreen: {
+    jumpStart: "あなたのプロジェクトをスタートさせるコンポーネントです！",
+    lorem2Sentences:
+      "Nulla cupidatat deserunt amet quis aliquip nostrud do adipisicing. Adipisicing excepteur elit laborum Lorem adipisicing do duis.",
+    demoHeaderTxExample: "Yay",
+    demoViaTxProp: "`tx` Propから",
+    demoViaSpecifiedTxProp: "`{{prop}}Tx` Propから",
+  },
+  demoDebugScreen: {
+    howTo: "ハウツー",
+    title: "デバッグ",
+    tagLine:
+      "おめでとうございます、あなたはとてもハイレベルなReact Nativeのテンプレートを使ってます。このボイラープレートを活用してください！",
+    reactotron: "Reactotronに送る",
+    reportBugs: "バグをレポートする",
+    demoList: "デモリスト",
+    demoPodcastList: "デモのポッドキャストリスト",
+    androidReactotronHint:
+      "もし動かなければ、Reactotronのデスクトップアプリが実行されていることを確認して, このコマンドをターミナルで実行した後、アプリをアプリをリロードしてください。 adb reverse tcp:9090 tcp:9090",
+    iosReactotronHint:
+      "もし動かなければ、Reactotronのデスクトップアプリが実行されていることを確認して、アプリをリロードしてください。",
+    macosReactotronHint:
+      "もし動かなければ、Reactotronのデスクトップアプリが実行されていることを確認して、アプリをリロードしてください。",
+    webReactotronHint:
+      "もし動かなければ、Reactotronのデスクトップアプリが実行されていることを確認して、アプリをリロードしてください。",
+    windowsReactotronHint:
+      "もし動かなければ、Reactotronのデスクトップアプリが実行されていることを確認して、アプリをリロードしてください。",
+  },
+  demoPodcastListScreen: {
+    title: "React Native Radioのエピソード",
+    onlyFavorites: "お気に入り表示",
+    favoriteButton: "お気に入り",
+    unfavoriteButton: "お気に入りを外す",
+    accessibility: {
+      cardHint: "ダブルタップで再生します。 ダブルタップと長押しで {{action}}",
+      switch: "スイッチオンでお気に入りを表示する",
+      favoriteAction: "お気に入りの切り替え",
+      favoriteIcon: "お気に入りのエピソードではありません",
+      unfavoriteIcon: "お気に入りのエピソードです",
+      publishLabel: "公開日 {{date}}",
+      durationLabel: "再生時間: {{hours}} 時間 {{minutes}} 分 {{seconds}} 秒",
+    },
+    noFavoritesEmptyState: {
+      heading: "どうやら空っぽのようですね",
+      content:
+        "お気に入りのエピソードがまだありません。エピソードにあるハートマークにタップして、お気に入りに追加しましょう！",
+    },
+  },
+  // @demo remove-block-end
+}
+
+export default jp

--- a/docs/boilerplate/app/i18n/Internationalization.md
+++ b/docs/boilerplate/app/i18n/Internationalization.md
@@ -4,7 +4,7 @@ sidebar_position: 160
 
 # Internationalization in Ignite Apps
 
-Ignite currently set up to have Internationalization setup in English, Arabic, and Korean! This is detected on app load and will set your app to that language.
+Ignite currently set up to have Internationalization setup in English, Arabic, Korean, French and Japanese! This is detected on app load and will set your app to that language.
 
 ## Right to Left languages (RTL)
 

--- a/test/vanilla/__snapshots__/ignite-remove-demo.test.ts.snap
+++ b/test/vanilla/__snapshots__/ignite-remove-demo.test.ts.snap
@@ -9,6 +9,7 @@ exports[`ignite-cli remove-demo should print the expected response 1`] = `
    Found '@demo remove-current-line', '@demo remove-block-start', '@demo remove-block-end' in /user/home/ignite/app/i18n/ar.ts
    Found '@demo remove-current-line', '@demo remove-block-start', '@demo remove-block-end' in /user/home/ignite/app/i18n/en.ts
    Found '@demo remove-current-line', '@demo remove-block-start', '@demo remove-block-end' in /user/home/ignite/app/i18n/fr.ts
+   Found '@demo remove-current-line', '@demo remove-block-start', '@demo remove-block-end' in /user/home/ignite/app/i18n/jp.ts
    Found '@demo remove-current-line', '@demo remove-block-start', '@demo remove-block-end' in /user/home/ignite/app/i18n/ko.ts
    Found '@demo remove-file' in /user/home/ignite/app/models/AuthenticationStore.ts
    Found '@demo remove-file' in /user/home/ignite/app/models/Episode.test.ts


### PR DESCRIPTION
## Please verify the following:

- [x] `yarn test` **jest** tests pass with new tests, if relevant
- [x] `yarn lint` **eslint** checks pass with new code, if relevant
- [x] `yarn format:check` **prettier** checks pass with new code, if relevant
- [x] `README.md` (or relevant documentation) has been updated with your changes

## Describe your PR

Hi all! This PR is to add another language (Japanese) to the boilerplate. I have translated all the texts under the translation object. I haven't gone any further than the i18n files for the sake of the scope of this PR, but it might be beneficial to translate the descriptions under component's demo ([example](https://github.com/infinitered/ignite/blob/e883593ffc1fb3b4349330dc477ff0296954b3cc/boilerplate/app/screens/DemoShowroomScreen/demos/DemoCard.tsx#L11)) in the future. I can try to hook them up to i18n file after this PR.

## Screenshots

<img width="350" src="https://github.com/user-attachments/assets/42725f9a-e727-4070-ae1c-cdfd8546ab7a">
<img width="350" src="https://github.com/user-attachments/assets/a2bdb2a1-eaa9-4fad-99eb-0b9c1fdd9313">
<img width="350" src="https://github.com/user-attachments/assets/614717ce-5d66-4aad-b931-be479ce769cf">
<img width="350" src="https://github.com/user-attachments/assets/9e8beddf-422f-4d35-be8a-57933ae0aebf">
<img width="350" src="https://github.com/user-attachments/assets/ea397e37-5682-44da-b07c-b17119875b80">
<img width="350" src="https://github.com/user-attachments/assets/c9c2ec96-8d02-44a3-b58f-53028c73d920">
