### PR TITLE
fix(boilerplate): bump patch-package version

### DIFF
--- a/boilerplate/package.json
+++ b/boilerplate/package.json
@@ -90,7 +90,7 @@
     "eslint-plugin-reactotron": "^0.1.2",
     "jest": "^29.2.1",
     "jest-expo": "~51.0.2",
-    "patch-package": "6.4.7",
+    "patch-package": "^8.0.0",
     "postinstall-prepare": "1.0.1",
     "prettier": "2.8.8",
     "react-test-renderer": "18.2.0",


### PR DESCRIPTION
## Please verify the following:

- [x] `yarn test` **jest** tests pass with new tests, if relevant
- [x] `yarn lint` **eslint** checks pass with new code, if relevant
- [x] `yarn format:check` **prettier** checks pass with new code, if relevant
- [x] `README.md` (or relevant documentation) has been updated with your changes

## Describe your PR
As per #2712 , patch-package is a bit too old. I also noticed it was fixed to the specific version. I don't see a big reason for this as it is not the type of project that would break api in minor version updates so I've let it be updateable.