### PR TITLE
feat(cli): experimental expo-router flag

### DIFF
--- a/boilerplate/.gitignore
+++ b/boilerplate/.gitignore
@@ -71,6 +71,7 @@ buck-out/
 bin/Exponent.app
 /android
 /ios
+expo-env.d.ts
 
 ## Secrets
 npm-debug.*

--- a/boilerplate/app/components/ListItem.tsx
+++ b/boilerplate/app/components/ListItem.tsx
@@ -102,7 +102,10 @@ interface ListItemActionProps {
  * @param {ListItemProps} props - The props for the `ListItem` component.
  * @returns {JSX.Element} The rendered `ListItem` component.
  */
-export function ListItem(props: ListItemProps) {
+export const ListItem = React.forwardRef<View, ListItemProps>(function ListItem(
+  props: ListItemProps,
+  ref,
+) {
   const {
     bottomSeparator,
     children,
@@ -135,7 +138,7 @@ export function ListItem(props: ListItemProps) {
   const $touchableStyles = [$touchableStyle, { minHeight: height }, style]
 
   return (
-    <View style={$containerStyles}>
+    <View ref={ref} style={$containerStyles}>
       <TouchableOpacity {...TouchableOpacityProps} style={$touchableStyles}>
         <ListItemAction
           side="left"
@@ -159,7 +162,7 @@ export function ListItem(props: ListItemProps) {
       </TouchableOpacity>
     </View>
   )
-}
+})
 
 /**
  * @param {ListItemActionProps} props - The props for the `ListItemAction` component.

--- a/boilerplate/src/app/_layout.tsx
+++ b/boilerplate/src/app/_layout.tsx
@@ -1,0 +1,45 @@
+import React from "react"
+import { Slot, SplashScreen } from "expo-router"
+import { GestureHandlerRootView } from "react-native-gesture-handler"
+import { useInitialRootStore } from "src/models"
+import { useFonts } from "@expo-google-fonts/space-grotesk"
+import { customFontsToLoad } from "src/theme"
+
+SplashScreen.preventAutoHideAsync()
+
+if (__DEV__) {
+  // Load Reactotron configuration in development. We don't want to
+  // include this in our production bundle, so we are using `if (__DEV__)`
+  // to only execute this in development.
+  require("src/devtools/ReactotronConfig.ts")
+}
+
+export { ErrorBoundary } from "src/components/ErrorBoundary/ErrorBoundary"
+
+export default function Root() {
+  // Wait for stores to load and render our layout inside of it so we have access
+  // to auth info etc
+  const { rehydrated } = useInitialRootStore()
+
+  const [fontsLoaded, fontError] = useFonts(customFontsToLoad)
+
+  const loaded = fontsLoaded && rehydrated
+
+  React.useEffect(() => {
+    if (fontError) throw fontError
+  }, [fontError])
+
+  React.useEffect(() => {
+    if (loaded) {
+      SplashScreen.hideAsync()
+    }
+  }, [loaded])
+
+  if (!loaded) {
+    return null
+  }
+
+  return <GestureHandlerRootView style={$root}><Slot /></GestureHandlerRootView>
+}
+
+const $root: ViewStyle = { flex: 1 }

--- a/boilerplate/src/app/index.tsx
+++ b/boilerplate/src/app/index.tsx
@@ -1,0 +1,76 @@
+import { observer } from "mobx-react-lite"
+import React from "react"
+import { Image, ImageStyle, TextStyle, View, ViewStyle } from "react-native"
+import { Text } from "src/components"
+import { isRTL } from "../i18n"
+import { colors, spacing } from "../theme"
+import { useSafeAreaInsetsStyle } from "../utils/useSafeAreaInsetsStyle"
+
+const welcomeLogo = require("../../assets/images/logo.png")
+const welcomeFace = require("../../assets/images/welcome-face.png")
+
+export default observer(function WelcomeScreen() {
+  const $bottomContainerInsets = useSafeAreaInsetsStyle(["bottom"])
+
+  return (
+    <View style={$container}>
+      <View style={$topContainer}>
+        <Image style={$welcomeLogo} source={welcomeLogo} resizeMode="contain" />
+        <Text
+          testID="welcome-heading"
+          style={$welcomeHeading}
+          tx="welcomeScreen.readyForLaunch"
+          preset="heading"
+        />
+        <Text tx="welcomeScreen.exciting" preset="subheading" />
+        <Image style={$welcomeFace} source={welcomeFace} resizeMode="contain" />
+      </View>
+
+      <View style={[$bottomContainer, $bottomContainerInsets]}>
+        <Text tx="welcomeScreen.postscript" size="md" />
+      </View>
+    </View>
+  )
+})
+
+const $container: ViewStyle = {
+  flex: 1,
+  backgroundColor: colors.background,
+}
+
+const $topContainer: ViewStyle = {
+  flexShrink: 1,
+  flexGrow: 1,
+  flexBasis: "57%",
+  justifyContent: "center",
+  paddingHorizontal: spacing.lg,
+}
+
+const $bottomContainer: ViewStyle = {
+  flexShrink: 1,
+  flexGrow: 0,
+  flexBasis: "43%",
+  backgroundColor: colors.palette.neutral100,
+  borderTopLeftRadius: 16,
+  borderTopRightRadius: 16,
+  paddingHorizontal: spacing.lg,
+  justifyContent: "space-around",
+}
+const $welcomeLogo: ImageStyle = {
+  height: 88,
+  width: "100%",
+  marginBottom: spacing.xxl,
+}
+
+const $welcomeFace: ImageStyle = {
+  height: 169,
+  width: 269,
+  position: "absolute",
+  bottom: -47,
+  right: -80,
+  transform: [{ scaleX: isRTL ? -1 : 1 }],
+}
+
+const $welcomeHeading: TextStyle = {
+  marginBottom: spacing.md,
+}

--- a/boilerplate/tsconfig.json
+++ b/boilerplate/tsconfig.json
@@ -31,6 +31,6 @@
       "module": "commonjs"
     }
   },
-  "include": ["index.js", "App.tsx", "app", "types", "plugins", "app.config.ts"],
+  "include": ["**/*.ts", "**/*.tsx", ".expo/types/**/*.ts", "expo-env.d.ts"],
   "exclude": ["node_modules", "test/**/*"]
 }

--- a/src/commands/generate.ts
+++ b/src/commands/generate.ts
@@ -21,6 +21,7 @@ async function generate(toolbox: GluegunToolbox) {
   // what generator are we running?
   const generator = parameters.first.toLowerCase()
 
+
   // we need a name for this component
   let name = parameters.second
   if (!name) {

--- a/src/commands/new.ts
+++ b/src/commands/new.ts
@@ -450,6 +450,7 @@ module.exports = {
     // #region Experimental Features parsing
     let newArch
     let expoVersion
+    let expoRouter = false
     const experimentalFlags = options.experimental?.split(",") ?? []
     log(`experimentalFlags: ${experimentalFlags}`)
 
@@ -457,7 +458,15 @@ module.exports = {
       if (flag === "new-arch") {
         newArch = true
       } else if (flag.indexOf("expo-") > -1) {
-        expoVersion = flag.substring(5)
+        if (flag !== "expo-router") {
+          expoVersion = flag.substring(5)
+        } else {
+          // user wants to convert to expo-router
+          // force demo code removal for easier conversion
+          // maybe one day convert the demo app
+          expoRouter = true
+          removeDemo = true
+        }
       }
     })
     // #endregion
@@ -571,12 +580,30 @@ module.exports = {
         .replace(/HelloWorld/g, projectName)
         .replace(/hello-world/g, projectNameKebab)
 
+      // add in expo-router package
+      if (expoRouter) {
+        // find "expo-localization" line and append "expo-router" line after it
+        packageJsonRaw = packageJsonRaw.replace(
+          /"expo-localization": ".*",/g,
+          `"expo-localization": "~15.0.3",${EOL}    "expo-router":  "~3.5.17",`,
+        )
+
+        // replace "main" entry point from App.js to "expo-router/entry"
+        packageJsonRaw = packageJsonRaw.replace(/"main": ".*",/g, `"main": "expo-router/entry",`)
+
+        // replace format and lint scripts
+        packageJsonRaw = packageJsonRaw.replace(
+          /"format": ".*",/g,
+          `"format": "prettier --write \\"src/**/*.{js,jsx,json,md,ts,tsx}\\"",`,
+        )
+        packageJsonRaw = packageJsonRaw.replace(
+          /"lint": ".*",/g,
+          `"lint": "eslint src test --fix --ext .js,.ts,.tsx && npm run format",`,
+        )
+      }
+
       // - If we need native dirs, change up start scripts from Expo Go variation to expo run:platform.
       if (needsPrebuild) {
-        packageJsonRaw = packageJsonRaw
-          .replace(/start --android/g, "run:android")
-          .replace(/start --ios/g, "run:ios")
-
         // If using canary build, update the expo dependency to the canary version
         if (expoVersion) {
           const expoDistTagOutput = await system.run("npm view expo dist-tags --json")
@@ -597,15 +624,14 @@ module.exports = {
         )
       }
 
-      // - If we're removing the demo code, clean up some dependencies that are no longer needed
+      // If we're removing the demo code, clean up some dependencies that are no longer needed
       if (removeDemo) {
         log(`Removing demo dependencies... ${demoDependenciesToRemove.join(", ")}`)
         packageJsonRaw = findAndRemoveDemoDependencies(packageJsonRaw)
       }
 
-      // - Then write it back out.
+      // Then write it back out.
       const packageJson = JSON.parse(packageJsonRaw)
-
       write("./package.json", packageJson)
       // #endregion
 
@@ -682,8 +708,8 @@ module.exports = {
         startSpinner(unboxingMessage)
         await packager.install({ ...packagerOptions, onProgress: log })
 
-        // if we're using the canary build, we need to install the canary versions of supporting Expo packages
-        if (expoVersion) {
+        // if we're using the Expo Go or canary build, we need to install the canary versions of supporting Expo packages
+        if (expoVersion || workflow === "expo") {
           await system.run("npx expo install --fix", { onProgress: log })
         }
         stopSpinner(unboxingMessage, "🧶")
@@ -726,6 +752,11 @@ module.exports = {
           appJson.expo.plugins[1][1].ios.deploymentTarget = "13.4"
         }
 
+        if (expoRouter) {
+          appJson.expo.experiments.typedRoutes = true
+          appJson.expo.plugins.push("expo-router")
+        }
+
         write("./app.json", appJson)
       } catch (e) {
         log(e)
@@ -766,6 +797,64 @@ module.exports = {
         p(yellow(`Unable to remove demo ${removeDemoPart}.`))
       }
       stopSpinner(` Removing fancy demo ${removeDemoPart}`, "🛠️")
+      // #endregion
+
+      // #region Expo Router edits
+      /**
+       * instructions mostly adapted from https://ignitecookbook.com/docs/recipes/ExpoRouter
+       * TODO
+       * fix generators
+       * remove the resetNavigation command from reactotronConfig
+       */
+      if (expoRouter) {
+        // mv ALL files under app/ to src/
+        await system.run(log(`mv app/* src/`))
+
+        // replace app/ with src/ in files
+        const expoRouterFilesToFix = [
+          "tsconfig.json",
+          "test/i18n.test.ts",
+          "src/devtools/ReactotronConfig.ts",
+          "src/components/Toggle.tsx",
+          "src/components/ListView.tsx",
+          "src/screens/WelcomeScreen.tsx",
+        ]
+        expoRouterFilesToFix.forEach((file) => {
+          const filePath = path(targetPath, file)
+          let fileContents = read(filePath)
+          fileContents = fileContents.replace(/app\//g, "src/")
+          write(filePath, fileContents)
+        })
+
+        // work in reactotron custom commands
+        const reactotronConfigPath = path(targetPath, "src/devtools/ReactotronConfig.ts")
+        let reactotronConfig = read(reactotronConfigPath)
+        reactotronConfig = reactotronConfig
+          .replace(
+            /import { goBack, resetRoot, navigate }.*/g,
+            'import { router } from "expo-router"',
+          )
+          .replace(/navigate\(route as any\).*/g, "router.push(route)")
+          .replace(/goBack\(\).*/g, " router.back()")
+
+        write(reactotronConfigPath, reactotronConfig)
+
+        // some clean up
+        await system.run(
+          log(`
+          \\rm src/app.tsx
+          mkdir src/components/ErrorBoundary
+          mv src/screens/ErrorScreen/* src/components/ErrorBoundary
+          rm -rf src/screens
+          rm -rf src/navigators
+          rm -rf app
+        `),
+        )
+      } else {
+        // remove src/ dir since not using expo-router
+        await system.run(log(`rm -rf src`))
+      }
+
       // #endregion
 
       // #region Format generator templates EOL for Windows


### PR DESCRIPTION
## Please verify the following:

- [ ] `yarn test` **jest** tests pass with new tests, if relevant
- [ ] `yarn lint` **eslint** checks pass with new code, if relevant
- [ ] `yarn format:check` **prettier** checks pass with new code, if relevant
- [ ] `README.md` (or relevant documentation) has been updated with your changes

## Describe your PR
- Adds `expo-router` value to the `--experimental` switch
- Ignites a new app (no demo app available, though) and makes all the updates as per the [Cookbook Recipe](https://ignitecookbook.com/docs/recipes/ExpoRouter/) automatically
- Quick and dirty right now, but I got it out of my brain and it works

## TODO
- [ ] Tests? xd
- [ ] Deploy it to `next` label for in the wild testing
- [ ] Remove the one Reactotron command about resetting nav state
- [ ] Update generators (`model` and `component` as `navigator` and `screen` will vanish) - that being said the cli probably still needs [some more support for sub dir paths on `generate` command](https://github.com/infinitered/ignite/issues/2708)