### PR TITLE
fix(boilerplate): refactor signIn key to logIn

### DIFF
--- a/boilerplate/app/i18n/jp.ts
+++ b/boilerplate/app/i18n/jp.ts
@@ -34,14 +34,14 @@ const jp: Translations = {
     invalidEmail: "有効なメールアドレスを入力してください.",
   },
   loginScreen: {
-    signIn: "サインイン",
+    logIn: "サインイン",
     enterDetails:
       "ここにあなたの情報を入力してトップシークレットをアンロックしましょう。何が待ち構えているか予想もつかないはずです。はたまたそうでも無いかも - ロケットサイエンスほど複雑なものではありません。",
     emailFieldLabel: "メールアドレス",
     passwordFieldLabel: "パスワード",
     emailFieldPlaceholder: "メールアドレスを入力してください",
     passwordFieldPlaceholder: "パスワードを入力してください",
-    tapToSignIn: "タップしてサインインしよう！",
+    tapToLogIn: "タップしてサインインしよう！",
     hint: "ヒント: お好みのメールアドレスとパスワードを使ってください :)",
   },
   demoNavigator: {


### PR DESCRIPTION
## Please verify the following:

- [x] `yarn test` **jest** tests pass with new tests, if relevant
- [x] `yarn lint` **eslint** checks pass with new code, if relevant
- [x] `yarn format:check` **prettier** checks pass with new code, if relevant
- [x] `README.md` (or relevant documentation) has been updated with your changes

## Describe your PR
- Updates the `jp` language string file signIn key to logIn