### PR TITLE
feat(cli): add --dir for generators

### DIFF
--- a/boilerplate/ignite/templates/component/NAME.tsx.ejs
+++ b/boilerplate/ignite/templates/component/NAME.tsx.ejs
@@ -1,4 +1,5 @@
 ---
+destinationDir: app/components
 patch:
   path: "app/components/index.ts"
   append: "export * from \"./<%= props.subdirectory %><%= props.pascalCaseName %>\"\n"

--- a/boilerplate/ignite/templates/component/NAME.tsx.ejs
+++ b/boilerplate/ignite/templates/component/NAME.tsx.ejs
@@ -1,5 +1,4 @@
 ---
-destinationDir: app/components
 patch:
   path: "app/components/index.ts"
   append: "export * from \"./<%= props.subdirectory %><%= props.pascalCaseName %>\"\n"

--- a/boilerplate/ignite/templates/model/NAME.test.ts.ejs
+++ b/boilerplate/ignite/templates/model/NAME.test.ts.ejs
@@ -1,3 +1,6 @@
+---
+destinationDir: app/models
+---
 import { <%= props.pascalCaseName %>Model } from "./<%= props.pascalCaseName %>"
 
 test("can be created", () => {

--- a/boilerplate/ignite/templates/model/NAME.ts.ejs
+++ b/boilerplate/ignite/templates/model/NAME.ts.ejs
@@ -1,4 +1,5 @@
 ---
+destinationDir: app/models
 patches:
   - path: "app/models/RootStore.ts"
     after: "from \"mobx-state-tree\"\n"

--- a/boilerplate/ignite/templates/screen/NAMEScreen.tsx.ejs
+++ b/boilerplate/ignite/templates/screen/NAMEScreen.tsx.ejs
@@ -1,4 +1,5 @@
 ---
+destinationDir: app/screens
 patches:
 - path: "app/screens/index.ts"
   append: "export * from \"./<%= props.pascalCaseName %>Screen\"\n"

--- a/docs/concept/Generator-Templates.md
+++ b/docs/concept/Generator-Templates.md
@@ -28,7 +28,7 @@ Let's say you have a file called `NAMEScreen.ts`.
 
 If they run `npx ignite-cli generate screen Pizza`, it'll name the file `PizzaScreen.ts`.
 
-If you'd like to customize the filename you can provide a filename option in the frontmatter of the template like so:
+If you'd like to customize the filename you can provide a filename option in the front matter of the template like so:
 
 ```
 ---
@@ -60,7 +60,9 @@ export function <%= props.pascalCaseName %>(props: <%= props.pascalCaseName %>Pr
 
 ## Front Matter
 
-"Front matter" is a way to specify meta-data about a template in the template itself. It's stripped out of the generated file. You delineate front matter by three dashes (`---`) above and below, and it has to be the very first thing in the template.
+"Front matter" is a way to specify meta-data about a template in the template itself. It's stripped out of the generated file. You delineate front matter by three dashes (`---`) above and below, and it has to be the very first thing in the template. The following front matter options are available:
+
+### destinationDir
 
 We use this in Ignite to customize the destination of a given template. For example, in `./ignite/templates/navigator/*` we could have:
 
@@ -74,8 +76,6 @@ import { StackNavigator } from "react-navigation"
 ```
 
 This would copy files to `./app/navigation/*` instead of the default `./app/navigators/*`.
-
-Other front matter options include:
 
 ### patch
 
@@ -110,5 +110,7 @@ patches:
     skip: <%= props.skipIndexFile %>
 ---
 ```
+
+## Notes
 
 Front matter is very powerful, but not necessarily super intuitive. If you have questions about it, ask in the [Ignite Slack community](https://community.infinite.red) or post a [Discussion](https://github.com/infinitered/ignite/discussions).

--- a/docs/concept/Generators.md
+++ b/docs/concept/Generators.md
@@ -133,7 +133,7 @@ This `--exact` switch specifies the generated filenames (`NAME` in the filename 
 
 `npx ignite-cli@latest g screen log-in` will generate `log-inScreen.tsx`
 
-### `--destinationDir`
+### `--dir`
 
 Specifies the output path for the generated files. This will override the default path of `app/` (Ignite's path where all app code lives at the time of this writing) and any `destinationDir:` front matter that exists. This is useful in the case of file-based routing navigation systems, such as [Expo Router](https://docs.expo.dev/router/introduction/).
 

--- a/docs/concept/Generators.md
+++ b/docs/concept/Generators.md
@@ -135,7 +135,7 @@ This `--exact` switch specifies the generated filenames (`NAME` in the filename 
 
 ### `--destinationDir`
 
-Specifies the output path for the generated files. This will override the default path of `app/` (Ignite's path where all app code lives at the time of this writing) and any `destinationDir:` front matter that exists. This is useful in the case of file-based routing navigation systems, such as [Expo Router](https://docs.expo.dev/router/introduction/)
+Specifies the output path for the generated files. This will override the default path of `app/` (Ignite's path where all app code lives at the time of this writing) and any `destinationDir:` front matter that exists. This is useful in the case of file-based routing navigation systems, such as [Expo Router](https://docs.expo.dev/router/introduction/).
 
 ## Customizing generators
 

--- a/docs/concept/Generators.md
+++ b/docs/concept/Generators.md
@@ -121,6 +121,22 @@ A few notes about sizes. iOS size has no upper limit, so be careful with the val
 
 Lastly, the splash-screen generator will exit if your input file has not been modified. The same source equality check, as the one on the app-icon generator, will encourage you to make customizations before using the generator (see the `--skip-source-equality-validation` section above).
 
+## CLI Options
+
+### `--exact`
+
+The default filename is PascalCased based on the name you pass in to the generate command. For example:
+
+`npx ignite-cli@latest g screen Episodes` will generate `EpisodesScreen.tsx` in the case of the default generator template `NAMEScreen.tsx`.
+
+This `--exact` switch specifies the generated filenames (`NAME` in the filename of your template) will be how you pass it in. For example:
+
+`npx ignite-cli@latest g screen log-in` will generate `log-inScreen.tsx`
+
+### `--destinationDir`
+
+Specifies the output path for the generated files. This will override the default path of `app/` (Ignite's path where all app code lives at the time of this writing) and any `destinationDir:` front matter that exists. This is useful in the case of file-based routing navigation systems, such as [Expo Router](https://docs.expo.dev/router/introduction/)
+
 ## Customizing generators
 
 You should feel free to make the provided templates your own! Just update the files in the `./ignite/templates/*` folders, and any generated files will then use your updated files. Read more in the [Generator Templates](./Generator-Templates.md) documentation.
@@ -141,6 +157,6 @@ Just run `npx ignite-cli update <type>` or `npx ignite-cli update --all` from th
 
 ## A Note About Windows
 
-If you are noticing upon using the generator for a source file (such as a screen or model) that frontmatter is not removed from the newly created file, it could be that the End of Line Sequence is misconfigured. Ignite tries to take care of this on its own, but sometimes your machine will not have a proper CLI utility such as `unix2dos` installed (this usually comes with Git).
+If you are noticing upon using the generator for a source file (such as a screen or model) that front matter is not removed from the newly created file, it could be that the End of Line Sequence is misconfigured. Ignite tries to take care of this on its own, but sometimes your machine will not have a proper CLI utility such as `unix2dos` installed (this usually comes with Git).
 
 In this case, you can open VS Code (or another IDE) and convert the EOL characters for all `ejs` files in the `ignite/templates` directory. Then run the generator command again and it should create the new files properly.

--- a/docs/concept/Generators.md
+++ b/docs/concept/Generators.md
@@ -123,15 +123,28 @@ Lastly, the splash-screen generator will exit if your input file has not been mo
 
 ## CLI Options
 
-### `--exact`
+### `--case`
 
-The default filename is PascalCased based on the name you pass in to the generate command. For example:
+The default filename format is PascalCase (`--case auto` or `--case pascal`), based on the name you pass in to the generate command. For example:
 
 `npx ignite-cli@latest g screen Episodes` will generate `EpisodesScreen.tsx` in the case of the default generator template `NAMEScreen.tsx`.
 
-This `--exact` switch specifies the generated filenames (`NAME` in the filename of your template) will be how you pass it in. For example:
+This `--case` switch specifies the generated filenames (`NAME` in the filename of your template) will be how you pass it in. For example:
 
-`npx ignite-cli@latest g screen log-in` will generate `log-inScreen.tsx`
+`npx ignite-cli@latest g screen log-in` will generate the following outputs given their template name:
+
+| --case       | tpl filename       | generated filename |
+| ------------ | ------------------ | ------------------ |
+| auto, pascal | NAMEScreen.tsx.ejs | LogInScreen.tsx    |
+| camel        | NAMEScreen.tsx.ejs | logInScreen.tsx    |
+| snake        | NAMEScreen.tsx.ejs | log_in_screen.tsx  |
+| kebab        | NAMEScreen.tsx.ejs | log-in-screen.tsx  |
+| none         | NAMEScreen.tsx.ejs | log-in.tsx         |
+| auto, pascal | NAME.tsx.ejs       | LogIn.tsx          |
+| camel        | NAME.tsx.ejs       | logIn.tsx          |
+| snake        | NAME.tsx.ejs       | log_in.tsx         |
+| kebab        | NAME.tsx.ejs       | log-in.tsx         |
+| none         | NAME.tsx.ejs       | log-in.tsx         |
 
 ### `--dir`
 

--- a/src/commands/generate.ts
+++ b/src/commands/generate.ts
@@ -21,8 +21,8 @@ async function generate(toolbox: GluegunToolbox) {
   // what generator are we running?
   const generator = parameters.first.toLowerCase()
 
-  // check if we should override front matter destinationDir or default dir
-  const destinationDir = parameters.options.destinationDir ?? parameters.third
+  // check if we should override front matter dir or default dir
+  const dir = parameters.options.dir ?? parameters.third
 
   // we need a name for this component
   let name = parameters.second
@@ -64,7 +64,7 @@ async function generate(toolbox: GluegunToolbox) {
     skipIndexFile: parameters.options.skipIndexFile,
     overwrite,
     subdirectory,
-    destinationDir,
+    dir,
     exact: parameters.options.exact,
   })
 

--- a/src/commands/generate.ts
+++ b/src/commands/generate.ts
@@ -21,6 +21,9 @@ async function generate(toolbox: GluegunToolbox) {
   // what generator are we running?
   const generator = parameters.first.toLowerCase()
 
+  // check if we should override front matter destinationDir or default dir
+  const destinationDir = parameters.options.destinationDir ?? parameters.third
+
   // we need a name for this component
   let name = parameters.second
   if (!name) {
@@ -57,9 +60,12 @@ async function generate(toolbox: GluegunToolbox) {
   const overwrite = !options.overwrite ? defaultOverwrite : boolFlag(options.overwrite)
   const { written, overwritten, exists } = await generateFromTemplate(generator, {
     name: pascalName,
+    originalName: name,
     skipIndexFile: parameters.options.skipIndexFile,
     overwrite,
     subdirectory,
+    destinationDir,
+    exact: parameters.options.exact,
   })
 
   heading(`Generated new files:`)

--- a/src/commands/generate.ts
+++ b/src/commands/generate.ts
@@ -65,7 +65,7 @@ async function generate(toolbox: GluegunToolbox) {
     overwrite,
     subdirectory,
     dir,
-    exact: parameters.options.exact,
+    case: parameters.options.case,
   })
 
   heading(`Generated new files:`)

--- a/src/commands/help.ts
+++ b/src/commands/help.ts
@@ -36,7 +36,7 @@ module.exports = {
       "npx ignite-cli generate component Hello",
       "npx ignite-cli generate model User",
       "npx ignite-cli generate screen Login",
-      "npx ignite-cli generate component Hello --destinationDir src/components",
+      "npx ignite-cli generate component Hello --dir src/components",
     ])
     p()
     command(

--- a/src/commands/help.ts
+++ b/src/commands/help.ts
@@ -36,6 +36,7 @@ module.exports = {
       "npx ignite-cli generate component Hello",
       "npx ignite-cli generate model User",
       "npx ignite-cli generate screen Login",
+      "npx ignite-cli generate component Hello --destinationDir src/components",
     ])
     p()
     command(

--- a/src/tools/generators.ts
+++ b/src/tools/generators.ts
@@ -83,8 +83,8 @@ export function showGeneratorHelp(toolbox: GluegunToolbox) {
   p()
   heading("Options")
   p()
-  command("--destinationDir  ", "Override front matter or default path for generated files", [
-    "npx ignite-cli g model Episodes --destinationDir src/models",
+  command("--dir  ", "Override front matter or default path for generated files", [
+    "npx ignite-cli g model Episodes --dir src/models",
   ])
   command("--exact  ", "Skips PascalCase of the name and uses it as is", [
     "npx ignite-cli g model episode --exact",
@@ -235,7 +235,7 @@ type GeneratorOptions = {
   skipIndexFile?: boolean
   subdirectory: string
   overwrite: boolean
-  destinationDir?: string
+  dir?: string
   exact?: boolean
 }
 
@@ -299,7 +299,7 @@ export async function generateFromTemplate(
 
     // where are we copying to?
     const defaultDestinationDir = path(appDir(), pluralize(generator), options.subdirectory) // e.g. app/components, app/screens, app/models
-    const overrideDestinationDir = options.destinationDir ?? frontMatterData.destinationDir // cli dir takes priority over front matter dir
+    const overrideDestinationDir = options.dir ?? frontMatterData.destinationDir // cli dir takes priority over front matter dir
     const destinationDir = overrideDestinationDir
       ? path(cwd(), overrideDestinationDir)
       : defaultDestinationDir

--- a/test/_test-helpers.ts
+++ b/test/_test-helpers.ts
@@ -41,8 +41,7 @@ function generateExpoRouterTemplatePath(pathname: string): string {
 }
 
 export function copyDefaultScreenGenerator(tempBoilerplatePath: string): void {
-  const REACT_NAVIGATION_SCREEN_TPL = `
----
+  const REACT_NAVIGATION_SCREEN_TPL = `---
 destinationDir: app/screens
 patches:
 - path: "app/screens/index.ts"
@@ -89,12 +88,10 @@ const $root: ViewStyle = {
 }
 
 export function copyExpoRouterScreenGenerator(tempBoilerplatePath: string): void {
-  const EXPO_ROUTER_SCREEN_TPL = `
-import React, { FC } from "react"
+  const EXPO_ROUTER_SCREEN_TPL = `import React, { FC } from "react"
 import { observer } from "mobx-react-lite"
 import { ViewStyle } from "react-native"
 import { Screen, Text } from "app/components"
-
 
 export default observer(function <%= props.pascalCaseName %>Screen() {
   return (

--- a/test/_test-helpers.ts
+++ b/test/_test-helpers.ts
@@ -31,3 +31,94 @@ export async function runError(cmd: string): Promise<string | any> {
   }
   return `No error thrown? Output: ${resultANSI}`
 }
+
+function generateDefaultTemplatePath(pathname: string): string {
+  return filesystem.path(pathname, "ignite", "templates", "screen", "NAMEScreen.tsx.ejs")
+}
+
+function generateExpoRouterTemplatePath(pathname: string): string {
+  return filesystem.path(pathname, "ignite", "templates", "screen", "NAME.tsx.ejs")
+}
+
+export function copyDefaultScreenGenerator(tempBoilerplatePath: string): void {
+  const REACT_NAVIGATION_SCREEN_TPL = `
+---
+destinationDir: app/screens
+patches:
+- path: "app/screens/index.ts"
+  append: "export * from "./<%= props.pascalCaseName %>Screen"\n"
+  skip: <%= props.skipIndexFile %>
+- path: "app/navigators/AppNavigator.tsx"
+  replace: "// IGNITE_GENERATOR_ANCHOR_APP_STACK_PARAM_LIST"
+  insert: "<%= props.pascalCaseName %>: undefined\n\t// IGNITE_GENERATOR_ANCHOR_APP_STACK_PARAM_LIST"
+- path: "app/navigators/AppNavigator.tsx"
+  replace: "{/* IGNITE_GENERATOR_ANCHOR_APP_STACK_SCREENS */}"
+  insert: "<Stack.Screen name="<%= props.pascalCaseName %>" component={Screens.<%= props.pascalCaseName %>Screen} />\n\t\t\t{/* IGNITE_GENERATOR_ANCHOR_APP_STACK_SCREENS */}"
+  skip: <%= props.skipIndexFile %>
+---
+import React, { FC } from "react"
+import { observer } from "mobx-react-lite"
+import { ViewStyle } from "react-native"
+import { AppStackScreenProps } from "app/navigators"
+import { Screen, Text } from "app/components"
+// import { useNavigation } from "@react-navigation/native"
+// import { useStores } from "app/models"
+
+interface <%= props.pascalCaseName %>ScreenProps extends AppStackScreenProps<"<%= props.pascalCaseName %>"> {}
+
+export const <%= props.pascalCaseName %>Screen: FC<<%= props.pascalCaseName %>ScreenProps> = observer(function <%= props.pascalCaseName %>Screen() {
+  // Pull in one of our MST stores
+  // const { someStore, anotherStore } = useStores()
+
+  // Pull in navigation via hook
+  // const navigation = useNavigation()
+  return (
+    <Screen style={$root} preset="scroll">
+      <Text text="<%= props.camelCaseName %>" />
+    </Screen>
+  )
+})
+
+const $root: ViewStyle = {
+  flex: 1,
+}
+`
+
+  const destination = generateDefaultTemplatePath(tempBoilerplatePath)
+  filesystem.write(destination, REACT_NAVIGATION_SCREEN_TPL)
+}
+
+export function copyExpoRouterScreenGenerator(tempBoilerplatePath: string): void {
+  const EXPO_ROUTER_SCREEN_TPL = `
+import React, { FC } from "react"
+import { observer } from "mobx-react-lite"
+import { ViewStyle } from "react-native"
+import { Screen, Text } from "app/components"
+
+
+export default observer(function <%= props.pascalCaseName %>Screen() {
+  return (
+    <Screen style={$root} preset="scroll">
+      <Text text="<%= props.camelCaseName %>" />
+    </Screen>
+  )
+})
+
+const $root: ViewStyle = {
+  flex: 1,
+}
+`
+
+  const destination = generateExpoRouterTemplatePath(tempBoilerplatePath)
+  filesystem.write(destination, EXPO_ROUTER_SCREEN_TPL)
+}
+
+export function removeDefaultScreenGenerator(tempBoilerplatePath: string): void {
+  const destination = generateDefaultTemplatePath(tempBoilerplatePath)
+  filesystem.remove(destination)
+}
+
+export function removeExpoRouterScreenGenerator(tempBoilerplatePath: string): void {
+  const destination = generateExpoRouterTemplatePath(tempBoilerplatePath)
+  filesystem.remove(destination)
+}

--- a/test/vanilla/ignite-generate.test.ts
+++ b/test/vanilla/ignite-generate.test.ts
@@ -436,7 +436,24 @@ describe("ignite-cli generate screens expo-router style", () => {
          /user/home/ignite/src/app/(app)/(tabs)/log-in.tsx
       "
     `)
+    expect(read(`${TEMP_DIR}/src/app/(app)/(tabs)/log-in.tsx`)).toMatchInlineSnapshot(`
+      "import React, { FC } from \\"react\\"
+      import { observer } from \\"mobx-react-lite\\"
+      import { ViewStyle } from \\"react-native\\"
+      import { Screen, Text } from \\"app/components\\"
 
-    // TODO add expect read and check template content
+      export default observer(function LogInScreen() {
+        return (
+          <Screen style={$root} preset=\\"scroll\\">
+            <Text text=\\"logIn\\" />
+          </Screen>
+        )
+      })
+
+      const $root: ViewStyle = {
+        flex: 1,
+      }
+      "
+    `)
   })
 })

--- a/test/vanilla/ignite-generate.test.ts
+++ b/test/vanilla/ignite-generate.test.ts
@@ -388,7 +388,7 @@ describe("ignite-cli generate with path params", () => {
   })
 
   it("should generate `pizza` model in the src/models directory with exact casing", async () => {
-    const result = await runIgnite(`generate model pizza --exact --dir=src/models`, options)
+    const result = await runIgnite(`generate model pizza --case=none --dir=src/models`, options)
 
     expect(replaceHomeDir(result)).toMatchInlineSnapshot(`
       "   
@@ -416,7 +416,7 @@ describe("ignite-cli generate screens expo-router style", () => {
 
   it("should generate `log-in` screen exactly in the requested path", async () => {
     const result = await runIgnite(
-      `generate screen log-in --exact --dir="src/app/(app)/(tabs)"`,
+      `generate screen log-in --case=none --dir="src/app/(app)/(tabs)"`,
       options,
     )
 
@@ -450,7 +450,7 @@ describe("ignite-cli generate screens expo-router style", () => {
 
   it("should generate dynamic id files at requested path", async () => {
     const result = await runIgnite(
-      `generate screen [id] --exact --dir="src/app/(app)/(tabs)/podcasts"`,
+      `generate screen [id] --case=none --dir="src/app/(app)/(tabs)/podcasts"`,
       options,
     )
 

--- a/test/vanilla/ignite-generate.test.ts
+++ b/test/vanilla/ignite-generate.test.ts
@@ -364,10 +364,7 @@ describe("ignite-cli generate", () => {
 
 describe("ignite-cli generate with path params", () => {
   it("should generate Topping component in the src/components directory", async () => {
-    const result = await runIgnite(
-      `generate component Topping --destination-dir=src/components`,
-      options,
-    )
+    const result = await runIgnite(`generate component Topping --dir=src/components`, options)
 
     expect(replaceHomeDir(result)).toMatchInlineSnapshot(`
       "   
@@ -379,10 +376,7 @@ describe("ignite-cli generate with path params", () => {
   })
 
   it("should generate Sicilian screen in the src/screens directory", async () => {
-    const result = await runIgnite(
-      `generate screen Sicilian --destination-dir=src/screens`,
-      options,
-    )
+    const result = await runIgnite(`generate screen Sicilian --dir=src/screens`, options)
 
     expect(replaceHomeDir(result)).toMatchInlineSnapshot(`
       "   
@@ -394,10 +388,7 @@ describe("ignite-cli generate with path params", () => {
   })
 
   it("should generate `pizza` model in the src/models directory with exact casing", async () => {
-    const result = await runIgnite(
-      `generate model pizza --exact --destination-dir=src/models`,
-      options,
-    )
+    const result = await runIgnite(`generate model pizza --exact --dir=src/models`, options)
 
     expect(replaceHomeDir(result)).toMatchInlineSnapshot(`
       "   
@@ -425,7 +416,7 @@ describe("ignite-cli generate screens expo-router style", () => {
 
   it("should generate `log-in` screen exactly in the requested path", async () => {
     const result = await runIgnite(
-      `generate screen log-in --exact --destination-dir="src/app/(app)/(tabs)"`,
+      `generate screen log-in --exact --dir="src/app/(app)/(tabs)"`,
       options,
     )
 
@@ -455,5 +446,39 @@ describe("ignite-cli generate screens expo-router style", () => {
       }
       "
     `)
+  })
+
+  it("should generate dynamic id files at requested path", async () => {
+    const result = await runIgnite(
+      `generate screen [id] --exact --dir="src/app/(app)/(tabs)/podcasts"`,
+      options,
+    )
+
+    expect(replaceHomeDir(result)).toMatchInlineSnapshot(`
+        "   
+           
+           Generated new files:
+           /user/home/ignite/src/app/(app)/(tabs)/podcasts/[id].tsx
+        "
+      `)
+    expect(read(`${TEMP_DIR}/src/app/(app)/(tabs)/podcasts/[id].tsx`)).toMatchInlineSnapshot(`
+      "import React, { FC } from \\"react\\"
+      import { observer } from \\"mobx-react-lite\\"
+      import { ViewStyle } from \\"react-native\\"
+      import { Screen, Text } from \\"app/components\\"
+
+      export default observer(function IdScreen() {
+        return (
+          <Screen style={$root} preset=\\"scroll\\">
+            <Text text=\\"id\\" />
+          </Screen>
+        )
+      })
+
+      const $root: ViewStyle = {
+        flex: 1,
+      }
+      "
+      `)
   })
 })


### PR DESCRIPTION
## Please verify the following:

- [x] `yarn test` **jest** tests pass with new tests, if relevant
- [x] `yarn lint` **eslint** checks pass with new code, if relevant
- [x] `yarn format:check` **prettier** checks pass with new code, if relevant
- [x] `README.md` (or relevant documentation) has been updated with your changes

## Goal
The generator has a path hardcoded in it, `app/`. While this is the current file structure of most Ignite projects, Expo Router becoming more popular (and some client project desired structures even without it) and uses this directory for the file-based routing system (that and `src/app/`).

The goal of these changes is to leverage Ignite generators but be flexible enough to put something in `src/app/(auth)/(tabs)/` for example, since there isn't really the pattern of a flat `screens/` directory in such projects. This will especially be nice when the functionality in #2714 lands as well, which lets you start an Ignite project with Expo Router.

## Describe your PR
- Closes #2708 
- Adds two new cli options for generators
  - `--dir` specifies where the output files should be generated (will override default app/ path and front matter if specified)
  - `--case=none` specifies that the filename should be exactly as typed in
- Updates documentation for the new options
- Updates help on generate command to display `--case` and `--dir`
- Adds tests to account for these options

