### PR TITLE
Remove demo patches along with dependencies

### DIFF
--- a/src/commands/new.ts
+++ b/src/commands/new.ts
@@ -30,7 +30,11 @@ import {
   expoGoCompatExpectedVersions,
   findAndUpdateDependencyVersions,
 } from "../tools/expoGoCompatibility"
-import { demoDependenciesToRemove, findAndRemoveDemoDependencies, findDemoPatches } from "../tools/demo"
+import {
+  demoDependenciesToRemove,
+  findAndRemoveDemoDependencies,
+  findDemoPatches,
+} from "../tools/demo"
 
 // deprecated: 'prebuild'. in favor of 'cng' instead.
 type Workflow = "expo" | "cng" | "prebuild" | "manual"
@@ -603,7 +607,7 @@ module.exports = {
         packageJsonRaw = findAndRemoveDemoDependencies(packageJsonRaw)
         const patchesToRemove = findDemoPatches()
         log(`Removing demo patches... ${patchesToRemove}`)
-        patchesToRemove.forEach(patch => filesystem.remove(patch))
+        patchesToRemove.forEach((patch) => filesystem.remove(patch))
       }
 
       // - Then write it back out.

--- a/src/commands/new.ts
+++ b/src/commands/new.ts
@@ -30,7 +30,7 @@ import {
   expoGoCompatExpectedVersions,
   findAndUpdateDependencyVersions,
 } from "../tools/expoGoCompatibility"
-import { demoDependenciesToRemove, findAndRemoveDemoDependencies } from "../tools/demo"
+import { demoDependenciesToRemove, findAndRemoveDemoDependencies, findDemoPatches } from "../tools/demo"
 
 // deprecated: 'prebuild'. in favor of 'cng' instead.
 type Workflow = "expo" | "cng" | "prebuild" | "manual"
@@ -601,6 +601,9 @@ module.exports = {
       if (removeDemo) {
         log(`Removing demo dependencies... ${demoDependenciesToRemove.join(", ")}`)
         packageJsonRaw = findAndRemoveDemoDependencies(packageJsonRaw)
+        const patchesToRemove = findDemoPatches()
+        log(`Removing demo patches... ${patchesToRemove}`)
+        patchesToRemove.forEach(patch => filesystem.remove(patch))
       }
 
       // - Then write it back out.

--- a/src/tools/demo.ts
+++ b/src/tools/demo.ts
@@ -216,12 +216,10 @@ export const demoDependenciesToRemove = [
 ]
 
 export function findDemoPatches(): string[] {
-  const globs = demoDependenciesToRemove.map((dep) => (`${dep}*.patch`))
-  const filePaths = filesystem
-    .cwd("./patches")
-    .find({
-      matching: globs
-    })
+  const globs = demoDependenciesToRemove.map((dep) => `${dep}*.patch`)
+  const filePaths = filesystem.cwd("./patches").find({
+    matching: globs,
+  })
   return filePaths
 }
 

--- a/src/tools/demo.ts
+++ b/src/tools/demo.ts
@@ -215,6 +215,16 @@ export const demoDependenciesToRemove = [
   "react-native-drawer-layout",
 ]
 
+export function findDemoPatches(): string[] {
+  const globs = demoDependenciesToRemove.map((dep) => (`${dep}*.patch`))
+  const filePaths = filesystem
+    .cwd("./patches")
+    .find({
+      matching: globs
+    })
+  return filePaths
+}
+
 // This function takes a package.json file as a string and removes the dependencies
 // specified in demoDependenciesToRemove and returns the updated package.json as a string.
 export function findAndRemoveDemoDependencies(packageJsonRaw: string): string {


### PR DESCRIPTION
## Please verify the following:

- [x] `yarn test` **jest** tests pass with new tests, if relevant
- [x] `yarn lint` **eslint** checks pass with new code, if relevant
- [x] `yarn format:check` **prettier** checks pass with new code, if relevant
- [x] `README.md` (or relevant documentation) has been updated with your changes

## Describe your PR

While testing fixes to component testing config, I found that a project generated with `ignite-cli@latest` and `--removeDemo` would have an error when installing a new dependency, because there was a patch for `react-native-drawer-layout`, which had been removed from the project:

```
patch-package 8.0.0
Applying patches...
Error: Patch file found for package react-native-drawer-layout which is not present at node_modules/react-native-drawer-layout
---
```

So now, in addition to removing demo-only dependencies, we'll remove any matching patch files from the project.