### PR TITLE
fix(boilerplate): remove GestureHandlerRootView

### DIFF
--- a/boilerplate/app/app.tsx
+++ b/boilerplate/app/app.tsx
@@ -16,6 +16,7 @@ if (__DEV__) {
   // If you turn it off in metro.config.js, you'll have to manually import it.
   require("./devtools/ReactotronConfig.ts")
 }
+import "./utils/gestureHandler"
 import "./i18n"
 import "./utils/ignoreWarnings"
 import { useFonts } from "expo-font"
@@ -28,8 +29,6 @@ import { ErrorBoundary } from "./screens/ErrorScreen/ErrorBoundary"
 import * as storage from "./utils/storage"
 import { customFontsToLoad } from "./theme"
 import Config from "./config"
-import { GestureHandlerRootView } from "react-native-gesture-handler"
-import { ViewStyle } from "react-native"
 
 export const NAVIGATION_PERSISTENCE_KEY = "NAVIGATION_STATE"
 
@@ -102,20 +101,14 @@ function App(props: AppProps) {
   return (
     <SafeAreaProvider initialMetrics={initialWindowMetrics}>
       <ErrorBoundary catchErrors={Config.catchErrors}>
-        <GestureHandlerRootView style={$container}>
-          <AppNavigator
-            linking={linking}
-            initialState={initialNavigationState}
-            onStateChange={onNavigationStateChange}
-          />
-        </GestureHandlerRootView>
+        <AppNavigator
+          linking={linking}
+          initialState={initialNavigationState}
+          onStateChange={onNavigationStateChange}
+        />
       </ErrorBoundary>
     </SafeAreaProvider>
   )
 }
 
 export default App
-
-const $container: ViewStyle = {
-  flex: 1,
-}

--- a/boilerplate/app/utils/gestureHandler.native.ts
+++ b/boilerplate/app/utils/gestureHandler.native.ts
@@ -1,0 +1,3 @@
+// Only import react-native-gesture-handler on native platforms
+// https://reactnavigation.org/docs/drawer-navigator/#installation
+import "react-native-gesture-handler"

--- a/boilerplate/app/utils/gestureHandler.ts
+++ b/boilerplate/app/utils/gestureHandler.ts
@@ -1,0 +1,2 @@
+// Don't import react-native-gesture-handler on web
+// https://reactnavigation.org/docs/drawer-navigator/#installation


### PR DESCRIPTION
## Please verify the following:

- [ ] `yarn test` **jest** tests pass with new tests, if relevant
- [ ] `yarn lint` **eslint** checks pass with new code, if relevant
- [ ] `yarn format:check` **prettier** checks pass with new code, if relevant
- [ ] `README.md` (or relevant documentation) has been updated with your changes

## Describe your PR
- Removes unnecessary `<GestureHandlerRootView />` from `app.tsx`
- This wrapper is only necessary if specifically using the Gesture Handler API (which the demo application does not)
- Coached by @satya164 in this [Twitter thread](https://x.com/satya164/status/1821493278245548051)