### PR TITLE
[v10] Fix expo template with RN upgrade

### DIFF
--- a/boilerplate/package.json
+++ b/boilerplate/package.json
@@ -54,7 +54,7 @@
     "mobx-state-tree": "5.3.0",
     "react": "18.2.0",
     "react-dom": "18.2.0",
-    "react-native": "0.74.3",
+    "react-native": "0.74.5",
     "react-native-drawer-layout": "4.0.0-alpha.9",
     "react-native-gesture-handler": "~2.16.1",
     "react-native-mmkv": "^2.12.2",

--- a/boilerplate/patches/@expo+metro-runtime+3.2.2.patch
+++ b/boilerplate/patches/@expo+metro-runtime+3.2.2.patch
@@ -1,0 +1,13 @@
+diff --git a/node_modules/@expo/metro-runtime/build/LoadingView.native.js b/node_modules/@expo/metro-runtime/build/LoadingView.native.js
+index c7ba770..b29469c 100644
+--- a/node_modules/@expo/metro-runtime/build/LoadingView.native.js
++++ b/node_modules/@expo/metro-runtime/build/LoadingView.native.js
+@@ -6,7 +6,7 @@ try {
+ }
+ catch {
+     // In react-native 0.75.0 LoadingView was renamed to DevLoadingView
+-    LoadingView = require('react-native/Libraries/Utilities/DevLoadingView');
++    // LoadingView = require('react-native/Libraries/Utilities/DevLoadingView');
+ }
+ exports.default = LoadingView;
+ //# sourceMappingURL=LoadingView.native.js.map


### PR DESCRIPTION
## Please verify the following:

- [x] `yarn test` **jest** tests pass with new tests, if relevant
- [x] `yarn lint` **eslint** checks pass with new code, if relevant
- [x] `yarn format:check` **prettier** checks pass with new code, if relevant
- [x] `README.md` (or relevant documentation) has been updated with your changes

## Describe your PR

Updates the RN version in use to fix an issue that was preventing all Android builds: https://github.com/expo/expo/issues/31005.

Once I upgraded, though, I ran into another issue: the JS bundle fails to load with:

    ```
    iOS Bundling failed 3255ms node_modules/expo/AppEntry.js (1892 modules)
    Unable to resolve "react-native/Libraries/Utilities/DevLoadingView" from "node_modules/@expo/metro-runtime/build/LoadingView.native.js"
    ```

This is in a conditional in LoadingView.native.js that should load the correct one, and does, so this appears to be an issue with conditional requires. I'm not sure how to fix that underlying issue just yet, so patching for now.

Will file a ticket to follow up with better long-term fixes, including potentially pinning the template version in use.