### PR TITLE
fix: change locale code for Japanese to ja

### DIFF
--- a/boilerplate/app/i18n/demo-ja.ts
+++ b/boilerplate/app/i18n/demo-ja.ts
@@ -1,6 +1,6 @@
 import { DemoTranslations } from "./demo-en"
 
-export const demoJp: DemoTranslations = {
+export const demoJa: DemoTranslations = {
   demoIcon: {
     description:
       "あらかじめ登録されたアイコンを描画するコンポーネントです。 `onPress` が提供されている場合は <TouchableOpacity /> にラップされますが、それ以外の場合は <View /> にラップされます。",
@@ -459,6 +459,6 @@ export const demoJp: DemoTranslations = {
   },
 }
 
-export default demoJp
+export default demoJa
 
 // @demo remove-file

--- a/boilerplate/app/i18n/i18n.ts
+++ b/boilerplate/app/i18n/i18n.ts
@@ -16,7 +16,7 @@ import jp from "./jp"
 // to use regional locales use { "en-US": enUS } etc
 const fallbackLocale = "en-US"
 export const i18n = new I18n(
-  { ar, en, "en-US": en, ko, fr, jp },
+  { ar, en, "en-US": en, ko, fr, ja: jp },
   { locale: fallbackLocale, defaultLocale: fallbackLocale, enableFallback: true },
 )
 

--- a/boilerplate/app/i18n/i18n.ts
+++ b/boilerplate/app/i18n/i18n.ts
@@ -7,7 +7,7 @@ import en, { Translations } from "./en"
 import ar from "./ar"
 import ko from "./ko"
 import fr from "./fr"
-import jp from "./jp"
+import ja from "./ja"
 
 // Migration guide from i18n 3.x -> 4.x:
 // https://github.com/fnando/i18n-js/blob/main/MIGRATING_FROM_V3_TO_V4.md
@@ -16,7 +16,7 @@ import jp from "./jp"
 // to use regional locales use { "en-US": enUS } etc
 const fallbackLocale = "en-US"
 export const i18n = new I18n(
-  { ar, en, "en-US": en, ko, fr, ja: jp },
+  { ar, en, "en-US": en, ko, fr, ja },
   { locale: fallbackLocale, defaultLocale: fallbackLocale, enableFallback: true },
 )
 

--- a/boilerplate/app/i18n/ja.ts
+++ b/boilerplate/app/i18n/ja.ts
@@ -1,7 +1,7 @@
-import demoJp from "./demo-jp"
+import demoJa from "./demo-ja"
 import { Translations } from "./en"
 
-const jp: Translations = {
+const ja: Translations = {
   common: {
     ok: "OK",
     cancel: "キャンセル",
@@ -123,8 +123,8 @@ const jp: Translations = {
     },
   },
   // @demo remove-block-start
-  ...demoJp,
+  ...demoJa,
   // @demo remove-block-end
 }
 
-export default jp
+export default ja

--- a/test/vanilla/__snapshots__/ignite-remove-demo.test.ts.snap
+++ b/test/vanilla/__snapshots__/ignite-remove-demo.test.ts.snap
@@ -10,11 +10,11 @@ exports[`ignite-cli remove-demo should print the expected response 1`] = `
    Found '@demo remove-file' in /user/home/ignite/app/i18n/demo-ar.ts
    Found '@demo remove-file' in /user/home/ignite/app/i18n/demo-en.ts
    Found '@demo remove-file' in /user/home/ignite/app/i18n/demo-fr.ts
-   Found '@demo remove-file' in /user/home/ignite/app/i18n/demo-jp.ts
+   Found '@demo remove-file' in /user/home/ignite/app/i18n/demo-ja.ts
    Found '@demo remove-file' in /user/home/ignite/app/i18n/demo-ko.ts
    Found '@demo remove-current-line', '@demo remove-block-start', '@demo remove-block-end' in /user/home/ignite/app/i18n/en.ts
    Found '@demo remove-current-line', '@demo remove-block-start', '@demo remove-block-end' in /user/home/ignite/app/i18n/fr.ts
-   Found '@demo remove-current-line', '@demo remove-block-start', '@demo remove-block-end' in /user/home/ignite/app/i18n/jp.ts
+   Found '@demo remove-current-line', '@demo remove-block-start', '@demo remove-block-end' in /user/home/ignite/app/i18n/ja.ts
    Found '@demo remove-current-line', '@demo remove-block-start', '@demo remove-block-end' in /user/home/ignite/app/i18n/ko.ts
    Found '@demo remove-file' in /user/home/ignite/app/models/AuthenticationStore.ts
    Found '@demo remove-file' in /user/home/ignite/app/models/Episode.test.ts


### PR DESCRIPTION
## Please verify the following:

- [x] `yarn test` **jest** tests pass with new tests, if relevant
- [x] `yarn lint` **eslint** checks pass with new code, if relevant
- [x] `yarn format:check` **prettier** checks pass with new code, if relevant
- [x] `README.md` (or relevant documentation) has been updated with your changes

## Describe your PR

I'm so sorry I just realized the locale code for Japanese was `ja` while the shortened name of the language itself is `jp`🙏 This PR fixes the locale applied in the `i18n.ts` to fix the bug that jp language isn't recognized by i18n. I sware this is the final PR for the series of translations

<img width="350" src="https://github.com/user-attachments/assets/22439758-123c-4aa4-95b0-555d80021abf">