### PR TITLE
Add yarn cache to gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -23,3 +23,6 @@ boilerplate/.gitignore.template
 
 # flame CLI
 .config
+
+# Yarn
+.yarn/*

--- a/boilerplate/.gitignore
+++ b/boilerplate/.gitignore
@@ -87,3 +87,6 @@ web-build/
 !env.js
 
 /coverage
+
+# Yarn
+.yarn/*


### PR DESCRIPTION
## Please verify the following:

- [x] `yarn test` **jest** tests pass with new tests, if relevant
- [x] `yarn lint` **eslint** checks pass with new code, if relevant
- [x] `yarn format:check` **prettier** checks pass with new code, if relevant
- [x] `README.md` (or relevant documentation) has been updated with your changes

## Describe your PR

Add the `.yarn` cache folder within the root `.gitignore` and bootstrap's `.gitignore`, to avoid the potential of git adding these files to the repo. 
