### PR TITLE
fix(boilerplate): react-test-renderer devDep for RNTL + npm

### DIFF
--- a/boilerplate/package.json
+++ b/boilerplate/package.json
@@ -90,6 +90,7 @@
     "patch-package": "^8.0.0",
     "postinstall-prepare": "1.0.1",
     "prettier": "2.8.8",
+    "react-test-renderer": "18.2.0",
     "reactotron-core-client": "^2.8.13",
     "reactotron-mst": "^3.1.7",
     "reactotron-react-js": "^3.3.11",


### PR DESCRIPTION
## Please verify the following:

- [ ] `yarn test` **jest** tests pass with new tests, if relevant
- [ ] `yarn lint` **eslint** checks pass with new code, if relevant
- [ ] `yarn format:check` **prettier** checks pass with new code, if relevant
- [ ] `README.md` (or relevant documentation) has been updated with your changes

## Describe your PR
- Closes #2747
- Must test with `--packager=npm` and see a successful project generates (currently CI doesn't test this)