### PR TITLE
Stream test command output to file for debugging purposes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -21,6 +21,9 @@ boilerplate/yarn.lock
 boilerplate/bun.lockb
 boilerplate/.gitignore.template
 
+# Test artifacts
+test/artifacts/*
+
 # flame CLI
 .config
 

--- a/boilerplate/test/setup.ts
+++ b/boilerplate/test/setup.ts
@@ -1,10 +1,6 @@
 // we always make sure 'react-native' gets included first
 import * as ReactNative from "react-native"
 import mockFile from "./mockFile"
-import { ensureArtifactsDirectory } from "../../test/_test-helpers"
-
-// make sure the git-ignored artifacts directory exists
-ensureArtifactsDirectory();
 
 // libraries to mock
 jest.doMock("react-native", () => {

--- a/boilerplate/test/setup.ts
+++ b/boilerplate/test/setup.ts
@@ -1,6 +1,10 @@
 // we always make sure 'react-native' gets included first
 import * as ReactNative from "react-native"
 import mockFile from "./mockFile"
+import { ensureArtifactsDirectory } from "../../test/_test-helpers"
+
+// make sure the git-ignored artifacts directory exists
+ensureArtifactsDirectory();
 
 // libraries to mock
 jest.doMock("react-native", () => {

--- a/test/_test-helpers.ts
+++ b/test/_test-helpers.ts
@@ -65,11 +65,11 @@ async function runSpawnAndLog(cmd: string, outputLog: WriteStream): Promise<numb
   return new Promise((resolve, reject) => {
     const subprocess = spawn('sh', ['-c', cmd], { stdio: ['ignore', outputLog, outputLog] })
     subprocess.on('close', (code) => {
-      console.log(`${cmd} exited with code ${code}`)
+      console.debug(`${cmd} exited with code ${code}`)
       resolve(code ?? 99)
     })
     subprocess.on('error', (err) => {
-      console.log(`Failed to start subprocess: ${err}`)
+      console.debug(`Failed to start subprocess: ${err}`)
       reject(err)
     })
   })

--- a/test/_test-helpers.ts
+++ b/test/_test-helpers.ts
@@ -31,6 +31,10 @@ type CommandOutput = {
   exitCode: number,
 }
 
+// Use `spawn` to run ignite command so that we can capture output in case of failure.
+// We write to a file in order to ensure we have at least partial output if there's enough errors that max buffer size is reached.
+// If the command completes, we'll read from the file and return the output.
+// Error code can be used to log output to test console only in case of error.
 export async function spawnIgnite(cmd: string, options: SpawnOptions): Promise<CommandOutput> {
   const fullCmd = `${options.pre ? options.pre + " && " : ""}${IGNITE} ${cmd}${options.post ? " && " + options.post : ""}`
   await deleteFileIfExists(options.outputFile)

--- a/test/_test-helpers.ts
+++ b/test/_test-helpers.ts
@@ -112,7 +112,11 @@ export async function spawnAndLog(cmd: string, options: SpawnOptions): Promise<C
 }
 
 export async function run(cmd: string, options: RunOptions = {}): Promise<string> {
-  const resultANSI = await system.run(buildCommand(cmd, options), shellOpts)
+  const pre = options.pre ? `${options.pre} && ` : ""
+  const post = options.post ? ` && ${options.post}` : ""
+  const resultANSI = await system.run(`${pre}${cmd}${post}`, shellOpts)
+  // this might have gone wrong?
+  // const resultANSI = await system.run(buildCommand(cmd, options), shellOpts)
   return stripANSI(resultANSI)
 }
 

--- a/test/_test-helpers.ts
+++ b/test/_test-helpers.ts
@@ -65,11 +65,11 @@ async function runSpawnAndLog(cmd: string, outputLog: WriteStream): Promise<numb
   return new Promise((resolve, reject) => {
     const subprocess = spawn('sh', ['-c', cmd], { stdio: ['ignore', outputLog, outputLog] })
     subprocess.on('close', (code) => {
-      console.debug(`${cmd} exited with code ${code}`)
+      console.log(`${cmd} exited with code ${code}`)
       resolve(code ?? 99)
     })
     subprocess.on('error', (err) => {
-      console.debug(`Failed to start subprocess: ${err}`)
+      console.log(`Failed to start subprocess: ${err}`)
       reject(err)
     })
   })

--- a/test/_test-helpers.ts
+++ b/test/_test-helpers.ts
@@ -18,8 +18,8 @@ type SpawnOptions = RunOptions & {
 }
 
 type CommandOutput = {
-  output: string,
-  exitCode: number,
+  output: string
+  exitCode: number
 }
 
 function buildCommand(cmd: string, options: RunOptions) {
@@ -58,8 +58,8 @@ async function setUpLogFile(filePath: string): Promise<WriteStream> {
   const outputLog = filesystem.createWriteStream(filePath)
 
   await new Promise((resolve, reject) => {
-    outputLog.on('open', resolve)
-    outputLog.on('error', err => reject(err))
+    outputLog.on("open", resolve)
+    outputLog.on("error", (err) => reject(err))
   })
 
   return outputLog
@@ -78,12 +78,12 @@ async function setUpLogFile(filePath: string): Promise<WriteStream> {
  */
 async function startSpawnAndLog(cmd: string, outputLog: WriteStream): Promise<number> {
   return new Promise((resolve, reject) => {
-    const subprocess = spawn('sh', ['-c', cmd], { stdio: ['ignore', outputLog, outputLog] })
-    subprocess.on('close', (code) => {
+    const subprocess = spawn("sh", ["-c", cmd], { stdio: ["ignore", outputLog, outputLog] })
+    subprocess.on("close", (code) => {
       console.log(`${cmd} exited with code ${code}`)
       resolve(code ?? 99)
     })
-    subprocess.on('error', (err) => {
+    subprocess.on("error", (err) => {
       console.log(`Failed to start subprocess: ${err}`)
       reject(err)
     })
@@ -117,7 +117,7 @@ export async function spawnAndLog(cmd: string, options: SpawnOptions): Promise<C
 
     const fileData = await filesystem.readAsync(filePath)
     if (fileData === undefined) {
-      throw new Error('Failed to read output file')
+      throw new Error("Failed to read output file")
     }
     return { exitCode, output: fileData }
   } catch (e) {
@@ -128,7 +128,10 @@ export async function spawnAndLog(cmd: string, options: SpawnOptions): Promise<C
 
 // Designed for printing command output to the Jest test console if it fails, by
 // throwing the output.
-export async function spawnIgniteAndPrintIfFail(cmd: string, options: SpawnOptions): Promise<string> {
+export async function spawnIgniteAndPrintIfFail(
+  cmd: string,
+  options: SpawnOptions,
+): Promise<string> {
   const { output, exitCode } = await spawnAndLogIgnite(cmd, options)
   if (exitCode !== 0) {
     // print entire command output to test console
@@ -138,7 +141,10 @@ export async function spawnIgniteAndPrintIfFail(cmd: string, options: SpawnOptio
   }
 }
 
-export async function spawnAndLogIgnite(cmd: string, options: SpawnOptions): Promise<CommandOutput> {
+export async function spawnAndLogIgnite(
+  cmd: string,
+  options: SpawnOptions,
+): Promise<CommandOutput> {
   return spawnAndLog(`${IGNITE} ${cmd}`, options)
 }
 

--- a/test/_test-helpers.ts
+++ b/test/_test-helpers.ts
@@ -34,11 +34,8 @@ type CommandOutput = {
 
 const artifactsDirectory = filesystem.path(__dirname, "artifacts")
 
-export function ensureArtifactsDirectory() {
-  filesystem.dir(artifactsDirectory)
-}
-
 async function setUpLogFile(filePath: string): Promise<WriteStream> {
+  filesystem.dir(artifactsDirectory)
   const outputLog = filesystem.createWriteStream(filePath)
 
   await new Promise((resolve, reject) => {

--- a/test/_test-helpers.ts
+++ b/test/_test-helpers.ts
@@ -126,6 +126,13 @@ export async function spawnAndLog(cmd: string, options: SpawnOptions): Promise<C
   }
 }
 
+export async function spawnAndLogIgnite(
+  cmd: string,
+  options: SpawnOptions,
+): Promise<CommandOutput> {
+  return spawnAndLog(`${IGNITE} ${cmd}`, options)
+}
+
 // Designed for printing command output to the Jest test console if it fails, by
 // throwing the output.
 export async function spawnIgniteAndPrintIfFail(
@@ -139,13 +146,6 @@ export async function spawnIgniteAndPrintIfFail(
   } else {
     return output
   }
-}
-
-export async function spawnAndLogIgnite(
-  cmd: string,
-  options: SpawnOptions,
-): Promise<CommandOutput> {
-  return spawnAndLog(`${IGNITE} ${cmd}`, options)
 }
 
 function generateDefaultTemplatePath(pathname: string): string {

--- a/test/vanilla/ignite-new-expo-router.test.ts
+++ b/test/vanilla/ignite-new-expo-router.test.ts
@@ -1,6 +1,7 @@
 import { filesystem } from "gluegun"
 import * as tempy from "tempy"
-import { run, runIgnite } from "../_test-helpers"
+import { run, runIgnite, spawnAndLog } from "../_test-helpers"
+import { stripANSI } from "../../src/tools/strip-ansi"
 
 const APP_NAME = "Foo"
 const originalDir = process.cwd()
@@ -14,13 +15,19 @@ describe(`ignite new with expo-router`, () => {
     beforeAll(async () => {
       tempDir = tempy.directory({ prefix: "ignite-" })
       try {
-        result = await runIgnite(
+        const commandOutput = await spawnAndLog(
           `new ${APP_NAME} --debug --packager=bun --install-deps=true --experimental=expo-router --state=mst --yes`,
           {
             pre: `cd ${tempDir}`,
             post: `cd ${originalDir}`,
+            outputFileName: 'ignite-new-router-bun.txt'
           },
         )
+        result = commandOutput.output
+        if (commandOutput.exitCode !== 0) {
+        // print entire command output to test console
+          throw new Error(`Ignite new exited with code ${commandOutput.exitCode}: \n${stripANSI(result)}`)
+        }
       } catch (e) {
         // Uncomment to debug tests. Leaving commented for now, because we were
         // seeing issues with max buffer size exceeded.

--- a/test/vanilla/ignite-new-expo-router.test.ts
+++ b/test/vanilla/ignite-new-expo-router.test.ts
@@ -1,7 +1,6 @@
 import { filesystem } from "gluegun"
 import * as tempy from "tempy"
-import { run, runIgnite, spawnAndLog } from "../_test-helpers"
-import { stripANSI } from "../../src/tools/strip-ansi"
+import { run, runIgnite, spawnIgniteAndPrintIfFail } from "../_test-helpers"
 
 const APP_NAME = "Foo"
 const originalDir = process.cwd()
@@ -14,26 +13,14 @@ describe(`ignite new with expo-router`, () => {
 
     beforeAll(async () => {
       tempDir = tempy.directory({ prefix: "ignite-" })
-      try {
-        const commandOutput = await spawnAndLog(
+      result = await spawnIgniteAndPrintIfFail(
           `new ${APP_NAME} --debug --packager=bun --install-deps=true --experimental=expo-router --state=mst --yes`,
           {
             pre: `cd ${tempDir}`,
             post: `cd ${originalDir}`,
             outputFileName: 'ignite-new-router-bun.txt'
           },
-        )
-        result = commandOutput.output
-        if (commandOutput.exitCode !== 0) {
-        // print entire command output to test console
-          throw new Error(`Ignite new exited with code ${commandOutput.exitCode}: \n${stripANSI(result)}`)
-        }
-      } catch (e) {
-        // Uncomment to debug tests. Leaving commented for now, because we were
-        // seeing issues with max buffer size exceeded.
-        // console.log("Ignite new output: \n", stripANSI(e.stdout))
-        throw new Error("Ignite new failed")
-      }
+      )
       appPath = filesystem.path(tempDir, APP_NAME)
     })
 

--- a/test/vanilla/ignite-new-expo-router.test.ts
+++ b/test/vanilla/ignite-new-expo-router.test.ts
@@ -14,12 +14,12 @@ describe(`ignite new with expo-router`, () => {
     beforeAll(async () => {
       tempDir = tempy.directory({ prefix: "ignite-" })
       result = await spawnIgniteAndPrintIfFail(
-          `new ${APP_NAME} --debug --packager=bun --install-deps=true --experimental=expo-router --state=mst --yes`,
-          {
-            pre: `cd ${tempDir}`,
-            post: `cd ${originalDir}`,
-            outputFileName: 'ignite-new-router-bun.txt'
-          },
+        `new ${APP_NAME} --debug --packager=bun --install-deps=true --experimental=expo-router --state=mst --yes`,
+        {
+          pre: `cd ${tempDir}`,
+          post: `cd ${originalDir}`,
+          outputFileName: "ignite-new-router-bun.txt",
+        },
       )
       appPath = filesystem.path(tempDir, APP_NAME)
     })

--- a/test/vanilla/ignite-new.test.ts
+++ b/test/vanilla/ignite-new.test.ts
@@ -329,51 +329,6 @@ describe("ignite new", () => {
 
     // we're done!
   })
-
-  // Yarn (only testing what might be affected by a different package manager: dependency installation, running commands)
-  describe(`ignite new ${APP_NAME} --debug --packager=yarn --workflow=cng --yes`, () => {
-    let tempDir: string
-    let result: string
-    let appPath: string
-    beforeAll(async () => {
-      tempDir = tempy.directory({ prefix: "ignite-" })
-
-      result = await runIgnite(`new ${APP_NAME} --debug --packager=yarn --workflow=cng --yes`, {
-        pre: `cd ${tempDir}`,
-        post: `cd ${originalDir}`,
-      })
-
-      appPath = filesystem.path(tempDir, APP_NAME)
-    })
-
-    afterAll(() => {
-      // console.log(tempDir) // uncomment for debugging, then run `code <tempDir>` to see the generated app
-      filesystem.remove(tempDir) // clean up our mess
-    })
-
-    it("should print success message", () => {
-      // at some point this should probably be a snapshot?
-      expect(result).toContain("Now get cooking! 🍽")
-    })
-
-    it("should be able to use `generate` command and have pass output pass yarn test, yarn lint, and yarn compile scripts", async () => {
-      // other common test operations
-      const runOpts = {
-        pre: `cd ${appPath}`,
-        post: `cd ${originalDir}`,
-      }
-
-      // #region Assert package.json Scripts Can Be Run
-      // run the tests; if they fail, run will raise and this test will fail
-      await run(`yarn test`, runOpts)
-      await run(`yarn lint`, runOpts)
-      await run(`yarn compile`, runOpts)
-      expect(await run("git diff HEAD --no-ext-diff", runOpts)).toBe("")
-    })
-    // #endregion
-
-    // we're done!
-  })
 })
 
 async function checkForLeftoverHelloWorld(filePath: string) {

--- a/test/vanilla/ignite-new.test.ts
+++ b/test/vanilla/ignite-new.test.ts
@@ -34,7 +34,7 @@ describe("ignite new", () => {
       result = await spawnIgniteAndPrintIfFail(`new ${APP_NAME} --debug --packager=bun --yes`, {
         pre: `cd ${tempDir}`,
         post: `cd ${originalDir}`,
-        outputFileName: "ignite-new-output-bun.txt"
+        outputFileName: "ignite-new-output-bun.txt",
       })
 
       appPath = filesystem.path(tempDir, APP_NAME)
@@ -281,11 +281,14 @@ describe("ignite new", () => {
     beforeAll(async () => {
       tempDir = tempy.directory({ prefix: "ignite-" })
 
-      result = await spawnIgniteAndPrintIfFail(`new ${APP_NAME} --debug --packager=yarn --workflow=cng --yes`, {
-        pre: `cd ${tempDir}`,
-        post: `cd ${originalDir}`,
-        outputFileName: "ignite-new-output-yarn.txt"
-      })
+      result = await spawnIgniteAndPrintIfFail(
+        `new ${APP_NAME} --debug --packager=yarn --workflow=cng --yes`,
+        {
+          pre: `cd ${tempDir}`,
+          post: `cd ${originalDir}`,
+          outputFileName: "ignite-new-output-yarn.txt",
+        },
+      )
 
       appPath = filesystem.path(tempDir, APP_NAME)
     })

--- a/test/vanilla/ignite-new.test.ts
+++ b/test/vanilla/ignite-new.test.ts
@@ -1,6 +1,6 @@
 import { filesystem } from "gluegun"
 import * as tempy from "tempy"
-import { spawnIgnite, runError, run, runIgnite } from "../_test-helpers"
+import { spawnAndLog, runError, run, runIgnite } from "../_test-helpers"
 import { stripANSI } from "../../src/tools/strip-ansi"
 
 const APP_NAME = "Foo"
@@ -32,7 +32,7 @@ describe("ignite new", () => {
     beforeAll(async () => {
       tempDir = tempy.directory({ prefix: "ignite-" })
 
-      const commandOutput = await spawnIgnite(`new ${APP_NAME} --debug --packager=bun --yes`, {
+      const commandOutput = await spawnAndLog(`new ${APP_NAME} --debug --packager=bun --yes`, {
         pre: `cd ${tempDir}`,
         post: `cd ${originalDir}`,
         outputFileName: "ignite-new-output.txt"
@@ -287,7 +287,7 @@ describe("ignite new", () => {
     beforeAll(async () => {
       tempDir = tempy.directory({ prefix: "ignite-" })
 
-      const commandOutput = await spawnIgnite(`new ${APP_NAME} --debug --packager=yarn --workflow=cng --yes`, {
+      const commandOutput = await spawnAndLog(`new ${APP_NAME} --debug --packager=yarn --workflow=cng --yes`, {
         pre: `cd ${tempDir}`,
         post: `cd ${originalDir}`,
         outputFileName: "ignite-new-output.txt"

--- a/test/vanilla/ignite-new.test.ts
+++ b/test/vanilla/ignite-new.test.ts
@@ -35,7 +35,7 @@ describe("ignite new", () => {
       const commandOutput = await spawnIgnite(`new ${APP_NAME} --debug --packager=bun --yes`, {
         pre: `cd ${tempDir}`,
         post: `cd ${originalDir}`,
-        outputFile: "ignite-new-output.txt"
+        outputFileName: "ignite-new-output.txt"
       })
       result = commandOutput.output
       if (commandOutput.exitCode !== 0) {
@@ -290,7 +290,7 @@ describe("ignite new", () => {
       const commandOutput = await spawnIgnite(`new ${APP_NAME} --debug --packager=yarn --workflow=cng --yes`, {
         pre: `cd ${tempDir}`,
         post: `cd ${originalDir}`,
-        outputFile: "ignite-new-output.txt"
+        outputFileName: "ignite-new-output.txt"
       })
       result = commandOutput.output
       if (commandOutput.exitCode !== 0) {

--- a/test/vanilla/ignite-new.test.ts
+++ b/test/vanilla/ignite-new.test.ts
@@ -35,7 +35,7 @@ describe("ignite new", () => {
       const commandOutput = await spawnAndLog(`new ${APP_NAME} --debug --packager=bun --yes`, {
         pre: `cd ${tempDir}`,
         post: `cd ${originalDir}`,
-        outputFileName: "ignite-new-output.txt"
+        outputFileName: "ignite-new-output-bun.txt"
       })
       result = commandOutput.output
       if (commandOutput.exitCode !== 0) {
@@ -290,7 +290,7 @@ describe("ignite new", () => {
       const commandOutput = await spawnAndLog(`new ${APP_NAME} --debug --packager=yarn --workflow=cng --yes`, {
         pre: `cd ${tempDir}`,
         post: `cd ${originalDir}`,
-        outputFileName: "ignite-new-output.txt"
+        outputFileName: "ignite-new-output-yarn.txt"
       })
       result = commandOutput.output
       if (commandOutput.exitCode !== 0) {

--- a/test/vanilla/ignite-new.test.ts
+++ b/test/vanilla/ignite-new.test.ts
@@ -1,7 +1,6 @@
 import { filesystem } from "gluegun"
 import * as tempy from "tempy"
-import { spawnAndLog, runError, run, runIgnite } from "../_test-helpers"
-import { stripANSI } from "../../src/tools/strip-ansi"
+import { runError, run, runIgnite, spawnIgniteAndPrintIfFail } from "../_test-helpers"
 
 const APP_NAME = "Foo"
 const originalDir = process.cwd()
@@ -32,16 +31,11 @@ describe("ignite new", () => {
     beforeAll(async () => {
       tempDir = tempy.directory({ prefix: "ignite-" })
 
-      const commandOutput = await spawnAndLog(`new ${APP_NAME} --debug --packager=bun --yes`, {
+      result = await spawnIgniteAndPrintIfFail(`new ${APP_NAME} --debug --packager=bun --yes`, {
         pre: `cd ${tempDir}`,
         post: `cd ${originalDir}`,
         outputFileName: "ignite-new-output-bun.txt"
       })
-      result = commandOutput.output
-      if (commandOutput.exitCode !== 0) {
-        // print entire command output to test console
-        throw new Error(`Ignite new exited with code ${commandOutput.exitCode}: \n${stripANSI(result)}`)
-      }
 
       appPath = filesystem.path(tempDir, APP_NAME)
     })
@@ -287,16 +281,11 @@ describe("ignite new", () => {
     beforeAll(async () => {
       tempDir = tempy.directory({ prefix: "ignite-" })
 
-      const commandOutput = await spawnAndLog(`new ${APP_NAME} --debug --packager=yarn --workflow=cng --yes`, {
+      result = await spawnIgniteAndPrintIfFail(`new ${APP_NAME} --debug --packager=yarn --workflow=cng --yes`, {
         pre: `cd ${tempDir}`,
         post: `cd ${originalDir}`,
         outputFileName: "ignite-new-output-yarn.txt"
       })
-      result = commandOutput.output
-      if (commandOutput.exitCode !== 0) {
-        // print entire command output to test console
-        throw new Error(`Ignite new exited with code ${commandOutput.exitCode}: \n${stripANSI(result)}`)
-      }
 
       appPath = filesystem.path(tempDir, APP_NAME)
     })

--- a/test/vanilla/ignite-new.test.ts
+++ b/test/vanilla/ignite-new.test.ts
@@ -287,10 +287,16 @@ describe("ignite new", () => {
     beforeAll(async () => {
       tempDir = tempy.directory({ prefix: "ignite-" })
 
-      result = await runIgnite(`new ${APP_NAME} --debug --packager=yarn --workflow=cng --yes`, {
+      const commandOutput = await spawnIgnite(`new ${APP_NAME} --debug --packager=yarn --workflow=cng --yes`, {
         pre: `cd ${tempDir}`,
         post: `cd ${originalDir}`,
+        outputFile: "ignite-new-output.txt"
       })
+      result = commandOutput.output
+      if (commandOutput.exitCode !== 0) {
+        // print entire command output to test console
+        throw new Error(`Ignite new exited with code ${commandOutput.exitCode}: \n${stripANSI(result)}`)
+      }
 
       appPath = filesystem.path(tempDir, APP_NAME)
     })


### PR DESCRIPTION
## Please verify the following:

- [x] `yarn test` **jest** tests pass with new tests, if relevant
- [x] `yarn lint` **eslint** checks pass with new code, if relevant
- [x] `yarn format:check` **prettier** checks pass with new code, if relevant
- [x] `README.md` (or relevant documentation) has been updated with your changes

## Describe your PR

### What

We needed `ignite new` output to be printed by failing tests when developing; otherwise you have to generate the app at least twice to see why a given test is failing.

### Approach

The way to get jest to print the output we want is by throwing it when the command fails. However, when we tried this, we found it was possible for the output to be so large for certain errors that it can hit node’s max buffer size, which *also* means you don’t get to view the error (and get a red herring error on top of that.)

That means we should stream the output with `spawn`, to manage output that's too large. In this PR, we stream it to a file so there’s always at least a partial record of the output, even if we fail to be able to print it to the console.

Existing tests expect a string of command output to test against, and so the simplest implementation for now was to just read the output from the file again. There’s potential for changing  this in the future but it should work just fine for now, since the happy path doesn’t involve output too large for a buffer.

### Testing

Throw an error somewhere in `new.ts`. it should be printed to the console for tests that run `ignite new`.

### Future improvements to consider

- Use with more commands? right now I focused on just `ignite new` since that's where we tend to have issues
    - it is getting a little silly to make `verbIgnite` versions of all these commands in order to account for appending Ignite in there. Might want to handle that differently. (As an options flag? Let the caller handle it?)
- Log cleanup?
    - I don’t think it’s necessary right now; they’re gitignored and re-written each test run. Shouldn’t be too much stuff.
- testing against streamed data instead of loading it all in as one file
    - complicated! Chunks of stream are probably not the entire string we want to test against, and what a given chunk looks like can change as things are added before it. Have to build a test utility library for this, practically.
- Avoid logging command run on normal test runs
    - Was hoping to use jest's `--verbose` flag to control this, but it doesn't appear to work like that. I think it’s more useful to log the command run than not, and it doesn’t take up too much space.
- automated log naming when using the spawn fns? tried look at auto-naming logs based on tests, jest doesn’t appear to have an affordance for that
