### PR TITLE
fix(cli): improper MST removal when using CLI prompt, new arch compat

### DIFF
--- a/boilerplate/app/devtools/ReactotronConfig.ts
+++ b/boilerplate/app/devtools/ReactotronConfig.ts
@@ -9,7 +9,10 @@ import { ArgType } from "reactotron-core-client"
 import { mst } from "reactotron-mst" // @mst remove-current-line
 import mmkvPlugin from "reactotron-react-native-mmkv"
 
-import { storage, clear } from "@/utils/storage"
+import {
+  storage,
+  clear, // @mst remove-current-line
+} from "@/utils/storage"
 import { goBack, resetRoot, navigate } from "@/navigators/navigationUtilities"
 
 import { Reactotron } from "./ReactotronClient"

--- a/boilerplate/src/app/_layout.tsx
+++ b/boilerplate/src/app/_layout.tsx
@@ -27,7 +27,8 @@ export default function Root() {
 
   const [fontsLoaded, fontError] = useFonts(customFontsToLoad)
 
-  const loaded = fontsLoaded && rehydrated
+  const loaded = fontsLoaded 
+                         && rehydrated // @mst remove-current-line
 
   useEffect(() => {
     if (fontError) throw fontError

--- a/src/commands/new.ts
+++ b/src/commands/new.ts
@@ -31,7 +31,11 @@ import type { ValidationsExports } from "../tools/validations"
 import { boolFlag } from "../tools/flag"
 import { cache } from "../tools/cache"
 import { mstDependenciesToRemove } from "../tools/mst"
-import { findAndRemoveDependencies } from "../tools/dependencies"
+import {
+  findAndRemoveDependencies,
+  findAndUpdateDependencyVersions,
+  newArchCompatExpectedVersions,
+} from "../tools/dependencies"
 import { demoDependenciesToRemove, findDemoPatches } from "../tools/demo"
 
 type Workflow = "cng" | "manual"
@@ -656,6 +660,14 @@ module.exports = {
       if (stateMgmt === "none") {
         log(`Removing MST dependencies... ${mstDependenciesToRemove.join(", ")}`)
         packageJsonRaw = findAndRemoveDependencies(packageJsonRaw, mstDependenciesToRemove)
+      }
+
+      if (experimentalNewArch) {
+        log(`Swapping new architecture compatible dependencies...`)
+        packageJsonRaw = findAndUpdateDependencyVersions(
+          packageJsonRaw,
+          newArchCompatExpectedVersions,
+        )
       }
 
       // Then write it back out.

--- a/src/commands/new.ts
+++ b/src/commands/new.ts
@@ -366,7 +366,7 @@ module.exports = {
           format: prettyPrompt.format.boolean,
           prefix,
         }))
-        stateMgmt = includeMSTResponse.includeMST
+        stateMgmt = includeMSTResponse.includeMST ? "mst" : "none"
       }
     }
 

--- a/src/tools/dependencies.ts
+++ b/src/tools/dependencies.ts
@@ -24,3 +24,25 @@ export function removePackageJSONDependencies(
   const updatedPackageJson = findAndRemoveDependencies(packageJsonRaw, dependenciesToRemove)
   filesystem.write(packageJsonPath, updatedPackageJson)
 }
+
+export function findAndUpdateDependencyVersions(
+  packageJsonRaw: string,
+  dependencies: Record<string, string>,
+): string {
+  let updatedPackageJson = packageJsonRaw
+
+  Object.keys(dependencies).forEach((depName) => {
+    const desiredVersion = dependencies[depName]
+    const regex = new RegExp(`"${depName}"\\s*:\\s*"[^"]+"`, "g")
+    updatedPackageJson = updatedPackageJson.replace(regex, `"${depName}": "${desiredVersion}"`)
+  })
+
+  // Make sure `expo-dev-client` is removed
+  updatedPackageJson = updatedPackageJson.replace(/"expo-dev-client"\s*:\s*"[^"]+",?/g, "")
+
+  return updatedPackageJson
+}
+
+export const newArchCompatExpectedVersions = {
+  "react-native-mmkv": "3.0.1",
+}


### PR DESCRIPTION
## Please verify the following:

- [ ] `yarn test` **jest** tests pass with new tests, if relevant
- [ ] `yarn lint` **eslint** checks pass with new code, if relevant
- [ ] `yarn format:check` **prettier** checks pass with new code, if relevant
- [ ] `README.md` (or relevant documentation) has been updated with your changes

## Describe your PR
- As described by @markrickert, when using the prompts to set the following scenario (yarn, no demo, git repo, install deps, no MST, expo router, new arch) - MST was not removed properly
- With proper MST removal, the `lint` step failed inside of the ReactotronConfig leaving in `clear` from `@/utils/storage` which we were no longer needing, so I added the proper MST removal directives around that)
- Also occurs in the main `_layout` file when in the `expo-router` scenario
- When opting into the new architecture, some libraries need to be updated (for example `react-native-mmkv` from 2 to 3), the `new` command has updates for this