### PR TITLE
Fix language switching and update date-fns to v4

### DIFF
--- a/boilerplate/app/app.tsx
+++ b/boilerplate/app/app.tsx
@@ -30,6 +30,7 @@ import * as storage from "./utils/storage"
 import { customFontsToLoad } from "./theme"
 import Config from "./config"
 import { KeyboardProvider } from "react-native-keyboard-controller"
+import { loadDateFnsLocale } from "./utils/formatDate"
 
 export const NAVIGATION_PERSISTENCE_KEY = "NAVIGATION_STATE"
 
@@ -75,7 +76,9 @@ function App(props: AppProps) {
   const [isI18nInitialized, setIsI18nInitialized] = useState(false)
 
   useEffect(() => {
-    initI18n().then(() => setIsI18nInitialized(true))
+    initI18n()
+      .then(() => setIsI18nInitialized(true))
+      .then(() => loadDateFnsLocale())
   }, [])
 
   // @mst replace-next-line React.useEffect(() => {

--- a/boilerplate/app/i18n/i18n.ts
+++ b/boilerplate/app/i18n/i18n.ts
@@ -1,6 +1,6 @@
 import * as Localization from "expo-localization"
 import { I18nManager } from "react-native"
-import * as i18next from "i18next"
+import i18n from "i18next"
 import { initReactI18next } from "react-i18next"
 import "intl-pluralrules"
 
@@ -14,8 +14,6 @@ import ja from "./ja"
 import hi from "./hi"
 
 const fallbackLocale = "en-US"
-
-export let i18n: i18next.i18n
 
 const systemLocales = Localization.getLocales()
 
@@ -46,7 +44,7 @@ if (locale?.languageTag && locale?.textDirection === "rtl") {
 }
 
 export const initI18n = async () => {
-  i18n = i18next.use(initReactI18next)
+  i18n.use(initReactI18next)
 
   await i18n.init({
     resources,

--- a/boilerplate/app/i18n/i18n.ts
+++ b/boilerplate/app/i18n/i18n.ts
@@ -13,55 +13,52 @@ import fr from "./fr"
 import ja from "./ja"
 import hi from "./hi"
 
-// to use regional locales use { "en-US": enUS } etc
 const fallbackLocale = "en-US"
 
 export let i18n: i18next.i18n
 
-const systemLocale = Localization.getLocales()[0]
-const systemLocaleTag = systemLocale?.languageTag ?? fallbackLocale
+const systemLocales = Localization.getLocales()
+
+const resources = { ar, en, ko, es, fr, ja, hi }
+const supportedTags = Object.keys(resources)
+
+// Checks to see if the device locale matches any of the supported locales
+// Device locale may be more specific and still match (e.g., en-US matches en)
+const systemTagMatchesSupportedTags = (deviceTag: string) => {
+  const primaryTag = deviceTag.split("-")[0]
+  return supportedTags.includes(primaryTag)
+}
+
+const pickSupportedLocale: () => Localization.Locale | undefined = () => {
+  return systemLocales.find((locale) => systemTagMatchesSupportedTags(locale.languageTag))
+}
+
+const locale = pickSupportedLocale()
+
+export let isRTL = false
+
+// Need to set RTL ASAP to ensure the app is rendered correctly. Waiting for i18n to init is too late.
+if (locale?.languageTag && locale?.textDirection === "rtl") {
+  I18nManager.allowRTL(true)
+  isRTL = true
+} else {
+  I18nManager.allowRTL(false)
+}
 
 export const initI18n = async () => {
   i18n = i18next.use(initReactI18next)
 
   await i18n.init({
-    resources: {
-      ar,
-      en,
-      "en-US": en,
-      ko,
-      es,
-      fr,
-      ja,
-      hi,
-    },
-    lng: fallbackLocale,
+    resources,
+    lng: locale?.languageTag ?? fallbackLocale,
     fallbackLng: fallbackLocale,
     interpolation: {
       escapeValue: false,
     },
   })
 
-  if (Object.prototype.hasOwnProperty.call(i18n.languages, systemLocaleTag)) {
-    // if specific locales like en-FI or en-US is available, set it
-    await i18n.changeLanguage(systemLocaleTag)
-  } else {
-    // otherwise try to fallback to the general locale (dropping the -XX suffix)
-    const generalLocale = systemLocaleTag.split("-")[0]
-    if (Object.prototype.hasOwnProperty.call(i18n.languages, generalLocale)) {
-      await i18n.changeLanguage(generalLocale)
-    } else {
-      await i18n.changeLanguage(fallbackLocale)
-    }
-  }
-
   return i18n
 }
-
-// handle RTL languages
-export const isRTL = systemLocale?.textDirection === "rtl"
-I18nManager.allowRTL(isRTL)
-I18nManager.forceRTL(isRTL)
 
 /**
  * Builds up valid keypaths for translations.

--- a/boilerplate/app/i18n/translate.ts
+++ b/boilerplate/app/i18n/translate.ts
@@ -1,10 +1,11 @@
-import { TOptions } from "i18next"
-import { i18n, TxKeyPath } from "./i18n"
+import i18n from "i18next"
+import type { TOptions } from "i18next"
+import { TxKeyPath } from "./i18n"
 
 /**
  * Translates text.
  * @param {TxKeyPath} key - The i18n key.
- * @param {i18n.TOptions} options - The i18n options.
+ * @param {TOptions} options - The i18n options.
  * @returns {string} - The translated text.
  * @example
  * Translations:

--- a/boilerplate/app/models/Episode.test.ts
+++ b/boilerplate/app/models/Episode.test.ts
@@ -27,14 +27,14 @@ const episode = EpisodeModel.create(data)
 test("publish date format", () => {
   expect(episode.datePublished.textLabel).toBe("Jan 20, 2022")
   expect(episode.datePublished.accessibilityLabel).toBe(
-    'demoPodcastListScreen:accessibility.publishLabel {"date":"Jan 20, 2022"}',
+    'demoPodcastListScreen:accessibility.publishLabel',
   )
 })
 
 test("duration format", () => {
   expect(episode.duration.textLabel).toBe("42:58")
   expect(episode.duration.accessibilityLabel).toBe(
-    'demoPodcastListScreen:accessibility.durationLabel {"hours":0,"minutes":42,"seconds":58}',
+    'demoPodcastListScreen:accessibility.durationLabel',
   )
 })
 

--- a/boilerplate/app/models/Episode.test.ts
+++ b/boilerplate/app/models/Episode.test.ts
@@ -27,14 +27,14 @@ const episode = EpisodeModel.create(data)
 test("publish date format", () => {
   expect(episode.datePublished.textLabel).toBe("Jan 20, 2022")
   expect(episode.datePublished.accessibilityLabel).toBe(
-    'demoPodcastListScreen:accessibility.publishLabel',
+    "demoPodcastListScreen:accessibility.publishLabel",
   )
 })
 
 test("duration format", () => {
   expect(episode.duration.textLabel).toBe("42:58")
   expect(episode.duration.accessibilityLabel).toBe(
-    'demoPodcastListScreen:accessibility.durationLabel',
+    "demoPodcastListScreen:accessibility.durationLabel",
   )
 })
 

--- a/boilerplate/app/utils/formatDate.ts
+++ b/boilerplate/app/utils/formatDate.ts
@@ -2,26 +2,48 @@
 // If you import with the syntax: import { format } from "date-fns" the ENTIRE library
 // will be included in your production bundle (even if you only use one function).
 // This is because react-native does not support tree-shaking.
-import type { Locale } from "date-fns"
-import format from "date-fns/format"
-import parseISO from "date-fns/parseISO"
-import ar from "date-fns/locale/ar-SA"
-import ko from "date-fns/locale/ko"
-import en from "date-fns/locale/en-US"
+import { type Locale } from "date-fns/locale"
+import { format } from "date-fns/format"
+import { parseISO } from "date-fns/parseISO"
 import i18n from "i18next"
 
 type Options = Parameters<typeof format>[2]
 
-const getLocale = (): Locale => {
-  const locale = i18n.language.split("-")[0]
-  return locale === "ar" ? ar : locale === "ko" ? ko : en
+let dateFnsLocale: Locale
+export const loadDateFnsLocale = () => {
+  const primaryTag = i18n.language.split("-")[0]
+  switch (primaryTag) {
+    case "en":
+      dateFnsLocale = require("date-fns/locale/en-US").default
+      break
+    case "ar":
+      dateFnsLocale = require("date-fns/locale/ar").default
+      break
+    case "ko":
+      dateFnsLocale = require("date-fns/locale/ko").default
+      break
+    case "es":
+      dateFnsLocale = require("date-fns/locale/es").default
+      break
+    case "fr":
+      dateFnsLocale = require("date-fns/locale/fr").default
+      break
+    case "hi":
+      dateFnsLocale = require("date-fns/locale/hi").default
+      break
+    case "ja":
+      dateFnsLocale = require("date-fns/locale/ja").default
+      break
+    default:
+      dateFnsLocale = require("date-fns/locale/en-US").default
+      break
+  }
 }
 
 export const formatDate = (date: string, dateFormat?: string, options?: Options) => {
-  const locale = getLocale()
   const dateOptions = {
     ...options,
-    locale,
+    locale: dateFnsLocale,
   }
   return format(parseISO(date), dateFormat ?? "MMM dd, yyyy", dateOptions)
 }

--- a/boilerplate/app/utils/formatDate.ts
+++ b/boilerplate/app/utils/formatDate.ts
@@ -8,7 +8,7 @@ import parseISO from "date-fns/parseISO"
 import ar from "date-fns/locale/ar-SA"
 import ko from "date-fns/locale/ko"
 import en from "date-fns/locale/en-US"
-import { i18n } from "@/i18n"
+import i18n from "i18next"
 
 type Options = Parameters<typeof format>[2]
 

--- a/boilerplate/package.json
+++ b/boilerplate/package.json
@@ -38,7 +38,7 @@
     "@react-navigation/native-stack": "^6.0.2",
     "@shopify/flash-list": "^1.6.4",
     "apisauce": "3.0.1",
-    "date-fns": "^2.30.0",
+    "date-fns": "^4.1.0",
     "expo": "~51.0.8",
     "expo-application": "~5.9.1",
     "expo-build-properties": "~0.12.1",


### PR DESCRIPTION
## Please verify the following:

- [x] `yarn test` **jest** tests pass with new tests, if relevant
- [x] `yarn lint` **eslint** checks pass with new code, if relevant
- [x] `yarn format:check` **prettier** checks pass with new code, if relevant
- [ ] `README.md` (or relevant documentation) has been updated with your changes

## Describe your PR

While updating date-fns to v4, I ran into a few issues with language switching.

### Languages were not being loaded correctly

The previous way we had of loading languages with i18n-js doesn't work with i18next. `hasOwnProperty` does not work with `i18n.languages`, as it's an array. `i18n.languages` is also empty on init, as it's only an array of the currently configured languages to use (preferred, then fallback), not all supported languages.

Instead I created a function to pick the first locale from device locales that we support, and configure i18n with that.

### Fast refresh would crash the app

This we fix by referring to i18n from the library, we don't need to store it in a variable in `i18n.ts`.

### Updates for date-fns v4

Here I just needed to update some import paths, but while I was there, I also added support for more of our supported locales, and conditionally load only the locale actually in use.

### Future improvements

I recommend we decide whether and how we want to follow up on these items later:

1. A better `Episode` test. It's not clear what this test wants to assert. If it wants to assert that the models are accounting for params correctly, we may have to find a way to manually test that, probably spying on `t()`. If it wants to assert that we're translating accessibility labels correctly, we should make it an E2E test. Etc.
2. Live reloading of locale while app is open on Android. Theoretically possible, but wasn't straightforward when I tried, particularly because we're using the `translate` function everywhere which doesn't know to react when language is changed (unlike if we were using the `useTranslation` hook.)
3. More foolproof toggling of RTL settings (i.e., always verifying if RTL setting matches what we expect, and if not, restart the app).
4. The drawer isn't rendering correctly when RTL is set, but it was also not rendering correctly with the i18n-js config. We need to circle back to this.

| Platform | This PR | With i18n-js |
|--------|--------|--------|
| iOS Device| <img src="https://github.com/user-attachments/assets/876ef5eb-6c3a-4982-8cdf-0a2187367a79" width=200 /> | don't have |
| iOS Sim | don't have | <img src="https://github.com/user-attachments/assets/8eacdaed-6172-4ee2-ae29-5018fc4c1b7a" width=200 /> |
| Android device | <img src="https://github.com/user-attachments/assets/7140bef9-6334-42d6-9c08-9de9e4ca82d6" width=200 /> | <img src="https://github.com/user-attachments/assets/6b96a503-8ba8-4cb4-b438-c0d55674c1c0" width=200 /> | 

