### PR TITLE
fix(expo-router): initialize i18n

### DIFF
--- a/boilerplate/src/app/_layout.tsx
+++ b/boilerplate/src/app/_layout.tsx
@@ -1,4 +1,4 @@
-import { useEffect } from "react"
+import { useEffect, useState } from "react"
 import { ViewStyle } from "react-native"
 import { Slot, SplashScreen } from "expo-router"
 import { GestureHandlerRootView } from "react-native-gesture-handler"
@@ -6,6 +6,8 @@ import { GestureHandlerRootView } from "react-native-gesture-handler"
 import { useInitialRootStore } from "@/models"
 import { useFonts } from "@expo-google-fonts/space-grotesk"
 import { customFontsToLoad } from "@/theme"
+import { initI18n } from "@/i18n"
+import { loadDateFnsLocale } from "@/utils/formatDate"
 
 SplashScreen.preventAutoHideAsync()
 
@@ -26,8 +28,15 @@ export default function Root() {
   // @mst remove-block-end
 
   const [fontsLoaded, fontError] = useFonts(customFontsToLoad)
+  const [isI18nInitialized, setIsI18nInitialized] = useState(false)
 
-  const loaded = fontsLoaded 
+  useEffect(() => {
+    initI18n()
+      .then(() => setIsI18nInitialized(true))
+      .then(() => loadDateFnsLocale())
+  }, [])
+
+  const loaded = fontsLoaded && isI18nInitialized 
                          && rehydrated // @mst remove-current-line
 
   useEffect(() => {


### PR DESCRIPTION
## Please verify the following:

- [ ] `yarn test` **jest** tests pass with new tests, if relevant
- [ ] `yarn lint` **eslint** checks pass with new code, if relevant
- [ ] `yarn format:check` **prettier** checks pass with new code, if relevant
- [ ] `README.md` (or relevant documentation) has been updated with your changes

## Describe your PR
- Fixes an issue in v10 where i18next wasn't initialized in an Expo Router project