### PR TITLE
Make icon default color explicit, and respond to dark mode

### DIFF
--- a/boilerplate/app/components/Icon.tsx
+++ b/boilerplate/app/components/Icon.tsx
@@ -9,6 +9,7 @@ import {
   ViewProps,
   ViewStyle,
 } from "react-native"
+import { useAppTheme } from "@/utils/useAppTheme"
 
 export type IconTypes = keyof typeof iconRegistry
 
@@ -66,9 +67,11 @@ export function Icon(props: IconProps) {
     TouchableOpacityProps | ViewProps
   >
 
+  const { theme } = useAppTheme()
+
   const $imageStyle: StyleProp<ImageStyle> = [
     $imageStyleBase,
-    color !== undefined && { tintColor: color },
+    { tintColor: color ?? theme.colors.text },
     size !== undefined && { width: size, height: size },
     $imageStyleOverride,
   ]


### PR DESCRIPTION
## Please verify the following:

- [x] `yarn test` **jest** tests pass with new tests, if relevant
- [x] `yarn lint` **eslint** checks pass with new code, if relevant
- [x] `yarn format:check` **prettier** checks pass with new code, if relevant
- [x] `README.md` (or relevant documentation) has been updated with your changes

## Describe your PR

I noticed the icons on the community screen weren't updating for dark mode.

Color isn't explicitly set by those icons, but it matches text color in our design system by default.

Here I explicitly assign a default color for icons, and make sure it updates with the theme.

| Before | After |
|--------|--------|
|  <img src="https://github.com/user-attachments/assets/bf440a93-e4ad-4be8-95c8-908c051540f3" width=250 /> | <img src="https://github.com/user-attachments/assets/f4546613-bbf9-455c-8c99-89999b3363c9" width=250 />

