### PR TITLE
fix(boilerplate): fix Toggle's Checkbox and Switch custom props

### DIFF
--- a/boilerplate/app/components/Toggle/Checkbox.tsx
+++ b/boilerplate/app/components/Toggle/Checkbox.tsx
@@ -29,13 +29,7 @@ export function Checkbox(props: CheckboxToggleProps) {
     (toggleProps: CheckboxInputProps) => <CheckboxInput {...toggleProps} icon={icon} />,
     [icon],
   )
-  return (
-    <Toggle
-      accessibilityRole="checkbox"
-      {...rest}
-      ToggleInput={checkboxInput}
-    />
-  )
+  return <Toggle accessibilityRole="checkbox" {...rest} ToggleInput={checkboxInput} />
 }
 
 function CheckboxInput(props: CheckboxInputProps) {

--- a/boilerplate/app/components/Toggle/Checkbox.tsx
+++ b/boilerplate/app/components/Toggle/Checkbox.tsx
@@ -24,7 +24,14 @@ interface CheckboxInputProps extends BaseToggleInputProps<CheckboxToggleProps> {
  * @returns {JSX.Element} The rendered `Checkbox` component.
  */
 export function Checkbox(props: CheckboxToggleProps) {
-  return <Toggle accessibilityRole="checkbox" {...props} ToggleInput={CheckboxInput} />
+  const { icon, ...rest } = props
+  return (
+    <Toggle
+      accessibilityRole="checkbox"
+      {...rest}
+      ToggleInput={(toggleProps) => <CheckboxInput {...toggleProps} icon={icon} />}
+    />
+  )
 }
 
 function CheckboxInput(props: CheckboxInputProps) {

--- a/boilerplate/app/components/Toggle/Checkbox.tsx
+++ b/boilerplate/app/components/Toggle/Checkbox.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useRef } from "react"
+import { useEffect, useRef, useCallback } from "react"
 import { Image, ImageStyle, Animated, StyleProp, View, ViewStyle } from "react-native"
 import { $styles } from "../../theme"
 import { iconRegistry, IconTypes } from "../Icon"
@@ -25,11 +25,15 @@ interface CheckboxInputProps extends BaseToggleInputProps<CheckboxToggleProps> {
  */
 export function Checkbox(props: CheckboxToggleProps) {
   const { icon, ...rest } = props
+  const checkboxInput = useCallback(
+    (toggleProps: CheckboxInputProps) => <CheckboxInput {...toggleProps} icon={icon} />,
+    [icon],
+  )
   return (
     <Toggle
       accessibilityRole="checkbox"
       {...rest}
-      ToggleInput={(toggleProps) => <CheckboxInput {...toggleProps} icon={icon} />}
+      ToggleInput={checkboxInput}
     />
   )
 }

--- a/boilerplate/app/components/Toggle/Switch.tsx
+++ b/boilerplate/app/components/Toggle/Switch.tsx
@@ -45,13 +45,7 @@ export function Switch(props: SwitchToggleProps) {
     ),
     [accessibilityMode],
   )
-  return (
-    <Toggle
-      accessibilityRole="switch"
-      {...rest}
-      ToggleInput={switchInput}
-    />
-  )
+  return <Toggle accessibilityRole="switch" {...rest} ToggleInput={switchInput} />
 }
 
 function SwitchInput(props: SwitchInputProps) {

--- a/boilerplate/app/components/Toggle/Switch.tsx
+++ b/boilerplate/app/components/Toggle/Switch.tsx
@@ -38,7 +38,16 @@ interface SwitchInputProps extends BaseToggleInputProps<SwitchToggleProps> {
  * @returns {JSX.Element} The rendered `Switch` component.
  */
 export function Switch(props: SwitchToggleProps) {
-  return <Toggle accessibilityRole="switch" {...props} ToggleInput={SwitchInput} />
+  const { accessibilityMode, ...rest } = props
+  return (
+    <Toggle
+      accessibilityRole="switch"
+      {...rest}
+      ToggleInput={(toggleProps) => (
+        <SwitchInput {...toggleProps} accessibilityMode={accessibilityMode} />
+      )}
+    />
+  )
 }
 
 function SwitchInput(props: SwitchInputProps) {

--- a/boilerplate/app/components/Toggle/Switch.tsx
+++ b/boilerplate/app/components/Toggle/Switch.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useMemo, useRef } from "react"
+import { useEffect, useMemo, useRef, useCallback } from "react"
 import {
   Animated,
   Image,
@@ -39,13 +39,17 @@ interface SwitchInputProps extends BaseToggleInputProps<SwitchToggleProps> {
  */
 export function Switch(props: SwitchToggleProps) {
   const { accessibilityMode, ...rest } = props
+  const switchInput = useCallback(
+    (toggleProps: SwitchInputProps) => (
+      <SwitchInput {...toggleProps} accessibilityMode={accessibilityMode} />
+    ),
+    [accessibilityMode],
+  )
   return (
     <Toggle
       accessibilityRole="switch"
       {...rest}
-      ToggleInput={(toggleProps) => (
-        <SwitchInput {...toggleProps} accessibilityMode={accessibilityMode} />
-      )}
+      ToggleInput={switchInput}
     />
   )
 }

--- a/boilerplate/app/screens/DemoShowroomScreen/demos/DemoToggle.tsx
+++ b/boilerplate/app/screens/DemoShowroomScreen/demos/DemoToggle.tsx
@@ -13,7 +13,7 @@ import {
 import { Demo } from "../DemoShowroomScreen"
 import { DemoDivider } from "../DemoDivider"
 import { DemoUseCase } from "../DemoUseCase"
-import type { ThemedStyle } from "@/theme"
+import { $styles, type ThemedStyle } from "@/theme"
 import { translate } from "@/i18n"
 
 function ControlledCheckbox(props: CheckboxToggleProps) {
@@ -70,6 +70,7 @@ export const DemoToggle: Demo = {
       name="demoToggle:useCase.statuses.name"
       description="demoToggle:useCase.statuses.description"
       layout="row"
+      itemStyle={$styles.flexWrap}
     >
       <ControlledCheckbox containerStyle={$centeredOneThirdCol} />
       <ControlledRadio containerStyle={$centeredOneThirdCol} />
@@ -166,6 +167,7 @@ export const DemoToggle: Demo = {
       name="demoToggle:useCase.styling.name"
       description="demoToggle:useCase.styling.description"
       layout="row"
+      itemStyle={$styles.flexWrap}
     >
       <ControlledCheckbox
         containerStyle={$centeredOneThirdCol}


### PR DESCRIPTION
## Please verify the following:

- [ ] `yarn test` **jest** tests pass with new tests, if relevant
- [x] `yarn lint` **eslint** checks pass with new code, if relevant
- [x] `yarn format:check` **prettier** checks pass with new code, if relevant
- [ ] `README.md` (or relevant documentation) has been updated with your changes
- [x] If this affects functionality there aren't tests for, I manually tested it, including by generating a new app locally if needed ([see docs](https://docs.infinite.red/ignite-cli/contributing/Contributing-To-Ignite/#testing-changes-from-your-local-copy-of-ignite)).

## Describe your PR

This PR addresses two issues: 

* In the Demo for the Toggle Showcase, two sections are not displayed properly (statuses & style). I added `$styles.flexWrap` to fix it.
* Then the custom properties of `Checkbox` and `Switch` were not pass down to the `CheckboxInput` and the `SwitchInput`, this notably broke the feature to pass down a custom icons. (There might be a more elegant way to fix this)


## Screenshots (if applicable)

<!-- If you’re submitting code changes related to a visible feature, please include before-and-after screenshots or videos. -->

<!-- If GH's auto attachment previews too large, trying resizing it with: <img src="filename-from-github-upload" width="300" /> -->

| Before                           | After                           |
| -------------------------------- | ------------------------------- |
| ![Screenshot 2024-10-13 at 11 42 39](https://github.com/user-attachments/assets/8d08a84b-871d-48cb-85f3-9f155b69e5c9)  | ![Screenshot 2024-10-13 at 11 44 15](https://github.com/user-attachments/assets/d55d2434-49cd-4f6c-bf58-1acee3e8d8d9) |
| ![Screenshot 2024-10-13 at 11 50 24](https://github.com/user-attachments/assets/dbe5226a-5437-4567-a703-697d5a57edbd) | ![Screenshot 2024-10-13 at 11 49 55](https://github.com/user-attachments/assets/3ffd51ba-855c-4a32-bc96-02d5b05fe505) |
| ![Screenshot 2024-10-13 at 11 42 54](https://github.com/user-attachments/assets/2c188266-6b9f-4ba8-865a-8ae14092f771)  | ![Screenshot 2024-10-13 at 11 50 54](https://github.com/user-attachments/assets/8a1ca9fc-9459-46ed-85ee-be2e4d11ac7b) | 
