### PR TITLE
chore: v10 typo: `setImperativeThemeing` becomes `setImperativeTheming`

### DIFF
--- a/boilerplate/app/utils/useAppTheme.ts
+++ b/boilerplate/app/utils/useAppTheme.ts
@@ -27,7 +27,7 @@ export const ThemeContext = createContext<ThemeContextType>({
 const themeContextToTheme = (themeContext: ThemeContexts): Theme =>
   themeContext === "dark" ? darkTheme : lightTheme
 
-const setImperativeThemeing = (theme: Theme) => {
+const setImperativeTheming = (theme: Theme) => {
   SystemUI.setBackgroundColorAsync(theme.colors.background)
 }
 
@@ -43,7 +43,7 @@ export const useThemeProvider = (initialTheme: ThemeContexts = undefined) => {
   const navigationTheme = themeScheme === "dark" ? DarkTheme : DefaultTheme
 
   useEffect(() => {
-    setImperativeThemeing(themeContextToTheme(themeScheme))
+    setImperativeTheming(themeContextToTheme(themeScheme))
   }, [themeScheme])
 
   return {


### PR DESCRIPTION
## Please verify the following:

- [x] `yarn test` **jest** tests pass with new tests, if relevant
- [x] `yarn lint` **eslint** checks pass with new code, if relevant
- [x] `yarn format:check` **prettier** checks pass with new code, if relevant
- [x] `README.md` (or relevant documentation) has been updated with your changes
- [x] If this affects functionality there aren't tests for, I manually tested it, including by generating a new app locally if needed ([see docs](https://docs.infinite.red/ignite-cli/contributing/Contributing-To-Ignite/#testing-changes-from-your-local-copy-of-ignite)).

## Describe your PR

Small typo fix.