### PR TITLE
chore: check node version during preinstall

### DIFF
--- a/package.json
+++ b/package.json
@@ -44,7 +44,7 @@
     "preinstall": "node ./scripts/check-node-version.js"
   },
   "engines": {
-    "node": ">=20.10.0"
+    "node": ">=20.0.0"
   },
   "dependencies": {
     "deepmerge-json": "^1.1.0",

--- a/package.json
+++ b/package.json
@@ -40,10 +40,11 @@
     "semantic-release": "semantic-release",
     "clean": "rm -drf ./build ./boilerplate/.gitignore.template ./boilerplate/node_modules ./boilerplate/ios/build/ ./boilerplate/ios/Pods/ ./boilerplate/android/app/build ./boilerplate/ios/.xcode.env.local",
     "ignite-cli:dev": "node bin/ignite",
-    "ignite-cli:prod": "wrap () { node bin/ignite \"$@\" --compiled-build | cat; }; wrap"
+    "ignite-cli:prod": "wrap () { node bin/ignite \"$@\" --compiled-build | cat; }; wrap",
+    "preinstall": "node ./scripts/check-node-version.js"
   },
   "engines": {
-    "node": "^18.18.0 || >=20.0.0"
+    "node": ">=20.10.0"
   },
   "dependencies": {
     "deepmerge-json": "^1.1.0",

--- a/scripts/check-node-version.js
+++ b/scripts/check-node-version.js
@@ -1,0 +1,30 @@
+const { engines } = require("../package.json")
+const currentNodeVersion = process.version
+const requiredNodeVersion = engines.node
+
+const compareVersions = (current, required) => {
+  const currentParts = current.replace("v", "").split(".")
+  const requiredParts = required.replace(">=", "").replace("<", "").split(".")
+
+  for (let i = 0; i < requiredParts.length; i++) {
+    const currentPart = parseInt(currentParts[i] || 0, 10)
+    const requiredPart = parseInt(requiredParts[i] || 0, 10)
+
+    if (currentPart > requiredPart) {
+      return true // Current version is higher
+    }
+    if (currentPart < requiredPart) {
+      return false // Current version is lower
+    }
+  }
+  return true // Versions match
+}
+
+if (!compareVersions(currentNodeVersion, requiredNodeVersion)) {
+  console.error(
+    `Required Node.js version ${requiredNodeVersion} not satisfied with current version ${currentNodeVersion}.`,
+  )
+  process.exit(1)
+}
+
+console.log("Node.js version is compatible.")


### PR DESCRIPTION
## Please verify the following:

- [ ] `yarn test` **jest** tests pass with new tests, if relevant
- [ ] `yarn lint` **eslint** checks pass with new code, if relevant
- [ ] `yarn format:check` **prettier** checks pass with new code, if relevant
- [ ] `README.md` (or relevant documentation) has been updated with your changes
- [ ] If this affects functionality there aren't tests for, I manually tested it, including by generating a new app locally if needed ([see docs](https://docs.infinite.red/ignite-cli/contributing/Contributing-To-Ignite/#testing-changes-from-your-local-copy-of-ignite)).

## Describe your PR
- An alternative to #2799 which only addresses `nvm` users, checks the node version prior to installing dependencies
- `nvm` doesn't respect `package.json`'s `engines.node` key (while it seems `asdf` does), but `scripts/node-version-check.js` was added to do this across all tooling

## Screenshots (if applicable)
<img width="657" alt="image" src="https://github.com/user-attachments/assets/032ff32f-a5df-4570-af7a-3f8cb80f70d8">
