### PR TITLE
refactor: replace shell commands with filesystem API in project creation

### DIFF
--- a/src/commands/new.ts
+++ b/src/commands/new.ts
@@ -842,16 +842,19 @@ module.exports = {
          * 4. Create a screen template that makes sense for Expo Router
          * 5. Clean up - move ErrorBoundary to proper spot and remove unused files
          */
-        await system.run(log(`mv app/* src/`))
+        filesystem
+          .cwd(targetPath)
+          .find("app")
+          .forEach((file) => filesystem.cwd(targetPath).move(file, file.replace("app", "src")))
         updateExpoRouterSrcDir(toolbox)
         refactorExpoRouterReactotronCmds(toolbox)
         createExpoRouterScreenTemplate(toolbox)
-        await cleanupExpoRouterConversion(toolbox)
+        cleanupExpoRouterConversion(toolbox, targetPath)
 
         stopSpinner(expoRouterMsg, "🧭")
       } else {
         // remove src/ dir since not using expo-router
-        await system.run(log(`rm -rf src`))
+        filesystem.cwd(targetPath).remove("src")
       }
       // #endregion
 

--- a/src/tools/react-native.ts
+++ b/src/tools/react-native.ts
@@ -327,27 +327,19 @@ export function updateExpoRouterSrcDir(toolbox: GluegunToolbox) {
   })
 }
 
-export async function cleanupExpoRouterConversion(toolbox: GluegunToolbox) {
-  const { system, parameters, print } = toolbox
+export function cleanupExpoRouterConversion(toolbox: GluegunToolbox, targetPath: string) {
+  const { filesystem } = toolbox
 
-  // debug?
-  const debug = boolFlag(parameters.options.debug)
-  const log = <T = unknown>(m: T): T => {
-    debug && print.info(` ${m}`)
-    return m
-  }
-
-  await system.run(
-    log(`
-      \\rm src/app.tsx
-      mkdir src/components/ErrorBoundary
-      mv src/screens/ErrorScreen/* src/components/ErrorBoundary
-      rm App.tsx
-      rm ignite/templates/screen/NAMEScreen.tsx.ejs
-      rm -rf ignite/templates/navigator
-      rm -rf src/screens
-      rm -rf src/navigators
-      rm -rf app
-    `),
+  const workingDir = filesystem.cwd(targetPath)
+  workingDir.cwd("src").remove("app.tsx")
+  workingDir.move(
+    workingDir.path("src", "screens", "ErrorScreen"),
+    workingDir.path("src", "components", "ErrorBoundary"),
   )
+  workingDir.remove("App.tsx")
+  workingDir.remove(workingDir.path("ignite", "templates", "screen", "NAMEScreen.tsx.ejs"))
+  workingDir.remove(workingDir.path("ignite", "templates", "navigator"))
+  workingDir.remove(workingDir.path("src", "screens"))
+  workingDir.remove(workingDir.path("src", "navigators"))
+  workingDir.remove("app")
 }


### PR DESCRIPTION
## Please verify the following:

- [x] `yarn test` **jest** tests pass with new tests, if relevant
- [x] `yarn lint` **eslint** checks pass with new code, if relevant
- [x] `yarn format:check` **prettier** checks pass with new code, if relevant
- [ ] `README.md` (or relevant documentation) has been updated with your changes
- [ ] If this affects functionality there aren't tests for, I manually tested it, including by generating a new app locally if needed ([see docs](https://docs.infinite.red/ignite-cli/contributing/Contributing-To-Ignite/#testing-changes-from-your-local-copy-of-ignite)).

## Describe your PR

<!-- If this PR addresses an issue, link to it in description: "Closes #333" -->

Fixes #2816.

This PR replaces the `rm` and `mv` shell commands in project creation with `gluegun (fs-jetpack)` filesystem calls to ensure compatibility with Windows (Since there's no `mv` and `rm` in Windows CMD).