### PR TITLE
fix(cli): fix issue with workflow prompt values

### DIFF
--- a/src/commands/new.ts
+++ b/src/commands/new.ts
@@ -299,12 +299,12 @@ module.exports = {
         message: "How do you want to manage Native code?",
         choices: [
           {
-            name: "CNG",
+            name: "cng",
             message: "Via Expo's Continuous Native Generation - Recommended [Default]",
             value: "cng",
           },
           {
-            name: "Manual",
+            name: "manual",
             message: "Manual - commits android/ios directories",
             value: "manual",
           },


### PR DESCRIPTION

## Describe your PR

- Closes #2819
- For some reason, even though we specify `value` in the `choices` array, the value was being set from the `name` property. I wonder if we need to check this upstream in gluegun.
- This fixes the issue where if you chose manual via the prompts, it still wouldn't remove `ios` and `android` dirs from the git ignore file (as it should have)
