### PR TITLE
Disable prop-types in linter

### DIFF
--- a/boilerplate/.eslintrc.js
+++ b/boilerplate/.eslintrc.js
@@ -41,7 +41,9 @@ module.exports = {
         ],
       },
     ],
-    //react-native
+    // react
+    "react/prop-types": 0,
+    // react-native
     "react-native/no-raw-text": 0,
     // reactotron
     "reactotron/no-tron-in-production": "error",

--- a/boilerplate/package.json
+++ b/boilerplate/package.json
@@ -90,7 +90,7 @@
     "postinstall-prepare": "1.0.1",
     "prettier": "^3.3.3",
     "react-test-renderer": "18.2.0",
-    "reactotron-core-client": "^2.8.13",
+    "reactotron-core-client": "2.9.4",
     "reactotron-mst": "^3.1.7",
     "reactotron-react-js": "^3.3.11",
     "reactotron-react-native": "^5.0.5",


### PR DESCRIPTION
Disables prop-types rule from eslint-plugin-react recommended config.

I thought this was already disabled since I hadn't seen errors with it, but ran into one today.

## Please verify the following:

- [x] `yarn test` **jest** tests pass with new tests, if relevant
- [x] `yarn lint` **eslint** checks pass with new code, if relevant
- [x] `yarn format:check` **prettier** checks pass with new code, if relevant
- [x] `README.md` (or relevant documentation) has been updated with your changes
- [x] If this affects functionality there aren't tests for, I manually tested it, including by generating a new app locally if needed ([see docs](https://docs.infinite.red/ignite-cli/contributing/Contributing-To-Ignite/#testing-changes-from-your-local-copy-of-ignite)).

## Describe your PR

<!-- If this PR addresses an issue, link to it in description: "Closes #333" -->

<!-- Add your PR description -->

## Screenshots (if applicable)

<!-- If you’re submitting code changes related to a visible feature, please include before-and-after screenshots or videos. -->

<!-- If GH's auto attachment previews too large, trying resizing it with: <img src="filename-from-github-upload" width="300" /> -->

| Before                           | After                           |
| -------------------------------- | ------------------------------- |
| [Insert before screenshot/video] | [Insert after screenshot/video] |
