### PR TITLE
fix(boilerplate): reworks some mst removal decorators

### DIFF
--- a/boilerplate/app/app.tsx
+++ b/boilerplate/app/app.tsx
@@ -101,9 +101,8 @@ function App(props: AppProps) {
   // In iOS: application:didFinishLaunchingWithOptions:
   // In Android: https://stackoverflow.com/a/45838109/204044
   // You can replace with your own loading component if you wish.
-  // @mst replace-next-line if (!isNavigationStateRestored || (!areFontsLoaded && !fontLoadError)) {
   if (
-    !rehydrated ||
+    !rehydrated || // @mst remove-current-line
     !isNavigationStateRestored ||
     !isI18nInitialized ||
     (!areFontsLoaded && !fontLoadError)

--- a/boilerplate/app/screens/WelcomeScreen.tsx
+++ b/boilerplate/app/screens/WelcomeScreen.tsx
@@ -21,7 +21,7 @@ interface WelcomeScreenProps extends AppStackScreenProps<"Welcome"> {}
 
 // @mst replace-next-line export const WelcomeScreen: FC<WelcomeScreenProps> = (
 export const WelcomeScreen: FC<WelcomeScreenProps> = observer(
-  function WelcomeScreen(
+  function WelcomeScreen( // @mst remove-current-line
     _props, // @demo remove-current-line
     // @mst replace-next-line ) => {
   ) {
@@ -81,7 +81,7 @@ export const WelcomeScreen: FC<WelcomeScreenProps> = observer(
     )
     // @mst replace-next-line }
   },
-)
+) // @mst remove-current-line
 
 const $topContainer: ThemedStyle<ViewStyle> = ({ spacing }) => ({
   flexShrink: 1,


### PR DESCRIPTION
## Please verify the following:

- [ ] `yarn test` **jest** tests pass with new tests, if relevant
- [ ] `yarn lint` **eslint** checks pass with new code, if relevant
- [ ] `yarn format:check` **prettier** checks pass with new code, if relevant
- [ ] `README.md` (or relevant documentation) has been updated with your changes
- [ ] If this affects functionality there aren't tests for, I manually tested it, including by generating a new app locally if needed ([see docs](https://docs.infinite.red/ignite-cli/contributing/Contributing-To-Ignite/#testing-changes-from-your-local-copy-of-ignite)).

## Describe your PR

- Closes #2829
- Closes #2828
- The reasons this occurred is when some different linting rules were applied (due to conditionals getting longer, prettier update, etc) the previous `@mst` mark up to remove / adjust syntax lines no longer worked. These changes fix that.

## How to Test
1. Observe failure via `npx ignite-cli@10.0.3 new PizzaLint --overwrite --packager=npm --yes --debug --install-deps false --state none --remove-demo`
2. Checkout this branch
3. Observe no failure via `ignite/bin/ignite new PizzaLint --overwrite --packager=npm --yes --debug --install-deps false --state none --remove-demo` where the first `ignite` directory is this GitHub project