### PR TITLE
fix(boilerplate): remove interop definition for FlashList

### DIFF
--- a/boilerplate/react-native.config.js
+++ b/boilerplate/react-native.config.js
@@ -5,18 +5,4 @@ module.exports = {
     // packages, you can add them to the referenced path below and uncomment this line.
     // "./assets/fonts/"
   ],
-
-  // This prevents FlashList from rendering a large red box.
-  // See: https://github.com/reactwg/react-native-new-architecture/discussions/135
-  // Remove when FlashList fully supports the new architecture.
-  // https://github.com/Shopify/flash-list/pull/550
-  //
-  project: {
-    android: {
-      unstable_reactLegacyComponentNames: ["CellContainer", "AutoLayoutView"],
-    },
-    ios: {
-      unstable_reactLegacyComponentNames: ["CellContainer", "AutoLayoutView"],
-    },
-  },
 }


### PR DESCRIPTION
## Please verify the following:

- [ ] `yarn test` **jest** tests pass with new tests, if relevant
- [ ] `yarn lint` **eslint** checks pass with new code, if relevant
- [ ] `yarn format:check` **prettier** checks pass with new code, if relevant
- [ ] `README.md` (or relevant documentation) has been updated with your changes
- [ ] If this affects functionality there aren't tests for, I manually tested it, including by generating a new app locally if needed ([see docs](https://docs.infinite.red/ignite-cli/contributing/Contributing-To-Ignite/#testing-changes-from-your-local-copy-of-ignite)).

## Describe your PR
- Removes the interop fabric definition for FlashList, since the New Architeture is now supported by that library
- I believe this is automatically handled by Expo now anyway

## Example log 

```
warn The "project.ios.unstable_reactLegacyComponentNames" config option is not necessary anymore for React Native 0.74 and does nothing. Please remove it from the "react-native.config.js" file.
warn The "project.android.unstable_reactLegacyComponentNames" config option is not necessary anymore for React Native 0.74 and does nothing. Please remove it from the "react-native.config.js" file
```