### PR TITLE
fix: include ajv in devDependencies for Expo Router and npm

### DIFF
--- a/boilerplate/package.json
+++ b/boilerplate/package.json
@@ -74,6 +74,7 @@
     "@testing-library/react-native": "^12.5.2",
     "@types/jest": "^29.2.1",
     "@types/react": "~18.2.14",
+    "ajv": "8.12.0",
     "babel-jest": "^29.2.1",
     "eslint": "^8.57.0",
     "eslint-config-expo": "^7.1.2",

--- a/boilerplate/package.json
+++ b/boilerplate/package.json
@@ -74,7 +74,6 @@
     "@testing-library/react-native": "^12.5.2",
     "@types/jest": "^29.2.1",
     "@types/react": "~18.2.14",
-    "ajv": "8.12.0",
     "babel-jest": "^29.2.1",
     "eslint": "^8.57.0",
     "eslint-config-expo": "^7.1.2",

--- a/src/commands/new.ts
+++ b/src/commands/new.ts
@@ -750,6 +750,11 @@ module.exports = {
         // do base install
         const installCmd = packager.installCmd({ packagerName })
         await system.run(installCmd, { onProgress: log })
+        // If they chose npm and also Expo Router, we need to run npm install ajv@^8 --legacy-peer-deps.
+        // see https://github.com/infinitered/ignite/issues/2840
+        if (packagerName === "npm" && experimentalExpoRouter) {
+          await system.run(`npm install ajv@^8 --legacy-peer-deps`, { onProgress: log })
+        }
         // now that expo is installed, we can run their install --fix for best Expo SDK compatibility
         const forwardOptions = packagerName === "npm" ? " -- --legacy-peer-deps" : ""
         await system.run(`npx expo install --fix${forwardOptions}`, { onProgress: log })


### PR DESCRIPTION
## Please verify the following:

- [x] `yarn test` **jest** tests pass with new tests, if relevant
- [x] `yarn lint` **eslint** checks pass with new code, if relevant
- [x] `yarn format:check` **prettier** checks pass with new code, if relevant
- [x] `README.md` (or relevant documentation) has been updated with your changes
- [x] If this affects functionality there aren't tests for, I manually tested it, including by generating a new app locally if needed ([see docs](https://docs.infinite.red/ignite-cli/contributing/Contributing-To-Ignite/#testing-changes-from-your-local-copy-of-ignite)).

## Describe your PR

<!-- If this PR addresses an issue, link to it in description: "Closes #333" -->

This would resolve one of the issues in https://github.com/infinitered/ignite/issues/2840, although there are additional problems with the Expo Router template.

<!-- Add your PR description -->

This is a little bit of a sledgehammer approach, but I wanted to start with the simple solution and we can enhance it if that seems necessary.

In https://github.com/infinitered/ignite/pull/2823, we added the `--legacy-peer-deps` flag for `npm install` commands. This fixed a problem upstream from https://github.com/standard/eslint-config-standard/issues/412, but I believe it has opened up a new problem for users who choose to use Expo Router and npm. Based on the [issues that Expo Router + ESLint has experienced with how bun resolves peer dependencies](https://github.com/expo/expo/issues/29150), I am guessing the legacy peer dependency resolution falls victim to the same problem.

The very simplest way to solve this is if the generated Ignite project includes `ajv` at the right version number in its own `devDependencies`. This version "wins" across the board.

The drawback to this approach is that if Expo Router changes its required `ajv` version, there may be some new errors for the project to resolve.

Another drawback to this PR is that it would add `ajv` to *all* projects, including other package managers that don't suffer from this problem, and including projects that do not opt in to Expo Router. So we could alternatively run `npm install ajv@^8 --legacy-peer-deps` in the install command right after https://github.com/infinitered/ignite/blob/e59d880c951a8ec729ca65f39ba0dae1de27a729/src/tools/packager.ts#L149, and maybe even do a check for if Expo Router is enabled.

## Screenshots (if applicable)

No screenshots, but running `node ~/ignite/bin/ignite new project-name` and choosing `npm` and Expo Router successfully works with this change.