### PR TITLE
fix(cli): catch expo install --fix tripping test

### DIFF
--- a/boilerplate/package.json
+++ b/boilerplate/package.json
@@ -90,7 +90,7 @@
     "postinstall-prepare": "1.0.1",
     "prettier": "^3.3.3",
     "react-test-renderer": "18.2.0",
-    "reactotron-core-client": "2.9.4",
+    "reactotron-core-client": "^2.9.4",
     "reactotron-mst": "^3.1.7",
     "reactotron-react-js": "^3.3.11",
     "reactotron-react-native": "^5.0.5",

--- a/src/commands/new.ts
+++ b/src/commands/new.ts
@@ -757,18 +757,8 @@ module.exports = {
         }
         // now that expo is installed, we can run their install --fix for best Expo SDK compatibility
         const forwardOptions = packagerName === "npm" ? " -- --legacy-peer-deps" : ""
-        // only log if not the test environment
-
-        try {
-          await system.run(`npx expo install --fix${forwardOptions}`, { onProgress: log })
-        } catch (e) {
-          log(e)
-          p(
-            yellow(
-              `Unable to run Expo's compatibility check, you may need to run \`npx expo install --fix\` after setup is completed.`,
-            ),
-          )
-        }
+        log("Running `npx expo install --fix...`")
+        await system.run(`npx expo install --fix${forwardOptions}`)
 
         stopSpinner(unboxingMessage, "🧶")
       }

--- a/src/commands/new.ts
+++ b/src/commands/new.ts
@@ -757,7 +757,18 @@ module.exports = {
         }
         // now that expo is installed, we can run their install --fix for best Expo SDK compatibility
         const forwardOptions = packagerName === "npm" ? " -- --legacy-peer-deps" : ""
-        await system.run(`npx expo install --fix${forwardOptions}`, { onProgress: log })
+        // only log if not the test environment
+
+        try {
+          await system.run(`npx expo install --fix${forwardOptions}`, { onProgress: log })
+        } catch (e) {
+          log(e)
+          p(
+            yellow(
+              `Unable to run Expo's compatibility check, you may need to run \`npx expo install --fix\` after setup is completed.`,
+            ),
+          )
+        }
 
         stopSpinner(unboxingMessage, "🧶")
       }

--- a/src/commands/new.ts
+++ b/src/commands/new.ts
@@ -761,7 +761,7 @@ module.exports = {
         if (process.env.CI !== "true") {
           const forwardOptions = packagerName === "npm" ? " -- --legacy-peer-deps" : ""
           log("Running `npx expo install --fix...`")
-          await system.run(`npx expo install --fix${forwardOptions}`)
+          await system.run(`npx expo install --fix${forwardOptions}`, { onProgress: log })
         }
 
         stopSpinner(unboxingMessage, "🧶")

--- a/src/commands/new.ts
+++ b/src/commands/new.ts
@@ -756,9 +756,13 @@ module.exports = {
           await system.run(`npm install ajv@^8 --legacy-peer-deps`, { onProgress: log })
         }
         // now that expo is installed, we can run their install --fix for best Expo SDK compatibility
-        const forwardOptions = packagerName === "npm" ? " -- --legacy-peer-deps" : ""
-        log("Running `npx expo install --fix...`")
-        await system.run(`npx expo install --fix${forwardOptions}`)
+        // for right now, we don't do this in CI because it returns a non-zero exit code
+        // see https://docs.expo.dev/more/expo-cli/#version-validation
+        if (process.env.CI !== "true") {
+          const forwardOptions = packagerName === "npm" ? " -- --legacy-peer-deps" : ""
+          log("Running `npx expo install --fix...`")
+          await system.run(`npx expo install --fix${forwardOptions}`)
+        }
 
         stopSpinner(unboxingMessage, "🧶")
       }


### PR DESCRIPTION
## Please verify the following:

- [x] `yarn test` **jest** tests pass with new tests, if relevant
- [x] `yarn lint` **eslint** checks pass with new code, if relevant
- [x] `yarn format:check` **prettier** checks pass with new code, if relevant
- [x] `README.md` (or relevant documentation) has been updated with your changes
- [ ] If this affects functionality there aren't tests for, I manually tested it, including by generating a new app locally if needed ([see docs](https://docs.infinite.red/ignite-cli/contributing/Contributing-To-Ignite/#testing-changes-from-your-local-copy-of-ignite)).

## Describe your PR

- Trying to fix the issue where Expo makes a release and `npx expo install --fix`, which is part of the new command, causes tests to fail due to it's console output
