### PR TITLE
fix: component generator template off in expo-router

### DIFF
--- a/boilerplate/ignite/templates/component/NAME.tsx.ejs
+++ b/boilerplate/ignite/templates/component/NAME.tsx.ejs
@@ -1,4 +1,5 @@
 ---
+destinationDir: app/components
 patch:
   path: "app/components/index.ts"
   append: "export * from \"./<%= props.subdirectory %><%= props.pascalCaseName %>\"\n"

--- a/boilerplate/ignite/templates/component/NAME.tsx.ejs
+++ b/boilerplate/ignite/templates/component/NAME.tsx.ejs
@@ -1,5 +1,5 @@
 ---
-destinationDir: app/components
+destinationDir: app/components/<%= props.subdirectory %>
 patch:
   path: "app/components/index.ts"
   append: "export * from \"./<%= props.subdirectory %><%= props.pascalCaseName %>\"\n"

--- a/src/tools/react-native.ts
+++ b/src/tools/react-native.ts
@@ -313,6 +313,7 @@ export function updateExpoRouterSrcDir(toolbox: GluegunToolbox) {
     "test/i18n.test.ts",
     "test/setup.ts",
     "ignite/templates/model/NAME.ts.ejs",
+    "ignite/templates/model/NAME.test.ts.ejs",
     "ignite/templates/component/NAME.tsx.ejs",
   ]
   expoRouterFilesToFix.forEach((file) => {

--- a/test/vanilla/ignite-new-expo-router.test.ts
+++ b/test/vanilla/ignite-new-expo-router.test.ts
@@ -47,6 +47,19 @@ describe(`ignite new with expo-router`, () => {
       expect(templates).toContain("screen")
       expect(templates).not.toContain("navigator")
 
+      // inspect that destinationDir has been adjusted
+      const modelTpl = filesystem.read(`${appPath}/ignite/templates/model/NAME.ts.ejs`)
+      expect(modelTpl).not.toContain("destinationDir: app/models")
+      expect(modelTpl).toContain("destinationDir: src/models")
+
+      const modelTestTpl = filesystem.read(`${appPath}/ignite/templates/model/NAME.test.ts.ejs`)
+      expect(modelTestTpl).not.toContain("destinationDir: app/models")
+      expect(modelTestTpl).toContain("destinationDir: src/models")
+
+      const componentTpl = filesystem.read(`${appPath}/ignite/templates/component/NAME.tsx.ejs`)
+      expect(componentTpl).not.toContain("app/components")
+      expect(componentTpl).toContain("src/components")
+
       // check entry point
       const packageJson = filesystem.read(`${appPath}/package.json`)
       expect(packageJson).toContain("expo-router/entry")


### PR DESCRIPTION
## Please verify the following:

- [ ] `yarn test` **jest** tests pass with new tests, if relevant
- [x] `yarn lint` **eslint** checks pass with new code, if relevant
- [x] `yarn format:check` **prettier** checks pass with new code, if relevant
- [ ] `README.md` (or relevant documentation) has been updated with your changes
- [ ] If this affects functionality there aren't tests for, I manually tested it, including by generating a new app locally if needed ([see docs](https://docs.infinite.red/ignite-cli/contributing/Contributing-To-Ignite/#testing-changes-from-your-local-copy-of-ignite)).

## Describe your PR
- Closes #2853
- Updates test to make sure this doesn't regress again
