### PR TITLE
fix(boilerplate): web platform fixes

### DIFF
--- a/boilerplate/app/screens/DemoShowroomScreen/DemoShowroomScreen.tsx
+++ b/boilerplate/app/screens/DemoShowroomScreen/DemoShowroomScreen.tsx
@@ -102,17 +102,13 @@ export const DemoShowroomScreen: FC<DemoTabScreenProps<"DemoShowroom">> =
       }
     }, [open])
 
-    const handleScroll = useCallback(
-      (sectionIndex: number, itemIndex = 0) => {
-        listRef.current?.scrollToLocation({
-          animated: true,
-          itemIndex,
-          sectionIndex,
-        })
-        toggleDrawer()
-      },
-      [toggleDrawer],
-    )
+    const handleScroll = useCallback((sectionIndex: number, itemIndex = 0) => {
+      listRef.current?.scrollToLocation({
+        animated: true,
+        itemIndex,
+        sectionIndex,
+      })
+    }, [])
 
     // handle Web links
     useEffect(() => {

--- a/boilerplate/app/screens/WelcomeScreen.tsx
+++ b/boilerplate/app/screens/WelcomeScreen.tsx
@@ -9,7 +9,7 @@ import {
 import { isRTL } from "../i18n"
 import { useStores } from "../models" // @demo remove-current-line
 import { AppStackScreenProps } from "../navigators"
-import type { ThemedStyle } from "@/theme"
+import { $styles, type ThemedStyle } from "@/theme"
 import { useHeader } from "../utils/useHeader" // @demo remove-current-line
 import { useSafeAreaInsetsStyle } from "../utils/useSafeAreaInsetsStyle"
 import { useAppTheme } from "@/utils/useAppTheme"
@@ -48,7 +48,7 @@ export const WelcomeScreen: FC<WelcomeScreenProps> = observer(
     const $bottomContainerInsets = useSafeAreaInsetsStyle(["bottom"])
 
     return (
-      <Screen preset="fixed">
+      <Screen preset="fixed" contentContainerStyle={$styles.flex1}>
         <View style={themed($topContainer)}>
           <Image style={themed($welcomeLogo)} source={welcomeLogo} resizeMode="contain" />
           <Text

--- a/boilerplate/app/utils/gestureHandler.ts
+++ b/boilerplate/app/utils/gestureHandler.ts
@@ -1,2 +1,6 @@
 // Don't import react-native-gesture-handler on web
 // https://reactnavigation.org/docs/drawer-navigator/#installation
+
+// This however is needed at the moment
+// https://github.com/software-mansion/react-native-gesture-handler/issues/2402
+import "setimmediate"

--- a/boilerplate/app/utils/useHeader.tsx
+++ b/boilerplate/app/utils/useHeader.tsx
@@ -1,6 +1,7 @@
-import { useLayoutEffect } from "react"
+import { useEffect, useLayoutEffect } from "react"
 import { useNavigation } from "@react-navigation/native"
 import { Header, HeaderProps } from "../components"
+import { Platform } from "react-native"
 
 /**
  * A hook that can be used to easily set the Header of a react-navigation screen from within the screen's component.
@@ -14,9 +15,17 @@ export function useHeader(
 ) {
   const navigation = useNavigation()
 
+  /**
+   * We need to have multiple implementations of this hook for web and mobile.
+   * Web needs to use useEffect to avoid a rendering loop.
+   * In mobile and also to avoid a visible header jump when navigating between screens, we use
+   * `useLayoutEffect`, which will apply the settings before the screen renders.
+   */
+  const usePlatformEffect = Platform.OS === "web" ? useEffect : useLayoutEffect
+
   // To avoid a visible header jump when navigating between screens, we use
   // `useLayoutEffect`, which will apply the settings before the screen renders.
-  useLayoutEffect(() => {
+  usePlatformEffect(() => {
     navigation.setOptions({
       headerShown: true,
       header: () => <Header {...headerProps} />,


### PR DESCRIPTION
## Please verify the following:

- [x] `yarn test` **jest** tests pass with new tests, if relevant
- [x] `yarn lint` **eslint** checks pass with new code, if relevant
- [x] `yarn format:check` **prettier** checks pass with new code, if relevant
- [ ] `README.md` (or relevant documentation) has been updated with your changes
- [x] If this affects functionality there aren't tests for, I manually tested it, including by generating a new app locally if needed ([see docs](https://docs.infinite.red/ignite-cli/contributing/Contributing-To-Ignite/#testing-changes-from-your-local-copy-of-ignite)).

## Describe your PR

- Closes #2807
- Addresses `useEffect` issue highlighted here: https://github.com/react-navigation/react-navigation/issues/11748
- Addresses `setImmediate` issue highlighted here: https://github.com/necolas/react-native-web/issues/1891#issuecomment-887502705
- Fixes `WelcomeScreen` displaying on Web properly
- Keyboard controller does not have issues with these latest deps (I've branched from the SDK 52 feature branch), so the fix is more straightforward than #2809
- Made an adjustment to the `toggleDrawer` being fired in `handleScroll` because it was getting caught in a loop (set state is bad in an effect anyway). So the drawer doesn't close upon clicking a nav item but it's much nicer than it not working (plus we have plans to remove the drawer from the demo application)

## Screenshots (if applicable)
### Web
| Before                           | After                           |
| -------------------------------- | ------------------------------- |
| ![image](https://github.com/user-attachments/assets/df2d002b-a023-4e0d-9117-eb6f7858ee2d) | ![image](https://github.com/user-attachments/assets/0930857d-0df7-433a-8510-f61149a7c190) |

### Regression check against mobile devices
| iPad | iPhone | Android |
| ---- | ------- | -------- |
| ![image](https://github.com/user-attachments/assets/5fab47d1-c5e0-4c63-b73f-241946a68ac0) | ![image](https://github.com/user-attachments/assets/6aa124c3-cb15-495b-894e-38ccf6d7f231) | ![image](https://github.com/user-attachments/assets/a6db48d6-dda5-41a9-990b-009941e3bd26) |

