### PR TITLE
fix: use PixelRatio for AutoImage values

### DIFF
--- a/boilerplate/app/components/AutoImage.tsx
+++ b/boilerplate/app/components/AutoImage.tsx
@@ -1,5 +1,5 @@
 import { useLayoutEffect, useState } from "react"
-import { Image, ImageProps, ImageURISource, Platform } from "react-native"
+import { Image, ImageProps, ImageURISource, Platform, PixelRatio } from "react-native"
 
 export interface AutoImageProps extends ImageProps {
   /**
@@ -52,11 +52,14 @@ export function useAutoImage(
 
   if (maxWidth && maxHeight) {
     const aspectRatio = Math.min(maxWidth / remoteWidth, maxHeight / remoteHeight)
-    return [remoteWidth * aspectRatio, remoteHeight * aspectRatio]
+    return [
+      PixelRatio.roundToNearestPixel(remoteWidth * aspectRatio),
+      PixelRatio.roundToNearestPixel(remoteHeight * aspectRatio),
+    ]
   } else if (maxWidth) {
-    return [maxWidth, maxWidth / remoteAspectRatio]
+    return [maxWidth, PixelRatio.roundToNearestPixel(maxWidth / remoteAspectRatio)]
   } else if (maxHeight) {
-    return [maxHeight * remoteAspectRatio, maxHeight]
+    return [PixelRatio.roundToNearestPixel(maxHeight * remoteAspectRatio), maxHeight]
   } else {
     return [remoteWidth, remoteHeight]
   }


### PR DESCRIPTION
## Please verify the following:

- [x] `yarn test` **jest** tests pass with new tests, if relevant
- [x] `yarn lint` **eslint** checks pass with new code, if relevant
- [x] `yarn format:check` **prettier** checks pass with new code, if relevant
- [x] `README.md` (or relevant documentation) has been updated with your changes
- [x] If this affects functionality there aren't tests for, I manually tested it, including by generating a new app locally if needed ([see docs](https://docs.infinite.red/ignite-cli/contributing/Contributing-To-Ignite/#testing-changes-from-your-local-copy-of-ignite)).

## Describe your PR

@markrickert recently made a change to this component on our client project to use [`PixelRatio.roundToNearestPixel`](https://reactnative.dev/docs/pixelratio#roundtonearestpixel) for the sizing from `useAutoImage`. No visible changes in the simulator, but it seems like a nice touch to clean up any trailing values in the auto image math.

## Screenshots (if applicable)

| Before                           | After                           |
| -------------------------------- | ------------------------------- |
| <img src="https://github.com/user-attachments/assets/55d2a1ae-b149-4e80-a0e0-caf8e519e421" width="300" /> | <img src="https://github.com/user-attachments/assets/ac216c95-3554-4c04-9fa9-687c4f9f4b9e" width="300" />  |

| Before                           | After                           |
| -------------------------------- | ------------------------------- |
| <img src="https://github.com/user-attachments/assets/1d63d5f8-976d-4065-ba68-b539f0ed7cea" width="300" /> | <img src="https://github.com/user-attachments/assets/33d3e280-2680-4474-9e4d-c56037ddf779" width="300" />  |

