### PR TITLE
fix(boilerplate): main entry point

### DIFF
--- a/boilerplate/App.tsx
+++ b/boilerplate/App.tsx
@@ -1,4 +1,5 @@
 import "@expo/metro-runtime"
+import { registerRootComponent } from "expo"
 import * as SplashScreen from "expo-splash-screen"
 import App from "@/app"
 
@@ -8,4 +9,7 @@ function IgniteApp() {
   return <App hideSplashScreen={SplashScreen.hideAsync} />
 }
 
-export default IgniteApp
+// registerRootComponent calls AppRegistry.registerComponent('main', () => App);
+// It also ensures that whether you load the app in Expo Go or in a native build,
+// the environment is set up appropriately
+registerRootComponent(IgniteApp)

--- a/boilerplate/package.json
+++ b/boilerplate/package.json
@@ -2,7 +2,7 @@
   "name": "hello-world",
   "version": "0.0.1",
   "private": true,
-  "main": "expo/AppEntry.js",
+  "main": "App.tsx",
   "scripts": {
     "compile": "tsc --noEmit -p . --pretty",
     "format": "eslint . --fix",


### PR DESCRIPTION
## Please verify the following:

- [x] `yarn test` **jest** tests pass with new tests, if relevant
- [x] `yarn lint` **eslint** checks pass with new code, if relevant
- [x] `yarn format:check` **prettier** checks pass with new code, if relevant
- [x] `README.md` (or relevant documentation) has been updated with your changes
- [x] If this affects functionality there aren't tests for, I manually tested it, including by generating a new app locally if needed ([see docs](https://docs.infinite.red/ignite-cli/contributing/Contributing-To-Ignite/#testing-changes-from-your-local-copy-of-ignite)).

## Describe your PR

- Closes #2875
- We had an old `main` value from the Expo Go days and while it worked in standard repos, it would not work properly in a monorepo out of the box. This fixes that.


## Test Plan
### Reproduction
- Follow [https://ignitecookbook.com/docs/recipes/SettingUpYarnMonorepo](Setting Up Yarn Monorepo] cookbook recipe
  - Note: in doing so I had to make some touch ups to the recipe, which can be found in [this PR](https://github.com/infinitered/ignite-cookbook/pull/184) if not yet published
- Observe the `Before` screenshot below

### Validation with plain Expo
- Follow [https://docs.expo.dev/guides/monorepos/#create-our-first-app](monorepo guide)
- Upon generating the app template, make sure to generate the app via `npx create-expo-app@latest --template react-navigation/template` to get a proper React Navigation template - otherwise `expo-router` will be used (which won't have this problem)

### Updating Ignite
- From the error state, modify the following:
  1. `package.json`, key `main` to `App.tsx` (an existing file)
  2. modify the contents of `App.tsx` to the following:

```tsx
import "@expo/metro-runtime"
import { registerRootComponent } from "expo"
import * as SplashScreen from "expo-splash-screen"
import App from "@/app"

SplashScreen.preventAutoHideAsync()

function IgniteApp() {
  return <App hideSplashScreen={SplashScreen.hideAsync} />
}

registerRootComponent(IgniteApp)
```
- Observe the `After` screenshot after running the app again

## Screenshots (if applicable)

<!-- If you’re submitting code changes related to a visible feature, please include before-and-after screenshots or videos. -->

<!-- If GH's auto attachment previews too large, trying resizing it with: <img src="filename-from-github-upload" width="300" /> -->

| Before                           | After                           |
| -------------------------------- | ------------------------------- |
| ![image](https://github.com/user-attachments/assets/bbaceee5-9c96-46db-a0a0-4001c5b394a7) | ![image](https://github.com/user-attachments/assets/2621efa1-26c8-44eb-8d02-a34655963abf) |
