### PR TITLE
fix(cli): update run commands in boilerplate README depending on packager

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -19,6 +19,7 @@ coverage
 # Ignite's source repo.
 boilerplate/yarn.lock
 boilerplate/bun.lockb
+boilerplate/bun.lock
 boilerplate/.gitignore.template
 
 # Test artifacts

--- a/src/commands/new.ts
+++ b/src/commands/new.ts
@@ -581,7 +581,14 @@ module.exports = {
       await copyBoilerplate(toolbox, {
         boilerplatePath,
         targetPath,
-        excluded: [".vscode", "node_modules", "yarn.lock", "bun.lockb", "package-lock.json"],
+        excluded: [
+          ".vscode",
+          "node_modules",
+          "yarn.lock",
+          "bun.lockb",
+          "bun.lock",
+          "package-lock.json",
+        ],
         overwrite,
       })
       stopSpinner(" 3D-printing a new React Native app", "🖨")

--- a/src/commands/new.ts
+++ b/src/commands/new.ts
@@ -9,6 +9,7 @@ import {
   refactorExpoRouterReactotronCmds,
   updateExpoRouterSrcDir,
   cleanupExpoRouterConversion,
+  updatePackagerCommandsInReadme,
 } from "../tools/react-native"
 import { packager, PackagerName } from "../tools/packager"
 import {
@@ -593,6 +594,10 @@ module.exports = {
         : boilerplate(".gitignore")
       const targetIgnorePath = log(path(targetPath, ".gitignore"))
       copy(log(boilerplateIgnorePath), targetIgnorePath, { overwrite: true })
+
+      // adjust the README.md with proper packager run commands
+      const readmePath = path(targetPath, "README.md")
+      updatePackagerCommandsInReadme(readmePath, packagerName)
 
       if (exists(targetIgnorePath) === false) {
         warning(`  Unable to copy ${boilerplateIgnorePath} to ${targetIgnorePath}`)

--- a/src/tools/react-native.test.ts
+++ b/src/tools/react-native.test.ts
@@ -1,0 +1,92 @@
+import { filesystem } from "gluegun"
+import { updatePackagerCommandsInReadme } from "./react-native"
+import * as tempy from "tempy"
+
+const EXAMPLE_README = `
+yarn
+yarn start
+yarn build:ios:sim
+yarn build:ios:dev
+yarn build:ios:prod
+`
+
+describe("react native", () => {
+  describe("updatePackagerCommandsInReadme", () => {
+    let tempDir: string
+
+    beforeEach(() => {
+      tempDir = tempy.directory({ prefix: "ignite-" })
+      filesystem.write(`${tempDir}/README.md`, EXAMPLE_README)
+    })
+
+    afterEach(() => {
+      filesystem.remove(tempDir) // clean up our mess
+    })
+
+    it("should update to npm", () => {
+      const readmePath = filesystem.path(tempDir, "README.md")
+
+      updatePackagerCommandsInReadme(readmePath, "npm")
+
+      const results = filesystem.read(readmePath)
+      const expectedResults = `
+npm install
+npm run start
+npm run build:ios:sim
+npm run build:ios:dev
+npm run build:ios:prod
+`
+
+      expect(results).toBe(expectedResults)
+    })
+
+    it("should update to yarn", () => {
+      const readmePath = filesystem.path(tempDir, "README.md")
+
+      updatePackagerCommandsInReadme(readmePath, "yarn")
+
+      const results = filesystem.read(readmePath)
+      const expectedResults = `
+yarn install
+yarn start
+yarn build:ios:sim
+yarn build:ios:dev
+yarn build:ios:prod
+`
+
+      expect(results).toBe(expectedResults)
+    })
+    it("should update to pnpm", () => {
+      const readmePath = filesystem.path(tempDir, "README.md")
+
+      updatePackagerCommandsInReadme(readmePath, "pnpm")
+
+      const results = filesystem.read(readmePath)
+      const expectedResults = `
+pnpm install
+pnpm run start
+pnpm run build:ios:sim
+pnpm run build:ios:dev
+pnpm run build:ios:prod
+`
+
+      expect(results).toBe(expectedResults)
+    })
+    it("should update to bun", () => {
+      const readmePath = filesystem.path(tempDir, "README.md")
+
+      updatePackagerCommandsInReadme(readmePath, "bun")
+
+      const results = filesystem.read(readmePath)
+      const expectedResults = `
+bun install
+bun run start
+bun run build:ios:sim
+bun run build:ios:dev
+bun run build:ios:prod
+`
+
+      expect(results).toBe(expectedResults)
+    })
+  })
+})

--- a/test/vanilla/ignite-new.test.ts
+++ b/test/vanilla/ignite-new.test.ts
@@ -56,7 +56,7 @@ describe("ignite new", () => {
       expect(dirs).toContain("ios")
       expect(dirs).toContain("android")
       expect(dirs).toContain("app")
-      expect(dirs).toContain("bun.lockb")
+      expect(dirs).toContain("bun.lock")
 
       // check the contents of ignite/templates
       const templates = filesystem.list(`${appPath}/ignite/templates`)
@@ -326,7 +326,7 @@ describe("ignite new", () => {
 async function checkForLeftoverHelloWorld(filePath: string) {
   const ignoreFolders = [
     "/xcuserdata",
-    "bun.lockb",
+    "bun.lock",
     ".git",
     "node_modules",
     "Pods",


### PR DESCRIPTION
## Please verify the following:

- [x] `yarn test` **jest** tests pass with new tests, if relevant
- [x] `yarn lint` **eslint** checks pass with new code, if relevant
- [x] `yarn format:check` **prettier** checks pass with new code, if relevant
- [x] `README.md` (or relevant documentation) has been updated with your changes
- [x] If this affects functionality there aren't tests for, I manually tested it, including by generating a new app locally if needed ([see docs](https://docs.infinite.red/ignite-cli/contributing/Contributing-To-Ignite/#testing-changes-from-your-local-copy-of-ignite)).

## Describe your PR

- Closes #2890 2890
- Looks at the `packagerName` in use for the install and updates the generated README.md with the proper install and run commands

## Screenshots (if applicable)



<!-- If GH's auto attachment previews too large, trying resizing it with: <img src="filename-from-github-upload" width="300" /> -->

| Before                           | After                           |
| -------------------------------- | ------------------------------- |
| ![image](https://github.com/user-attachments/assets/ff534ca4-cd9d-4d2f-aaf0-6f5c664d57bb) | ![image](https://github.com/user-attachments/assets/92cb2b39-6474-47ca-9cb3-878058326659) |
