### PR TITLE
test: migrate RNTL Text to screen api

### DIFF
--- a/boilerplate/app/components/Text.test.tsx
+++ b/boilerplate/app/components/Text.test.tsx
@@ -1,4 +1,4 @@
-import { render } from "@testing-library/react-native"
+import { render, screen } from "@testing-library/react-native"
 import { Text } from "./Text"
 
 /* This is an example component test using react-native-testing-library. For more
@@ -8,7 +8,7 @@ const testText = "Test string"
 
 describe("Text", () => {
   it("should render the component", () => {
-    const { getByText } = render(<Text text={testText} />)
-    expect(getByText(testText)).toBeDefined()
+    render(<Text text={testText} />)
+    expect(screen.getByText(testText)).toBeDefined()
   })
 })


### PR DESCRIPTION
## Description

basic render function uses a new api with `screen.query`

https://callstack.github.io/react-native-testing-library/docs/api/render

> The modern and recommended way of accessing queries is to use the screen object exported by the @testing-library/react-native package. This object will contain methods of all available queries bound to the most recently rendered UI.

## Checklist

<!-- if an item doesn't apply, just delete it -->

- [x] `README.md` and other relevant documentation has been updated with my changes
- [x] I have manually tested this, including by generating a new app locally ([see docs](https://docs.infinite.red/ignite-cli/contributing/Contributing-To-Ignite/#testing-changes-from-your-local-copy-of-ignite)).


![CleanShot 2025-02-05 at 16 09 50](https://github.com/user-attachments/assets/4a012efe-5163-40eb-bfb2-f541c108f314)
