### PR TITLE
fix: add `android.allowBackup: false` to expo app config

### DIFF
--- a/boilerplate/app.json
+++ b/boilerplate/app.json
@@ -23,7 +23,8 @@
       "adaptiveIcon": {
         "foregroundImage": "./assets/images/app-icon-android-adaptive-foreground.png",
         "backgroundImage": "./assets/images/app-icon-android-adaptive-background.png"
-      }
+      },
+      "allowBackup": false
     },
     "ios": {
       "icon": "./assets/images/app-icon-ios.png",


### PR DESCRIPTION
## Description

Expo defines `android.allowBackup` as `true` by default. 😱  https://docs.expo.dev/versions/latest/config/app/#allowbackup

This should be opt-in behavior, imho. Setting this value to false will prevent apps from automatically backing up the app’s documents directory to google drive on the user’s behalf. 

Developers should have to opt into this behavior by manually changing this to true or removing the value from the `app.json` file.
