### PR TITLE
fix(boilerplate) Fix Icon Type definitions

### DIFF
--- a/boilerplate/app/components/Header.tsx
+++ b/boilerplate/app/components/Header.tsx
@@ -10,7 +10,7 @@ import {
 import { isRTL, translate } from "@/i18n"
 import { $styles } from "../theme"
 import { ExtendedEdge, useSafeAreaInsetsStyle } from "../utils/useSafeAreaInsetsStyle"
-import { Icon, IconTypes } from "./Icon"
+import { IconTypes, PressableIcon } from "./Icon"
 import { Text, TextProps } from "./Text"
 import { useAppTheme } from "@/utils/useAppTheme"
 import type { ThemedStyle } from "@/theme"
@@ -255,7 +255,7 @@ function HeaderAction(props: HeaderActionProps) {
 
   if (icon) {
     return (
-      <Icon
+      <PressableIcon
         size={24}
         icon={icon}
         color={iconColor}

--- a/boilerplate/app/components/Icon.tsx
+++ b/boilerplate/app/components/Icon.tsx
@@ -46,8 +46,8 @@ type IconProps = Omit<ViewProps, "style"> & BaseIconProps
  * A component to render a registered icon.
  * It is wrapped in a <TouchableOpacity />
  * @see [Documentation and Examples]{@link https://docs.infinite.red/ignite-cli/boilerplate/app/components/Icon/}
- * @param {IconProps} props - The props for the `Icon` component.
- * @returns {JSX.Element} The rendered `Icon` component.
+ * @param {PressableIconProps} props - The props for the `PressableIcon` component.
+ * @returns {JSX.Element} The rendered `PressableIcon` component.
  */
 export function PressableIcon(props: PressableIconProps) {
   const {

--- a/boilerplate/app/components/Icon.tsx
+++ b/boilerplate/app/components/Icon.tsx
@@ -1,4 +1,3 @@
-import { ComponentType } from "react"
 import {
   Image,
   ImageStyle,

--- a/boilerplate/app/components/Icon.tsx
+++ b/boilerplate/app/components/Icon.tsx
@@ -13,7 +13,7 @@ import { useAppTheme } from "@/utils/useAppTheme"
 
 export type IconTypes = keyof typeof iconRegistry
 
-interface IconProps extends TouchableOpacityProps {
+type BaseIconProps = {
   /**
    * The name of the icon
    */
@@ -38,16 +38,47 @@ interface IconProps extends TouchableOpacityProps {
    * Style overrides for the icon container
    */
   containerStyle?: StyleProp<ViewStyle>
+}
 
-  /**
-   * An optional function to be called when the icon is pressed
-   */
-  onPress?: TouchableOpacityProps["onPress"]
+type PressableIconProps = Omit<TouchableOpacityProps, "style"> & BaseIconProps
+type IconProps = Omit<ViewProps, "style"> & BaseIconProps
+
+/**
+ * A component to render a registered icon.
+ * It is wrapped in a <TouchableOpacity />
+ * @see [Documentation and Examples]{@link https://docs.infinite.red/ignite-cli/boilerplate/app/components/Icon/}
+ * @param {IconProps} props - The props for the `Icon` component.
+ * @returns {JSX.Element} The rendered `Icon` component.
+ */
+export function PressableIcon(props: PressableIconProps) {
+  const {
+    icon,
+    color,
+    size,
+    style: $imageStyleOverride,
+    containerStyle: $containerStyleOverride,
+    ...WrapperProps
+  } = props
+
+  const { theme } = useAppTheme()
+
+  const $imageStyle: StyleProp<ImageStyle> = [
+    $imageStyleBase,
+    { tintColor: color ?? theme.colors.text },
+    size !== undefined && { width: size, height: size },
+    $imageStyleOverride,
+  ]
+
+  return (
+    <TouchableOpacity {...WrapperProps} style={$containerStyleOverride}>
+      <Image style={$imageStyle} source={iconRegistry[icon]} />
+    </TouchableOpacity>
+  )
 }
 
 /**
  * A component to render a registered icon.
- * It is wrapped in a <TouchableOpacity /> if `onPress` is provided, otherwise a <View />.
+ * It is wrapped in a <View />, use `PressableIcon` if you want to react to input
  * @see [Documentation and Examples]{@link https://docs.infinite.red/ignite-cli/boilerplate/app/components/Icon/}
  * @param {IconProps} props - The props for the `Icon` component.
  * @returns {JSX.Element} The rendered `Icon` component.
@@ -62,11 +93,6 @@ export function Icon(props: IconProps) {
     ...WrapperProps
   } = props
 
-  const isPressable = !!WrapperProps.onPress
-  const Wrapper = (WrapperProps?.onPress ? TouchableOpacity : View) as ComponentType<
-    TouchableOpacityProps | ViewProps
-  >
-
   const { theme } = useAppTheme()
 
   const $imageStyle: StyleProp<ImageStyle> = [
@@ -77,13 +103,9 @@ export function Icon(props: IconProps) {
   ]
 
   return (
-    <Wrapper
-      accessibilityRole={isPressable ? "imagebutton" : undefined}
-      {...WrapperProps}
-      style={$containerStyleOverride}
-    >
+    <View {...WrapperProps} style={$containerStyleOverride}>
       <Image style={$imageStyle} source={iconRegistry[icon]} />
-    </Wrapper>
+    </View>
   )
 }
 

--- a/boilerplate/app/components/Icon.tsx
+++ b/boilerplate/app/components/Icon.tsx
@@ -56,7 +56,7 @@ export function PressableIcon(props: PressableIconProps) {
     size,
     style: $imageStyleOverride,
     containerStyle: $containerStyleOverride,
-    ...WrapperProps
+    ...pressableProps
   } = props
 
   const { theme } = useAppTheme()
@@ -69,7 +69,7 @@ export function PressableIcon(props: PressableIconProps) {
   ]
 
   return (
-    <TouchableOpacity {...WrapperProps} style={$containerStyleOverride}>
+    <TouchableOpacity {...pressableProps} style={$containerStyleOverride}>
       <Image style={$imageStyle} source={iconRegistry[icon]} />
     </TouchableOpacity>
   )
@@ -89,7 +89,7 @@ export function Icon(props: IconProps) {
     size,
     style: $imageStyleOverride,
     containerStyle: $containerStyleOverride,
-    ...WrapperProps
+    ...viewProps
   } = props
 
   const { theme } = useAppTheme()
@@ -102,7 +102,7 @@ export function Icon(props: IconProps) {
   ]
 
   return (
-    <View {...WrapperProps} style={$containerStyleOverride}>
+    <View {...viewProps} style={$containerStyleOverride}>
       <Image style={$imageStyle} source={iconRegistry[icon]} />
     </View>
   )

--- a/boilerplate/app/screens/LoginScreen.tsx
+++ b/boilerplate/app/screens/LoginScreen.tsx
@@ -1,7 +1,14 @@
 import { observer } from "mobx-react-lite"
 import { ComponentType, FC, useEffect, useMemo, useRef, useState } from "react"
 import { TextInput, TextStyle, ViewStyle } from "react-native"
-import { Button, Icon, Screen, Text, TextField, TextFieldAccessoryProps } from "../components"
+import {
+  Button,
+  PressableIcon,
+  Screen,
+  Text,
+  TextField,
+  TextFieldAccessoryProps,
+} from "../components"
 import { useStores } from "../models"
 import { AppStackScreenProps } from "../navigators"
 import type { ThemedStyle } from "@/theme"
@@ -60,7 +67,7 @@ export const LoginScreen: FC<LoginScreenProps> = observer(function LoginScreen(_
     () =>
       function PasswordRightAccessory(props: TextFieldAccessoryProps) {
         return (
-          <Icon
+          <PressableIcon
             icon={isAuthPasswordHidden ? "view" : "hidden"}
             color={colors.palette.neutral800}
             containerStyle={props.style}

--- a/docs/boilerplate/app/components/Icon.md
+++ b/docs/boilerplate/app/components/Icon.md
@@ -86,7 +86,7 @@ The `containerStyle` is an optional prop that sets the style of the icon contain
 The `onPress` prop can be passed to a `PressableIcon` Component, which will forward it to the wrapped `TouchableOpacity`s `onPress` prop.
 
 ```tsx
-<PressableIconIcon icon="ladybug" onPress={() => Alert.alert("Hello")} />
+<PressableIcon icon="ladybug" onPress={() => Alert.alert("Hello")} />
 ```
 
 ## Custom Icons

--- a/docs/boilerplate/app/components/Icon.md
+++ b/docs/boilerplate/app/components/Icon.md
@@ -4,12 +4,16 @@ sidebar_position: 35
 
 # Icon
 
-Ignite's `Icon` Component renders an icon using predefined icon images. You can use those, override them, or customize this component to create any number of image based icons. If `onPress` is passed, it will wrap the icon in a [`TouchableOpacity`](https://reactnative.dev/docs/touchableopacity) component, otherwise it will use a [`View`](https://reactnative.dev/docs/view) component.
+Ignite's `Icon` and `PressableIcon` Components renders an icon using predefined icon images. You can use those, override them, or customize this component to create any number of image based icons. `PressableIcon` will wrap the icon in a [`TouchableOpacity`](https://reactnative.dev/docs/touchableopacity) component, `Icon` will use a [`View`](https://reactnative.dev/docs/view) component.
 
 ![icon-component](https://github.com/user-attachments/assets/25888c72-8bd9-4cbd-b55f-909b0f6b0bca)
 
 ```tsx
-<Icon icon="ladybug" onPress={() => Alert.alert("Hello")} />
+<PressableIcon icon="ladybug" onPress={() => Alert.alert("Hello")} />
+```
+
+```tsx
+<Icon icon="debug" />
 ```
 
 ## Props
@@ -71,7 +75,7 @@ The `style` prop is optional. This is an object that overrides the default style
 
 ### `containerStyle`
 
-The `containerStyle` is an optional prop that sets the style of the icon container, and is of the type `StyleProp<ViewStyle>`. See React Native docs on [ViewStyle](https://reactnative.dev/docs/view-style-props) for more information.
+The `containerStyle` is an optional prop that sets the style of the icon container (either a `TouchableOpacity` or `View`), and is of the type `StyleProp<ViewStyle>`. See React Native docs on [ViewStyle](https://reactnative.dev/docs/view-style-props) for more information.
 
 ```tsx
 <Icon icon="bug" containerStyle={{ backgroundColor: "red" }} />
@@ -79,10 +83,10 @@ The `containerStyle` is an optional prop that sets the style of the icon contain
 
 ### `onPress`
 
-The `onPress` optional prop is a function that will be called when the icon is pressed. Note that when this prop is passed, the icon will be wrapped in a `TouchableOpacity` component rather than a `View` component.
+The `onPress` prop can be passed to a `PressableIcon` Component, which will forward it to the wrapped `TouchableOpacity`s `onPress` prop.
 
 ```tsx
-<Icon icon="ladybug" onPress={() => Alert.alert("Hello")} />
+<PressableIconIcon icon="ladybug" onPress={() => Alert.alert("Hello")} />
 ```
 
 ## Custom Icons
@@ -107,4 +111,8 @@ You can then use your custom icon by passing its name through the `icon` prop.
 
 ```tsx
 <Icon icon="custom" />
+```
+
+```tsx
+<PressableIcon icon="custom" onPress={() => Alert.alert("I'm a custom PressableIcon!")} />
 ```

--- a/docs/boilerplate/app/components/Icon.md
+++ b/docs/boilerplate/app/components/Icon.md
@@ -4,7 +4,7 @@ sidebar_position: 35
 
 # Icon
 
-Ignite's `Icon` and `PressableIcon` Components renders an icon using predefined icon images. You can use those, override them, or customize this component to create any number of image based icons. `PressableIcon` will wrap the icon in a [`TouchableOpacity`](https://reactnative.dev/docs/touchableopacity) component, `Icon` will use a [`View`](https://reactnative.dev/docs/view) component.
+Ignite's `Icon` and `PressableIcon` Components render an icon using predefined icon images. You can use those, override them, or customize this component to create any number of image based icons. `PressableIcon` will wrap the icon in a [`TouchableOpacity`](https://reactnative.dev/docs/touchableopacity) component, `Icon` will use a [`View`](https://reactnative.dev/docs/view) component.
 
 ![icon-component](https://github.com/user-attachments/assets/25888c72-8bd9-4cbd-b55f-909b0f6b0bca)
 


### PR DESCRIPTION
## Description

There were two issues at play here:

1. Icon's `style` prop overrides the Wrapped `TouchableOpacity`'s `style` prop with an incompatible `StyleProp<ImageStyle>`
2. Icon changed the wrapper used based on the presence of the `onPress` prop, which made accurate typing and linting difficult.

See
https://github.com/infinitered/ignite/issues/2888#issuecomment-2738096598 for more information.

This commit fixes #2888 by simply separating `Icon` into `PressableIcon` and `Icon` components, with simplified prop types for each, and updates the docs to reflect the change.

- Issues:  #2888 

## Checklist

- [x] `README.md` and other relevant documentation has been updated with my changes
