### PR TITLE
fix(cli): reorder demo app question

### DIFF
--- a/docs/cli/Ignite-CLI.md
+++ b/docs/cli/Ignite-CLI.md
@@ -98,7 +98,7 @@ Starts the interactive prompt for generating a new Ignite project. Any options n
 - `--overwrite` overwrite the target directory if it exists
 - `--targetPath` string, specify a target directory where the project should be created
 - `--removeDemo` will remove the boilerplate demo code after project creation
-- `--state` string, one of `mst` or `none` to include MobX-State-Tree in project (can only be set to `none` if `--removeDemo=true`)
+- `--state` string, one of `mst` or `none` to include MobX-State-Tree in project (**note:** if opting out of MobX-State-Tree the demo application will be removed)
 - `--useCache` flag specifying to use dependency cache for quicker installs
 - `--no-timeout` flag to disable the timeout protection (useful for slow internet connections)
 - `--yes` accept all prompt defaults

--- a/docs/cli/Ignite-CLI.md
+++ b/docs/cli/Ignite-CLI.md
@@ -104,7 +104,7 @@ Starts the interactive prompt for generating a new Ignite project. Any options n
 - `--yes` accept all prompt defaults
 - `--workflow` string, one of `cng` or `manual` for project initialization
 - `--experimental` comma separated string, indicates experimental features (which may or may not be stable) to turn on during installation. **A CNG workflow is require for these flags** `--workflow=cng`
-  - `expo-router` converts the project to [Expo Router](https://docs.expo.dev/router/introduction/) from React Navigation
+  - `expo-router` converts the base project to use [Expo Router](https://docs.expo.dev/router/introduction/) from React Navigation (**note:** the demo application will be removed)
   - `new-arch` enables [The New Architecture](https://reactnative.dev/docs/new-architecture-intro)
   - `expo-canary` uses Expo's highly experimental canary release instead of the la test stable SDK
   - `expo-beta` uses Expo's latest beta SDK available instead of the latest stable SDK

--- a/src/commands/new.ts
+++ b/src/commands/new.ts
@@ -342,54 +342,6 @@ module.exports = {
     }
     // #endregion
 
-    // #region Prompt to Remove Demo code
-    const defaultRemoveDemo = false
-    let removeDemo = useDefault(options.removeDemo)
-      ? defaultRemoveDemo
-      : boolFlag(options.removeDemo)
-    if (removeDemo === undefined) {
-      const removeDemoResponse = await prompt.ask<{ removeDemo: boolean }>(() => ({
-        type: "confirm",
-        name: "removeDemo",
-        message:
-          "Remove demo code? We recommend leaving it in if it's your first time using Ignite",
-        initial: defaultRemoveDemo,
-        format: prettyPrompt.format.boolean,
-        prefix,
-      }))
-      removeDemo = removeDemoResponse.removeDemo
-    }
-    // #endregion
-
-    // #region Prompt to Remove MobX-State-Tree code
-    const defaultMST = "mst"
-    let stateMgmt = useDefault(options.state) ? defaultMST : options.state
-
-    if (stateMgmt === undefined) {
-      if (!removeDemo) {
-        stateMgmt = "mst"
-      } else {
-        // only ask if we're removing the demo code
-        const includeMSTResponse = await prompt.ask<{ includeMST: StateMgmt }>(() => ({
-          type: "confirm",
-          name: "includeMST",
-          message: "Include MobX-State-Tree code? (recommended)",
-          initial: defaultMST,
-          format: prettyPrompt.format.boolean,
-          prefix,
-        }))
-        stateMgmt = includeMSTResponse.includeMST ? "mst" : "none"
-      }
-    }
-
-    if (!removeDemo && stateMgmt === "none") {
-      p()
-      p(yellow(`Warning: You can't remove MobX-State-Tree code without removing demo code.`))
-      p(yellow(`Setting --state=mst`))
-      stateMgmt = "mst"
-    }
-    // #endregion
-
     // #region Packager
     // check if a packager is provided, or detect one
     // we pass in expo because we can't use pnpm if we're using expo
@@ -505,7 +457,8 @@ module.exports = {
       const expoRouterResponse = await prompt.ask<{ experimentalExpoRouter: boolean }>(() => ({
         type: "confirm",
         name: "experimentalExpoRouter",
-        message: "[Experimental] Expo Router for navigation?",
+        message:
+          "[Experimental] Expo Router for navigation? (This will remove the demo application)",
         initial: defaultExpoRouter,
         format: prettyPrompt.format.boolean,
         prefix,
@@ -520,7 +473,7 @@ module.exports = {
 
     // New Architecture
     const defaultNewArch = false
-    let newArchEnabled = useDefault(options.newArch) ? defaultNewArch : options.newArch
+    let newArchEnabled = useDefault(options.newArch) ? defaultNewArch : boolFlag(options.newArch)
     if (newArchEnabled === undefined) {
       const newArchResponse = await prompt.ask<{ experimentalNewArch: boolean }>(() => ({
         type: "confirm",
@@ -533,6 +486,46 @@ module.exports = {
       newArchEnabled = newArchResponse.experimentalNewArch
     }
 
+    // #endregion
+
+    // #region Prompt to Remove MobX-State-Tree code
+    const defaultMST = "mst"
+    let stateMgmt = useDefault(options.state) ? defaultMST : options.state
+
+    if (stateMgmt === undefined) {
+      const includeMSTResponse = await prompt.ask<{ includeMST: StateMgmt }>(() => ({
+        type: "confirm",
+        name: "includeMST",
+        message:
+          "Include MobX-State-Tree for state management? (Recommended - opting out will remove the demo application)",
+        initial: true,
+        format: prettyPrompt.format.boolean,
+        prefix,
+      }))
+      stateMgmt = includeMSTResponse.includeMST ? "mst" : "none"
+    }
+    // #endregion
+
+    // #region Prompt to Remove Demo code
+    const defaultRemoveDemo = stateMgmt !== "mst" || experimentalExpoRouter
+    if (defaultRemoveDemo) {
+      p(yellow(`Warning: the demo application will be removed.`))
+    }
+    let removeDemo = useDefault(options.removeDemo)
+      ? defaultRemoveDemo
+      : boolFlag(options.removeDemo)
+    if (!defaultRemoveDemo && removeDemo === undefined) {
+      const removeDemoResponse = await prompt.ask<{ removeDemo: boolean }>(() => ({
+        type: "confirm",
+        name: "removeDemo",
+        message:
+          "Remove demo code? We recommend leaving it in if it's your first time using Ignite",
+        initial: defaultRemoveDemo,
+        format: prettyPrompt.format.boolean,
+        prefix,
+      }))
+      removeDemo = removeDemoResponse.removeDemo
+    }
     // #endregion
 
     // #region Debug


### PR DESCRIPTION
## Description

- Closes #2916 
- Moves the `Remove demo code` prompt after nav and state mgmt questions which can force it's removal
- Warns the user better about demo code being removed
- Updates docs to mention this as well

## Screenshots

<!-- If not applicable, delete this whole section -->

<!-- If you’re submitting code changes related to a visible feature, please include before-and-after screenshots or videos. -->

### Added notes in the prompts
![image](https://github.com/user-attachments/assets/e8daf559-3ea3-4f30-9b45-33c3c5517c8d)

### If expo-router and/or MST removal, prints a warning instead of prompting `Remove demo code`
![image](https://github.com/user-attachments/assets/b937ca28-501c-4975-bf48-351bea2c5eca)


## Checklist

<!-- if an item doesn't apply, just delete it -->

- [x] `README.md` and other relevant documentation has been updated with my changes
- [x] I have manually tested this, including by generating a new app locally ([see docs](https://docs.infinite.red/ignite-cli/contributing/Contributing-To-Ignite/#testing-changes-from-your-local-copy-of-ignite)).
