### PR TITLE
update ir-docs orb version and specify SSH key

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -17,7 +17,7 @@ parameters:
     default: false
 
 orbs:
-  publish-docs: infinitered/publish-docs@0.4.9
+  publish-docs: infinitered/publish-docs@0.5.0
 jobs:
   tests:
     <<: *defaults
@@ -101,6 +101,7 @@ publish-details: &publish-details
   target_docs_dir: "docs"
   target_repo: "git@github.com:infinitered/ir-docs.git"
   target_repo_directory: "target"
+  ssh_key_fingerprint: "${IR_DOCS_KEY_FINGERPRINT}"
 
 workflows:
   version: 2


### PR DESCRIPTION
## Description

* Updates the Infinite Red docs CircleCI orb from v0.4.9 to v0.5.0 and adds SSH key fingerprint configuration.

## Screenshots

N/A

## Checklist

- [x] `README.md` and other relevant documentation has been updated with my changes
- [x]  I have manually tested this, including by generating a new app locally ([see docs](https://docs.infinite.red/ignite-cli/contributing/Contributing-To-Ignite/#testing-changes-from-your-local-copy-of-ignite)).
