### PR TITLE
fix(boilerplate): updated i18n translate

### DIFF
--- a/boilerplate/app/i18n/translate.ts
+++ b/boilerplate/app/i18n/translate.ts
@@ -20,7 +20,7 @@ import { TxKeyPath } from "./i18n"
  * ```ts
  * import { translate } from "./i18n"
  *
- * translate("common:ok", { name: "world" })
+ * translate("hello", { name: "world" })
  * // => "Hello world!"
  * ```
  */


### PR DESCRIPTION
updated the doc for i18n translate to reflect proper usage of the translation keys

- Its a quick small change to rename the example key which is present in the translate.ts file for i18n translations.
- I am starting out the development of my own RN project and came across the ignite project and was exploring the project whenI found this tiny issue.




