### PR TITLE
fix(boilerplate): Move Error Boundary Inside Theme Provider

### DIFF
--- a/boilerplate/app/app.tsx
+++ b/boilerplate/app/app.tsx
@@ -26,10 +26,8 @@ import * as Linking from "expo-linking"
 import * as SplashScreen from "expo-splash-screen"
 import { useInitialRootStore } from "./models" // @mst remove-current-line
 import { AppNavigator, useNavigationPersistence } from "./navigators"
-import { ErrorBoundary } from "./screens/ErrorScreen/ErrorBoundary"
 import * as storage from "./utils/storage"
 import { customFontsToLoad } from "./theme"
-import Config from "./config"
 import { KeyboardProvider } from "react-native-keyboard-controller"
 import { loadDateFnsLocale } from "./utils/formatDate"
 
@@ -112,15 +110,13 @@ export function App() {
   // otherwise, we're ready to render the app
   return (
     <SafeAreaProvider initialMetrics={initialWindowMetrics}>
-      <ErrorBoundary catchErrors={Config.catchErrors}>
-        <KeyboardProvider>
-          <AppNavigator
-            linking={linking}
-            initialState={initialNavigationState}
-            onStateChange={onNavigationStateChange}
-          />
-        </KeyboardProvider>
-      </ErrorBoundary>
+      <KeyboardProvider>
+        <AppNavigator
+          linking={linking}
+          initialState={initialNavigationState}
+          onStateChange={onNavigationStateChange}
+        />
+      </KeyboardProvider>
     </SafeAreaProvider>
   )
 }

--- a/boilerplate/app/navigators/AppNavigator.tsx
+++ b/boilerplate/app/navigators/AppNavigator.tsx
@@ -17,7 +17,6 @@ import { DemoNavigator, DemoTabParamList } from "./DemoNavigator" // @demo remov
 import { navigationRef, useBackButtonHandler } from "./navigationUtilities"
 import { useAppTheme, useThemeProvider } from "@/utils/useAppTheme"
 import { ComponentProps } from "react"
-import { ErrorBoundary } from "@/screens"
 
 /**
  * This type allows TypeScript to know what routes are defined in this navigator
@@ -109,11 +108,11 @@ export const AppNavigator = observer(function AppNavigator(props: NavigationProp
 
   return (
     <ThemeProvider value={{ themeScheme, setThemeContextOverride }}>
-      <ErrorBoundary catchErrors={Config.catchErrors}>
-        <NavigationContainer ref={navigationRef} theme={navigationTheme} {...props}>
+      <NavigationContainer ref={navigationRef} theme={navigationTheme} {...props}>
+        <Screens.ErrorBoundary catchErrors={Config.catchErrors}>
           <AppStack />
-        </NavigationContainer>
-      </ErrorBoundary>
+        </Screens.ErrorBoundary>
+      </NavigationContainer>
     </ThemeProvider>
   )
   // @mst replace-next-line }

--- a/boilerplate/app/navigators/AppNavigator.tsx
+++ b/boilerplate/app/navigators/AppNavigator.tsx
@@ -17,6 +17,7 @@ import { DemoNavigator, DemoTabParamList } from "./DemoNavigator" // @demo remov
 import { navigationRef, useBackButtonHandler } from "./navigationUtilities"
 import { useAppTheme, useThemeProvider } from "@/utils/useAppTheme"
 import { ComponentProps } from "react"
+import { ErrorBoundary } from "@/screens"
 
 /**
  * This type allows TypeScript to know what routes are defined in this navigator
@@ -108,9 +109,11 @@ export const AppNavigator = observer(function AppNavigator(props: NavigationProp
 
   return (
     <ThemeProvider value={{ themeScheme, setThemeContextOverride }}>
-      <NavigationContainer ref={navigationRef} theme={navigationTheme} {...props}>
-        <AppStack />
-      </NavigationContainer>
+      <ErrorBoundary catchErrors={Config.catchErrors}>
+        <NavigationContainer ref={navigationRef} theme={navigationTheme} {...props}>
+          <AppStack />
+        </NavigationContainer>
+      </ErrorBoundary>
     </ThemeProvider>
   )
   // @mst replace-next-line }


### PR DESCRIPTION
## Description

This PR resolved a bug that was recently reported [here](https://github.com/infinitered/ignite/issues/2923) that describes an error being thrown when the `ErrorBoundary` component is rendered outside of the `ThemeProvider`.


