### PR TITLE
improve logic for other `onPress` props

### DIFF
--- a/boilerplate/app/components/Icon.tsx
+++ b/boilerplate/app/components/Icon.tsx
@@ -62,8 +62,10 @@ export function Icon(props: IconProps) {
     ...WrapperProps
   } = props
 
-  const isPressable = !!WrapperProps.onPress
-  const Wrapper = (WrapperProps?.onPress ? TouchableOpacity : View) as ComponentType<
+    const isPressable =
+    !!WrapperProps.onPress || !!WrapperProps.onPressIn || !!WrapperProps.onPressOut || !!WrapperProps.onLongPress
+    
+  const Wrapper = (isPressable ? TouchableOpacity : View) as ComponentType<
     TouchableOpacityProps | ViewProps
   >
 


### PR DESCRIPTION
## Description

Ran into an issue where I wanted to use `onPressIn` and nothing was firing for the Icon button. I updated the Icon component to include all the pressability props to make sure the correct wrapper is used.

Should be a very minor change, so no real need for full on testing, but I'll let you guys double check my work!

Thanks again,
Chris
