### PR TITLE
change pointerEvents none from a prop to a style

### DIFF
--- a/boilerplate/app/components/Header.tsx
+++ b/boilerplate/app/components/Header.tsx
@@ -198,11 +198,11 @@ export function Header(props: HeaderProps) {
         {!!titleContent && (
           <View
             style={[
+              $titleWrapperPointerEvents,
               titleMode === "center" && themed($titleWrapperCenter),
               titleMode === "flex" && $titleWrapperFlex,
               $titleContainerStyleOverride,
             ]}
-            pointerEvents="none"
           >
             <Text
               weight="medium"
@@ -307,6 +307,10 @@ const $actionIconContainer: ThemedStyle<ViewStyle> = ({ spacing }) => ({
 
 const $actionFillerContainer: ViewStyle = {
   width: 16,
+}
+
+const $titleWrapperPointerEvents: ViewStyle = {
+  pointerEvents: "none"
 }
 
 const $titleWrapperCenter: ThemedStyle<ViewStyle> = ({ spacing }) => ({


### PR DESCRIPTION
## Description

The boilerplate's Header component contains a View with a prop, pointerEvents="none". This gave me a warning in the console, saying "props.pointerEvents is deprecated. Use style.pointerEvents", so this PR makes that change. See here to confirm that the pointerEvents prop is deprecated in react-native-web: https://grep.app/search?q=props.pointerEvents+is+deprecated.+Use+style.pointerEvents


## Screenshots

<!-- If not applicable, delete this whole section -->

<!-- If you’re submitting code changes related to a visible feature, please include before-and-after screenshots or videos. -->

<!-- If GH's auto attachment previews too large, trying resizing it with: <img src="filename-from-github-upload" width="300" /> -->

| Before                           | After                           |
| -------------------------------- | ------------------------------- |
| [Insert before screenshot/video] | [Insert after screenshot/video] |

## Checklist

- [ ] I have manually tested this, including by generating a new app locally ([see docs](https://docs.infinite.red/ignite-cli/contributing/Contributing-To-Ignite/#testing-changes-from-your-local-copy-of-ignite)).
