### PR TITLE
feat(ListItem): Improve ListItem component to dynamically choose between TouchableOpacity and View based on touchable props

### DIFF
--- a/boilerplate/app/components/ListItem.tsx
+++ b/boilerplate/app/components/ListItem.tsx
@@ -131,7 +131,11 @@ export const ListItem = forwardRef<View, ListItemProps>(function ListItem(
   } = props
   const { themed } = useAppTheme()
 
-  const isTouchable = TouchableOpacityProps.onPress !== undefined || TouchableOpacityProps.onPressIn !== undefined || TouchableOpacityProps.onPressOut !== undefined || TouchableOpacityProps.onLongPress !== undefined
+  const isTouchable =
+    TouchableOpacityProps.onPress !== undefined ||
+    TouchableOpacityProps.onPressIn !== undefined ||
+    TouchableOpacityProps.onPressOut !== undefined ||
+    TouchableOpacityProps.onLongPress !== undefined
 
   const $textStyles = [$textStyle, $textStyleOverride, TextProps?.style]
 

--- a/boilerplate/app/components/ListItem.tsx
+++ b/boilerplate/app/components/ListItem.tsx
@@ -1,5 +1,4 @@
-import { forwardRef, ReactElement } from "react"
-import React from "react"
+import { forwardRef, ReactElement, ComponentType } from "react"
 import {
   StyleProp,
   TextStyle,
@@ -147,39 +146,31 @@ export const ListItem = forwardRef<View, ListItemProps>(function ListItem(
 
   const $touchableStyles = [$styles.row, $touchableStyle, { minHeight: height }, style]
 
-  const content = (
-    <>
-      <ListItemAction
-        side="left"
-        size={height}
-        icon={leftIcon}
-        iconColor={leftIconColor}
-        Component={LeftComponent}
-      />
-
-      <Text {...TextProps} tx={tx} text={text} txOptions={txOptions} style={themed($textStyles)}>
-        {children}
-      </Text>
-
-      <ListItemAction
-        side="right"
-        size={height}
-        icon={rightIcon}
-        iconColor={rightIconColor}
-        Component={RightComponent}
-      />
-    </>
-  )
+  const Wrapper: ComponentType<TouchableOpacityProps> = isTouchable ? TouchableOpacity : View
 
   return (
     <View ref={ref} style={themed($containerStyles)}>
-      {isTouchable ? (
-        <TouchableOpacity {...TouchableOpacityProps} style={$touchableStyles}>
-          {content}
-        </TouchableOpacity>
-      ) : (
-        <View style={$touchableStyles}>{content}</View>
-      )}
+      <Wrapper {...TouchableOpacityProps} style={$touchableStyles}>
+        <ListItemAction
+          side="left"
+          size={height}
+          icon={leftIcon}
+          iconColor={leftIconColor}
+          Component={LeftComponent}
+        />
+
+        <Text {...TextProps} tx={tx} text={text} txOptions={txOptions} style={themed($textStyles)}>
+          {children}
+        </Text>
+
+        <ListItemAction
+          side="right"
+          size={height}
+          icon={rightIcon}
+          iconColor={rightIconColor}
+          Component={RightComponent}
+        />
+      </Wrapper>
     </View>
   )
 })

--- a/boilerplate/app/components/ListItem.tsx
+++ b/boilerplate/app/components/ListItem.tsx
@@ -1,4 +1,5 @@
 import { forwardRef, ReactElement } from "react"
+import React from "react"
 import {
   StyleProp,
   TextStyle,
@@ -130,6 +131,8 @@ export const ListItem = forwardRef<View, ListItemProps>(function ListItem(
   } = props
   const { themed } = useAppTheme()
 
+  const isTouchable = TouchableOpacityProps.onPress !== undefined || TouchableOpacityProps.onPressIn !== undefined || TouchableOpacityProps.onPressOut !== undefined || TouchableOpacityProps.onLongPress !== undefined
+
   const $textStyles = [$textStyle, $textStyleOverride, TextProps?.style]
 
   const $containerStyles = [
@@ -140,29 +143,39 @@ export const ListItem = forwardRef<View, ListItemProps>(function ListItem(
 
   const $touchableStyles = [$styles.row, $touchableStyle, { minHeight: height }, style]
 
+  const content = (
+    <>
+      <ListItemAction
+        side="left"
+        size={height}
+        icon={leftIcon}
+        iconColor={leftIconColor}
+        Component={LeftComponent}
+      />
+
+      <Text {...TextProps} tx={tx} text={text} txOptions={txOptions} style={themed($textStyles)}>
+        {children}
+      </Text>
+
+      <ListItemAction
+        side="right"
+        size={height}
+        icon={rightIcon}
+        iconColor={rightIconColor}
+        Component={RightComponent}
+      />
+    </>
+  )
+
   return (
     <View ref={ref} style={themed($containerStyles)}>
-      <TouchableOpacity {...TouchableOpacityProps} style={$touchableStyles}>
-        <ListItemAction
-          side="left"
-          size={height}
-          icon={leftIcon}
-          iconColor={leftIconColor}
-          Component={LeftComponent}
-        />
-
-        <Text {...TextProps} tx={tx} text={text} txOptions={txOptions} style={themed($textStyles)}>
-          {children}
-        </Text>
-
-        <ListItemAction
-          side="right"
-          size={height}
-          icon={rightIcon}
-          iconColor={rightIconColor}
-          Component={RightComponent}
-        />
-      </TouchableOpacity>
+      {isTouchable ? (
+        <TouchableOpacity {...TouchableOpacityProps} style={$touchableStyles}>
+          {content}
+        </TouchableOpacity>
+      ) : (
+        <View style={$touchableStyles}>{content}</View>
+      )}
     </View>
   )
 })


### PR DESCRIPTION
## Description

This pull request improves the `ListItem` component, focusing on enhancing flexibility by dynamically choosing between `TouchableOpacity` and `View` based on the presence of touchable props. 

- Issues: fixes #2859

## Screenshots

<!-- If not applicable, delete this whole section -->

<!-- If you’re submitting code changes related to a visible feature, please include before-and-after screenshots or videos. -->

<!-- If GH's auto attachment previews too large, trying resizing it with: <img src="filename-from-github-upload" width="300" /> -->

| Before                           | After                           |
| -------------------------------- | ------------------------------- |
| ![Simulator Screen Recording - iPhone 16 Pro - 2025-04-30 at 18 20 58](https://github.com/user-attachments/assets/f4f84373-2209-4bc5-82b5-7270015a8863) | ![Simulator Screen Recording - iPhone 16 Pro - 2025-04-30 at 18 20 23](https://github.com/user-attachments/assets/2600d297-aaa7-4fa8-813c-afce5c94a428) |

## Checklist

<!-- if an item doesn't apply, just delete it -->

- [x] `README.md` and other relevant documentation has been updated with my changes
- [x] I have manually tested this, including by generating a new app locally ([see docs](https://docs.infinite.red/ignite-cli/contributing/Contributing-To-Ignite/#testing-changes-from-your-local-copy-of-ignite)).
