### PR TITLE
feat: better type suggestions in useNavigate hook

### DIFF
--- a/boilerplate/app/navigators/AppNavigator.tsx
+++ b/boilerplate/app/navigators/AppNavigator.tsx
@@ -115,3 +115,10 @@ export const AppNavigator = observer(function AppNavigator(props: NavigationProp
   )
   // @mst replace-next-line }
 })
+
+declare global {
+  // eslint-disable-next-line @typescript-eslint/no-namespace
+  namespace ReactNavigation {
+    interface RootParamList extends AppStackParamList {}
+  }
+}


### PR DESCRIPTION
## Description

 The useNavigate hook from react navigation by default not coming with any route name suggestions
