### PR TITLE
Fixed Broken Link in Documentation

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -91,7 +91,7 @@ Nothing makes it into Ignite unless it's been proven on projects that Infinite R
 | react-native-keyboard-controller | Keyboard library     | v1      | Great keyboard manager library                 |
 | FlashList                        | FlatList replacement | v1      | A performant drop-in replacement for FlatList  |
 
-Ignite also comes with a [component library](./docs/boilerplate/app/components/Components.md) that is tuned for custom designs, theming support, testing, custom fonts, generators, and much, much more.
+Ignite also comes with a [component library](./boilerplate/app/components/Components.md) that is tuned for custom designs, theming support, testing, custom fonts, generators, and much, much more.
 
 ## Quick Start
 


### PR DESCRIPTION
Edited the component library link in `/docs/README.md` to fix an issue where it linked to `/docs/docs`, an invalid URL. This results in `ignite/docs/README.md` needing to differ from `ignite/README.md`, however the link now works as expected. It could be changed to an absolute link to keep the two README files the same if that's needed.