### PR TITLE
chore(docs): followup on #2945: borken docusauras links

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -155,7 +155,7 @@ Ready to see how we can work together? [Send us a message](https://infinite.red/
 
 ## License and Trademark Notice
 
-This project's source code is licensed under the [MIT License](LICENSE). The Ignite name, its logo, and any other brand assets associated with Ignite and Infinite Red are the exclusive property of Infinite Red, Inc. These marks are not covered by the MIT License provided herein and may not be used without explicit written permission from Infinite Red, Inc.
+This project's source code is licensed under the [MIT License](https://github.com/infinitered/ignite/blob/master/LICENSE). The Ignite name, its logo, and any other brand assets associated with Ignite and Infinite Red are the exclusive property of Infinite Red, Inc. These marks are not covered by the MIT License provided herein and may not be used without explicit written permission from Infinite Red, Inc.
 
 ### Note on Generated Code
 


### PR DESCRIPTION
## Description

CircleCI failed on that last merge to master in #2945. This should fix the remaining broken links so docusauras can deploy the docs without  error.

CI failed with:

https://app.circleci.com/pipelines/github/infinitered/ignite/4013/workflows/ea30949e-b664-4781-8124-c61cfa465ff2/jobs/4837


```
  [cause]: Error: Docusaurus found broken links!
  
  Please check the pages of your site in the list below, and make sure you don't reference any path that does not exist.
  Note: it's possible to ignore broken links with the 'onBrokenLinks' Docusaurus configuration, and let the build pass.
  
  Exhaustive list of all broken links found:
  - Broken link on source page path = /ignite-cli/:
     -> linking to LICENSE/ (resolved as: /ignite-cli/LICENSE/)
```