### PR TITLE
fix(cli): correct mobx removal when using prompts

### DIFF
--- a/src/commands/new.ts
+++ b/src/commands/new.ts
@@ -514,6 +514,7 @@ module.exports = {
     let removeDemo = useDefault(options.removeDemo)
       ? defaultRemoveDemo
       : boolFlag(options.removeDemo)
+
     if (!defaultRemoveDemo && removeDemo === undefined) {
       const removeDemoResponse = await prompt.ask<{ removeDemo: boolean }>(() => ({
         type: "confirm",
@@ -525,6 +526,8 @@ module.exports = {
         prefix,
       }))
       removeDemo = removeDemoResponse.removeDemo
+    } else {
+      removeDemo = defaultRemoveDemo
     }
     // #endregion
 
@@ -826,6 +829,10 @@ module.exports = {
       // #region Remove Demo code
       const removeDemoPart = removeDemo === true ? "code" : "markup"
       startSpinner(`Removing fancy demo ${removeDemoPart}`)
+
+      p(yellow(`removeDemo: ${removeDemo}`))
+      p(yellow(`removeDemoPart: ${removeDemoPart}`))
+      // process.exit(1)
       try {
         const IGNITE = "node " + filesystem.path(__dirname, "..", "..", "bin", "ignite")
         const CMD = removeDemo === true ? "remove-demo" : "remove-demo-markup"


### PR DESCRIPTION
## Description

<!-- Add your PR description here -->

- Closes #2947
- This actually worked if you use the CLI switches, ie: `--state none` but failed during the prompts
  - `useDefault` is only meant to apply the default value if `--yes` is applied, so even though we skipped the prompt for removing the demo application (as intended, because the user wanted to remove MST), we didn't later remove the code, only markup
  - Since our tests utilize the CLI, this fell through the cracks, need to better emulate following prompts at some point would be a good follow up to this. 

## Checklist

<!-- if an item doesn't apply, just delete it -->

- [x] I have manually tested this, including by generating a new app locally ([see docs](https://docs.infinite.red/ignite-cli/contributing/Contributing-To-Ignite/#testing-changes-from-your-local-copy-of-ignite)).
