### PR TITLE
fix(tests): fix i18n tests [skip ci]

### DIFF
--- a/boilerplate/test/i18n.test.ts
+++ b/boilerplate/test/i18n.test.ts
@@ -5,6 +5,14 @@ import { exec } from "child_process"
 // don't hold your test suite hostage by always failing.
 const EXCEPTIONS: string[] = [
   // "welcomeScreen:readyForLaunch",
+
+  /**
+   * This translation key actually shows up in a comment describing the usage of the translate
+   * function in the app/i18n/translate.ts file. Because the grep command in the i18n test below
+   * doesn't account for commented out code, we must manually exclude it so tests don't fail 
+   * because of a comment.
+   */
+  "hello",
 ]
 
 function iterate(obj, stack, array) {


### PR DESCRIPTION
## Description

The tests were failing on #2924 but i thought it was just the CI being flaky… surely changing one word in a comment wouldn’t cause the entire test suite to hang! So i merged it. 

_Boy was I wrong._ Turns out that the i18n tests actually greps the filesystem looking for instances of the `translate()` function, extracts their keys, and then compares those keys to the list inside the translation files.

[This `grep` command](https://github.com/infinitered/ignite/blob/master/boilerplate/test/i18n.test.ts#L49) doesn’t take commented code into consideration so it sees these blocks of code as equally valid instances of the `translate()`function:

```typescript
translate("key1")

// translate("key2")

/**
  * translate("key3")
  */
```

So the test will look for `["key1", "key2", "key3"]` and make sure the translations exist instead of just `["key1"]` like we'd expect.

To solve this, I added the key `”hello”` to the EXCEPTIONS list with a large comment above it about _why_... so that this comment will no longer cause the test suite to hang and eventually fail.

## Checklist

- [x] I have manually tested this, including by generating a new app locally ([see docs](https://docs.infinite.red/ignite-cli/contributing/Contributing-To-Ignite/#testing-changes-from-your-local-copy-of-ignite)).
