### PR TITLE
fix(boilerplate): Button text uses TextStyle instead of ViewStyle

### DIFF
--- a/boilerplate/app/components/Button.tsx
+++ b/boilerplate/app/components/Button.tsx
@@ -239,7 +239,7 @@ const $pressedViewPresets: Record<Presets, ThemedStyle<ViewStyle>> = {
   reversed: ({ colors }) => ({ backgroundColor: colors.palette.neutral700 }),
 }
 
-const $pressedTextPresets: Record<Presets, ThemedStyle<ViewStyle>> = {
+const $pressedTextPresets: Record<Presets, ThemedStyle<TextStyle>> = {
   default: () => ({ opacity: 0.9 }),
   filled: () => ({ opacity: 0.9 }),
   reversed: () => ({ opacity: 0.9 }),


### PR DESCRIPTION
## Description

Fixing type for Button's `pressedTextPresets`. Change from ViewStyle to TextStyle. This was a minor change that I caught will review types a project created by Ignite.

## Checklist

- [x] I have manually tested this, including by generating a new app locally ([see docs](https://docs.infinite.red/ignite-cli/contributing/Contributing-To-Ignite/#testing-changes-from-your-local-copy-of-ignite)).
