### PR TITLE
feat(ios): add a default iOS privacyManifest

### DIFF
--- a/boilerplate/app.config.ts
+++ b/boilerplate/app.config.ts
@@ -17,6 +17,23 @@ module.exports = ({ config }: ConfigContext): Partial<ExpoConfig> => {
 
   return {
     ...config,
+    ios: {
+      ...config.ios,
+      // This privacyManifests is to get you started.
+      // See Expo's guide on apple privacy manifests here:
+      // https://docs.expo.dev/guides/apple-privacy/
+      // You may need to add more privacy manifests depending on your app's usage of APIs.
+      // More details and a list of "required reason" APIs can be found in the Apple Developer Documentation.
+      // https://developer.apple.com/documentation/bundleresources/privacy-manifest-files
+      privacyManifests: {
+        NSPrivacyAccessedAPITypes: [
+          {
+            NSPrivacyAccessedAPIType: "NSPrivacyAccessedAPICategoryUserDefaults",
+            NSPrivacyAccessedAPITypeReasons: ["CA92.1"], // CA92.1 = "Access info from same app, per documentation"
+          },
+        ],
+      },
+    },
     plugins: [...existingPlugins, require("./plugins/withSplashScreen").withSplashScreen],
   }
 }

--- a/test/vanilla/ignite-new.test.ts
+++ b/test/vanilla/ignite-new.test.ts
@@ -66,6 +66,12 @@ describe("ignite new", () => {
       expect(templates).toContain("app-icon")
     })
 
+    it("should have created an apple privacy manifest file", () => {
+      // now let's examine the spun-up app
+      const dirs = filesystem.list(appPath + `/ios/${APP_NAME}/`)
+      expect(dirs).toContain("PrivacyInfo.xcprivacy")
+    })
+
     it(`should have renamed all permutations of hello-world to ${APP_NAME}`, async () => {
       // react-native-rename doesn't always catch everything, so we need to check for
       // any instances and fail if it doesn't work


### PR DESCRIPTION

## Description

I added this default config to the boilerplate in the typescript file instead of the json file so i could put comments on the code.

🌈 🙌 With tests! 🙌 🌈 

- Issues: Closes #2674

## Checklist

- [x] I have manually tested this, including by generating a new app locally ([see docs](https://docs.infinite.red/ignite-cli/contributing/Contributing-To-Ignite/#testing-changes-from-your-local-copy-of-ignite)).
