### PR TITLE
chore(linter): Add some more rules to the no-restricted-import rule

### DIFF
--- a/boilerplate/.eslintrc.js
+++ b/boilerplate/.eslintrc.js
@@ -39,6 +39,16 @@ module.exports = {
             importNames: ["default"],
             message: "Import named exports from 'react' instead.",
           },
+          {
+            name: "react-native",
+            importNames: ["SafeAreaView"],
+            message: "Use the SafeAreaView from 'react-native-safe-area-context' instead.",
+          },
+          {
+            name: "react-native",
+            importNames: ["Text", "Button", "TextInput"],
+            message: "Use the custom wrapper component from 'app/src/components'.",
+          }
         ],
       },
     ],

--- a/boilerplate/app/components/Text.tsx
+++ b/boilerplate/app/components/Text.tsx
@@ -1,4 +1,5 @@
 import { TOptions } from "i18next"
+// eslint-disable-next-line no-restricted-imports
 import { StyleProp, Text as RNText, TextProps as RNTextProps, TextStyle } from "react-native"
 import { isRTL, translate, TxKeyPath } from "@/i18n"
 import type { ThemedStyle, ThemedStyleArray } from "@/theme"

--- a/boilerplate/app/components/TextField.tsx
+++ b/boilerplate/app/components/TextField.tsx
@@ -2,6 +2,7 @@ import { ComponentType, forwardRef, Ref, useImperativeHandle, useRef } from "rea
 import {
   ImageStyle,
   StyleProp,
+  // eslint-disable-next-line no-restricted-imports
   TextInput,
   TextInputProps,
   TextStyle,

--- a/boilerplate/app/screens/LoginScreen.tsx
+++ b/boilerplate/app/screens/LoginScreen.tsx
@@ -1,5 +1,6 @@
 import { observer } from "mobx-react-lite"
 import { ComponentType, FC, useEffect, useMemo, useRef, useState } from "react"
+// eslint-disable-next-line no-restricted-imports
 import { TextInput, TextStyle, ViewStyle } from "react-native"
 import {
   Button,

--- a/boilerplate/test/setup.ts
+++ b/boilerplate/test/setup.ts
@@ -1,4 +1,5 @@
 // we always make sure 'react-native' gets included first
+// eslint-disable-next-line no-restricted-imports
 import * as ReactNative from "react-native"
 import mockFile from "./mockFile"
 


### PR DESCRIPTION
## Description

Adds two useful rules to the eslint config for `no-restricted-imports`:

1. We include `react-native-safe-area-view` and should always use the `SafeAreaView` from that library instead of from `react-native`
2. We have our own custom `Text`, `TextField` (TextInput), and `Button` components. Add rules to disallow these from `react-native` to ensure developers are using the components that ship with ignite and not importing from react-native.

## Checklist

- [x] I have manually tested this, including by generating a new app locally ([see docs](https://docs.infinite.red/ignite-cli/contributing/Contributing-To-Ignite/#testing-changes-from-your-local-copy-of-ignite)).
