### PR TITLE
fix(boilerplate): fixes the tintColor of the image on the welcome screen

### DIFF
--- a/boilerplate/app/components/EmptyState.tsx
+++ b/boilerplate/app/components/EmptyState.tsx
@@ -196,7 +196,7 @@ export function EmptyState(props: EmptyStateProps) {
           source={imageSource}
           {...ImageProps}
           style={$imageStyles}
-          tintColor={theme.isDark ? theme.colors.palette.neutral900 : undefined}
+          tintColor={theme.colors.palette.neutral900}
         />
       )}
 

--- a/boilerplate/app/screens/WelcomeScreen.tsx
+++ b/boilerplate/app/screens/WelcomeScreen.tsx
@@ -62,7 +62,7 @@ export const WelcomeScreen: FC<WelcomeScreenProps> = observer(
             style={$welcomeFace}
             source={welcomeFace}
             resizeMode="contain"
-            tintColor={theme.isDark ? theme.colors.palette.neutral900 : undefined}
+            tintColor={theme.colors.palette.neutral900}
           />
         </View>
 

--- a/boilerplate/src/app/index.tsx
+++ b/boilerplate/src/app/index.tsx
@@ -30,7 +30,7 @@ export default observer(function WelcomeScreen() {
           style={$welcomeFace}
           source={welcomeFace}
           resizeMode="contain"
-          tintColor={theme.isDark ? theme.colors.palette.neutral900 : undefined}
+          tintColor={theme.colors.palette.neutral900}
         />
       </View>
 


### PR DESCRIPTION
## Description

This PR sets the tint color for the welcome eyes image without a `isDark` check.

- Issues: closes #2841

## Screenshots

| Before                           | After                           |
| -------------------------------- | ------------------------------- |
| ![Simulator Screen Recording - iPhone 16 Pro - 2025-05-21 at 16 08 31](https://github.com/user-attachments/assets/c54194eb-4132-4163-b7c7-aa9a22d351f2) | ![Simulator Screen Recording - iPhone 16 Pro - 2025-05-21 at 16 06 23](https://github.com/user-attachments/assets/d44ff3c8-f7c9-467f-a626-edb418d16d53) |

## Checklist

- [x] I have manually tested this, including by generating a new app locally ([see docs](https://docs.infinite.red/ignite-cli/contributing/Contributing-To-Ignite/#testing-changes-from-your-local-copy-of-ignite)).
