### PR TITLE
fix(boilerplate,cli): node engine

### DIFF
--- a/boilerplate/package.json
+++ b/boilerplate/package.json
@@ -87,7 +87,7 @@
     "typescript": "~5.8.3"
   },
   "engines": {
-    "node": "^18.18.0 || >=20.0.0"
+    "node": ">=20.0.0"
   },
   "expo": {
     "install": {

--- a/package.json
+++ b/package.json
@@ -43,7 +43,7 @@
     "ignite-cli:prod": "wrap () { node bin/ignite \"$@\" --compiled-build | cat; }; wrap"
   },
   "engines": {
-    "node": "^18.18.0 || >=20.0.0"
+    "node": ">=20.0.0"
   },
   "dependencies": {
     "deepmerge-json": "^1.1.0",


### PR DESCRIPTION
## Description

<!-- Add your PR description here -->

- Updates `package.json` node engine to be 20+ to be aligned with Expo 53 recommendation

## Screenshots

![image](https://github.com/user-attachments/assets/4331fe54-8251-4b7a-a127-175a8700e540)

