### PR TITLE
Fix BackHandler.removeEventListener Deprecation Error

### DIFF
--- a/boilerplate/app/navigators/navigationUtilities.ts
+++ b/boilerplate/app/navigators/navigationUtilities.ts
@@ -87,10 +87,10 @@ export function useBackButtonHandler(canExit: (routeName: string) => boolean) {
     }
 
     // Subscribe when we come to life
-    BackHandler.addEventListener("hardwareBackPress", onBackPress)
+    const subscription = BackHandler.addEventListener("hardwareBackPress", onBackPress)
 
     // Unsubscribe when we're done
-    return () => BackHandler.removeEventListener("hardwareBackPress", onBackPress)
+    return () => subscription.remove()
   }, [])
 }
 


### PR DESCRIPTION
I came across this bug while I was updating versions of my app.  I would love another set of eyes on this

## Problem

The `useBackButtonHandler` function in `navigationUtilities.ts` was using the deprecated `BackHandler.removeEventListener()` method, which causes a runtime error in React Native 0.79.2 with Expo ^53.0.0

`TypeError: _reactNative.BackHandler.removeEventListener is not a function`

This occurs because `BackHandler.removeEventListener()` was removed from the React Native API starting in version 0.71.

## Solution

Updated the code to use the modern `BackHandler` API where `addEventListener()` returns a `NativeEventSubscription` object with a `remove()` method.

**Before:**

```typescript
BackHandler.addEventListener("hardwareBackPress", onBackPress)
return () => BackHandler.removeEventListener("hardwareBackPress", onBackPress)
```

After:
```typescript
const subscription = BackHandler.addEventListener("hardwareBackPress", onBackPress)
return () => subscription.remove()
```

## References
- [React Native BackHandler Documentation](https://reactnative.dev/docs/backhandler)
- https://stackoverflow.com/questions/70988324/removeeventlistener-is-deprecated-and-i-dont-achieve-to-refacto-it-properly
