### PR TITLE
chore(docs): remove section on `useAppTheme()` causing docs to fail build step

### DIFF
--- a/docs/boilerplate/app/utils/Utils.md
+++ b/docs/boilerplate/app/utils/Utils.md
@@ -13,24 +13,6 @@ Every app needs a junk drawer. Here you can find a library of utilities that are
 We sometimes create a separate `app/hooks` folder just for hooks. This is a matter of preference.
 :::
 
-### useAppTheme
-
-A hook that returns various properties and tools relating to theming your app.
-
-```tsx
-const { themed, themeContext } = useAppTheme()
-
-const $themedStyle: ThemedStyle<ViewStyle> = (theme) =({
-  backgroundColor: theme.colors.background
-})
-
-<View style={themed($themedStyle)}>
-  <Text>{themeContext}</Text>
-</View>
-```
-
-[Full `useAppTheme`](./useAppTheme.tsx.md)
-
 ### useSafeAreaInsetsStyle
 
 A hook can be used to create a safe-area-aware style object that can be passed directly to a View.


### PR DESCRIPTION
## Description

Fixes build errors in the docs that prevented them being updated with the release of v11. I accidentally left a link to a non-existent page in there 🤦 

This is already documented in the theme context docs.

## Checklist

- [x] `README.md` and other relevant documentation has been updated with my changes
- [x] I have manually tested this, including by generating a new app locally ([see docs](https://docs.infinite.red/ignite-cli/contributing/Contributing-To-Ignite/#testing-changes-from-your-local-copy-of-ignite)).
