### PR TITLE
chore(docs): remove video about ignite 9 from readmes

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,16 +36,6 @@ Here are a few videos / talks that introduce Ignite and show off some of its fea
       </figure>
     </td>
   </tr>
-  <tr>
-    <td>
-      <figure>
-        <a href="https://www.youtube.com/watch?v=QmkMsUYrTlk">
-          <img src="https://img.youtube.com/vi/QmkMsUYrTlk/sddefault.jpg" alt="Jamon's Code Quest on Ignite 9" width="100%" /><br />
-        <figcaption><strong>What's new in Ignite 9</strong></figcaption>
-        </a>
-      </figure>
-    </td>
-  </tr>
 </table>
 
 ## [Full Documentation](https://github.com/infinitered/ignite/blob/master/docs/README.md)

--- a/docs/README.md
+++ b/docs/README.md
@@ -40,16 +40,6 @@ Here are a few videos / talks that introduce Ignite and show off some of its fea
       </figure>
     </td>
   </tr>
-  <tr>
-    <td>
-      <figure>
-        <a href="https://www.youtube.com/watch?v=QmkMsUYrTlk">
-          <img src="https://img.youtube.com/vi/QmkMsUYrTlk/sddefault.jpg" alt="Jamon's Code Quest on Ignite 9" width="100%" /><br />
-        <figcaption><strong>What's new in Ignite 9</strong></figcaption>
-        </a>
-      </figure>
-    </td>
-  </tr>
 </table>
 
 ## [Full Documentation](https://github.com/infinitered/ignite/blob/master/docs/README.md)

--- a/docs/boilerplate/app/theme/context.ts.md
+++ b/docs/boilerplate/app/theme/context.ts.md
@@ -1,5 +1,6 @@
 ---
 sidebar_position: 10
+title: context.ts
 ---
 
 # theme/context.ts


### PR DESCRIPTION
## Description

another small docs fix to remove the ignite 9 video and fix the theme context page title.

- [x] `README.md` and other relevant documentation has been updated with my changes
- [x] I have manually tested this, including by generating a new app locally ([see docs](https://docs.infinite.red/ignite-cli/contributing/Contributing-To-Ignite/#testing-changes-from-your-local-copy-of-ignite)).
