### PR TITLE
fix: peer-deps needed react-test-renderer 19.0.0

### DIFF
--- a/boilerplate/package.json
+++ b/boilerplate/package.json
@@ -79,6 +79,7 @@
     "jest": "~29.7.0",
     "jest-expo": "~53.0.7",
     "prettier": "^3.3.3",
+    "react-test-renderer": "19.0.0",
     "reactotron-core-client": "^2.9.4",
     "reactotron-react-js": "^3.3.11",
     "reactotron-react-native": "^5.0.5",


### PR DESCRIPTION
## Description

Closes #2976

jest-expo was expecting a different version of react-test-renderer than was installed.

## Checklist

- [x] I have manually tested this, including by generating a new app locally ([see docs](https://docs.infinite.red/ignite-cli/contributing/Contributing-To-Ignite/#testing-changes-from-your-local-copy-of-ignite)).
