### PR TITLE
refactor: rename build script for clarity

### DIFF
--- a/boilerplate/README.md
+++ b/boilerplate/README.md
@@ -18,7 +18,7 @@ To make things work on your local simulator, or on your phone, you need first to
 
 ```bash
 yarn build:ios:sim # build for ios simulator
-yarn build:ios:dev # build for ios device
+yarn build:ios:device # build for ios device
 yarn build:ios:prod # build for ios device
 ```
 

--- a/boilerplate/package.json
+++ b/boilerplate/package.json
@@ -20,11 +20,11 @@
     "test:maestro": "maestro test -e MAESTRO_APP_ID=com.helloworld .maestro/flows",
     "adb": "adb reverse tcp:9090 tcp:9090 && adb reverse tcp:3000 tcp:3000 && adb reverse tcp:9001 tcp:9001 && adb reverse tcp:8081 tcp:8081",
     "build:ios:sim": "eas build --profile development --platform ios --local",
-    "build:ios:dev": "eas build --profile development:device --platform ios --local",
+    "build:ios:device": "eas build --profile development:device --platform ios --local",
     "build:ios:preview": "eas build --profile preview --platform ios --local",
     "build:ios:prod": "eas build --profile production --platform ios --local",
     "build:android:sim": "eas build --profile development --platform android --local",
-    "build:android:dev": "eas build --profile development:device --platform android --local",
+    "build:android:device": "eas build --profile development:device --platform android --local",
     "build:android:preview": "eas build --profile preview --platform android --local",
     "build:android:prod": "eas build --profile production --platform android --local"
   },

--- a/src/tools/react-native.test.ts
+++ b/src/tools/react-native.test.ts
@@ -7,7 +7,7 @@ const EXAMPLE_README = `
 yarn
 yarn start
 yarn build:ios:sim
-yarn build:ios:dev
+yarn build:ios:device
 yarn build:ios:prod
 `
 
@@ -34,7 +34,7 @@ describe("react native", () => {
 npm install
 npm run start
 npm run build:ios:sim
-npm run build:ios:dev
+npm run build:ios:device
 npm run build:ios:prod
 `
 
@@ -51,7 +51,7 @@ npm run build:ios:prod
 yarn install
 yarn start
 yarn build:ios:sim
-yarn build:ios:dev
+yarn build:ios:device
 yarn build:ios:prod
 `
 
@@ -67,7 +67,7 @@ yarn build:ios:prod
 pnpm install
 pnpm run start
 pnpm run build:ios:sim
-pnpm run build:ios:dev
+pnpm run build:ios:device
 pnpm run build:ios:prod
 `
 
@@ -83,7 +83,7 @@ pnpm run build:ios:prod
 bun install
 bun run start
 bun run build:ios:sim
-bun run build:ios:dev
+bun run build:ios:device
 bun run build:ios:prod
 `
 


### PR DESCRIPTION
## Description

Whenever I'm working in an Ignited project, I get confused because I expect `yarn build:<platform>:dev` to be like "development" - which I usually take to mean an emulator or simulator build.

But for in this case, `dev` has been short for "device", which is confusing to me.

This is just a personal point of confusion. My GAFO on this is like, a 3. Happy to close out if others disagree more strongly.

## Checklist

<!-- if an item doesn't apply, just delete it -->

- [x] `README.md` and other relevant documentation has been updated with my changes
- [x] I have manually tested this, including by generating a new app locally ([see docs](https://docs.infinite.red/ignite-cli/contributing/Contributing-To-Ignite/#testing-changes-from-your-local-copy-of-ignite)).
