### PR TITLE
fix: update worklets exclude to drop version

### DIFF
--- a/boilerplate/package.json
+++ b/boilerplate/package.json
@@ -94,7 +94,7 @@
   "expo": {
     "install": {
       "exclude": [
-        "react-native-worklets@~0.7.0-nightly-20251001-14eca5b4c"
+        "react-native-worklets"
       ]
     }
   }

--- a/src/commands/new.ts
+++ b/src/commands/new.ts
@@ -590,7 +590,7 @@ module.exports = {
         // find "expo-localization" line and append "expo-router" line after it
         packageJsonRaw = packageJsonRaw.replace(
           /"expo-localization": ".*",/g,
-          `"expo-localization": "${packageJsonParsed.dependencies["expo-localization"]}",${EOL}    "expo-router":  "~5.0.7",`,
+          `"expo-localization": "${packageJsonParsed.dependencies["expo-localization"]}",${EOL}    "expo-router":  "~6.0.10",`,
         )
 
         // replace "main" entry point from App.js to "expo-router/entry"

--- a/src/tools/packager.ts
+++ b/src/tools/packager.ts
@@ -147,7 +147,7 @@ function installCmd(options: PackageRunOptions) {
   } else if (options.packagerName === "yarn") {
     return `yarn install${silent}`
   } else if (options.packagerName === "npm") {
-    return `npm install${silent}`
+    return `npm install${silent} --legacy-peer-deps`
   } else if (options.packagerName === "bun") {
     return `bun install${silent}`
   } else {

--- a/src/tools/react-native.test.ts
+++ b/src/tools/react-native.test.ts
@@ -31,7 +31,7 @@ describe("react native", () => {
 
       const results = filesystem.read(readmePath)
       const expectedResults = `
-npm install
+npm install --legacy-peer-deps
 npm run start
 npm run build:ios:sim
 npm run build:ios:device


### PR DESCRIPTION
## Description

There's an issue when providing the version in the `expo.install.excludes` keys, which might be related to the -nightly suffix as it doesn't fall into some of the prerelease tags (not 100% on this).

Looking at [the docs](https://docs.expo.dev/versions/latest/config/package-json/#installexclude), it seems like they may have migrated away from providing the specific version in the key anyway? This doesn't match with Expo's test cases on the matter, but it is what the docs say now.

- Closes #3000 

In addition to this, I updated the `expo-router` version we slide into the template from the new command. This wasn't required, as `expo install --fix` actually would have fixed it anyway, should the worklets install would have actually been excluded.

## Screenshots

### Before terminal output
Note how it says it is skipping them, but it still lists it as a version it is going to update with `install --check`

```tsx
npx expo install --check
Skipped checking dependencies: react-native-worklets@0.7.0-nightly-20251001-14eca5b4c. These dependencies are listed in expo.install.exclude in package.json. Learn more: https://docs.expo.dev/more/expo-cli/#configuring-dependency-validation
The following packages should be updated for best compatibility with the installed expo version:
  expo-router@5.0.7 - expected version: ~6.0.10
  react-native-worklets@0.7.0-nightly-20251001-14eca5b4c - expected version: 0.5.1
Your project may not work correctly until you install the expected versions of the packages.
? Fix dependencies? › (Y/n)
```

### After terminal output
Then, when dropping the version from package.json:

```tsx
npx expo install --check
Skipped checking dependencies: react-native-worklets@0.7.0-nightly-20251001-14eca5b4c. These dependencies are listed in expo.install.exclude in package.json. Learn more: https://docs.expo.dev/more/expo-cli/#configuring-dependency-validation
The following packages should be updated for best compatibility with the installed expo version:
  expo-router@5.0.7 - expected version: ~6.0.10
Your project may not work correctly until you install the expected versions of the packages.
? Fix dependencies? › (Y/n)
```

