### PR TITLE
chore: bump react-native-worklets version to proper release

### DIFF
--- a/boilerplate/package.json
+++ b/boilerplate/package.json
@@ -62,7 +62,7 @@
     "react-native-safe-area-context": "5.6.0",
     "react-native-screens": "~4.16.0",
     "react-native-web": "~0.21.0",
-    "react-native-worklets": "0.7.0-nightly-20251001-14eca5b4c",
+    "react-native-worklets": "0.6.1",
     "setimmediate": "^1.0.5"
   },
   "devDependencies": {


### PR DESCRIPTION
## Description

SW released the bug fix we were pulling in with their nightlies in https://github.com/software-mansion/react-native-reanimated/releases/tag/worklets-0.6.1.

We still need to exclude from Expo install commands because the Expo template wants to use `0.5`.

## Screenshots

New ignite app, `yarn web`

<img width="1507" height="785" alt="Screenshot 2025-10-09 at 10 52 24 AM" src="https://github.com/user-attachments/assets/455c8e97-95af-489a-9f97-7214980de595" />

## Checklist

<!-- if an item doesn't apply, just delete it -->

- [x] `README.md` and other relevant documentation has been updated with my changes
- [x] I have manually tested this, including by generating a new app locally ([see docs](https://docs.infinite.red/ignite-cli/contributing/Contributing-To-Ignite/#testing-changes-from-your-local-copy-of-ignite)).
