### PR TITLE
docs: update expo pkg versions from 54 upgrade

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,15 +48,14 @@ Nothing makes it into Ignite unless it's been proven on projects that Infinite R
 
 | Library                          | Category             | Version | Description                                    |
 | -------------------------------- | -------------------- | ------- | ---------------------------------------------- |
-| React Native                     | Mobile Framework     | v0.79   | The best cross-platform mobile framework       |
+| React Native                     | Mobile Framework     | v0.81   | The best cross-platform mobile framework       |
 | React                            | UI Framework         | v19     | The most popular UI framework in the world     |
 | TypeScript                       | Language             | v5      | Static typechecking                            |
 | React Navigation                 | Navigation           | v7      | Performant and consistent navigation framework |
-| Expo                             | SDK                  | v53     | Allows (optional) Expo modules                 |
-| Expo Font                        | Custom Fonts         | v13     | Import custom fonts                            |
-| Expo Localization                | Internationalization | v16     | i18n support (including RTL!)                  |
-| Expo Status Bar                  | Status Bar Library   | v2      | Status bar support                             |
-| RN Reanimated                    | Animations           | v3      | Beautiful and performant animations            |
+| Expo                             | SDK                  | v54     | Allows (optional) Expo modules                 |
+| Expo Font                        | Custom Fonts         | v14     | Import custom fonts                            |
+| Expo Localization                | Internationalization | v17     | i18n support (including RTL!)                  |
+| RN Reanimated                    | Animations           | v4      | Beautiful and performant animations            |
 | MMKV                             | Persistence          | v3      | State persistence                              |
 | apisauce                         | REST client          | v3      | Communicate with back-end                      |
 | Jest                             | Test Runner          | v29     | Standard test runner for JS apps               |

--- a/docs/README.md
+++ b/docs/README.md
@@ -52,15 +52,14 @@ Nothing makes it into Ignite unless it's been proven on projects that Infinite R
 
 | Library                          | Category             | Version | Description                                    |
 | -------------------------------- | -------------------- | ------- | ---------------------------------------------- |
-| React Native                     | Mobile Framework     | v0.79   | The best cross-platform mobile framework       |
+| React Native                     | Mobile Framework     | v0.81   | The best cross-platform mobile framework       |
 | React                            | UI Framework         | v19     | The most popular UI framework in the world     |
 | TypeScript                       | Language             | v5      | Static typechecking                            |
 | React Navigation                 | Navigation           | v7      | Performant and consistent navigation framework |
-| Expo                             | SDK                  | v53     | Allows (optional) Expo modules                 |
-| Expo Font                        | Custom Fonts         | v13     | Import custom fonts                            |
-| Expo Localization                | Internationalization | v16     | i18n support (including RTL!)                  |
-| Expo Status Bar                  | Status Bar Library   | v2      | Status bar support                             |
-| RN Reanimated                    | Animations           | v3      | Beautiful and performant animations            |
+| Expo                             | SDK                  | v54     | Allows (optional) Expo modules                 |
+| Expo Font                        | Custom Fonts         | v14     | Import custom fonts                            |
+| Expo Localization                | Internationalization | v17     | i18n support (including RTL!)                  |
+| RN Reanimated                    | Animations           | v4      | Beautiful and performant animations            |
 | MMKV                             | Persistence          | v3      | State persistence                              |
 | apisauce                         | REST client          | v3      | Communicate with back-end                      |
 | Jest                             | Test Runner          | v29     | Standard test runner for JS apps               |


### PR DESCRIPTION
## Description

It was reported in the community slack that we missed updating the docs with some version numbers after the last SDK upgrade.

- Issues: <!-- e.g. "fixes #9999", "related: #9999", etc -->

## Screenshots

| Before                           | After                           |
| -------------------------------- | ------------------------------- |
| <img width="525" height="515" alt="image" src="https://github.com/user-attachments/assets/99c9e95d-564d-48c3-9225-edb0e26684fa" /> | <img width="518" height="515" alt="image" src="https://github.com/user-attachments/assets/f5dd9102-5991-4d54-8d5f-e53250819902" /> |

## Checklist

<!-- if an item doesn't apply, just delete it -->

- [x] `README.md` and other relevant documentation has been updated with my changes
