### PR TITLE
fix(boilerplate): fix _OnFlowStart.yaml Maestro flow

### DIFF
--- a/boilerplate/.maestro/shared/_OnFlowStart.yaml
+++ b/boilerplate/.maestro/shared/_OnFlowStart.yaml
@@ -36,22 +36,4 @@ appId: ${MAESTRO_APP_ID}
       # this regex allows for different hosts and ports
       - tapOn: "http://.*:.*" 
       - waitForAnimationToEnd
-
-- runFlow:
-    when:
-      platform: Android
-      visible:
-        id: "${MAESTRO_APP_ID}:id/bottom_sheet" # id of the android bottom sheet we want to dismiss
-    commands:
-      - swipe:
-          direction: DOWN
-      - waitForAnimationToEnd
-- runFlow:
-    when:
-      platform: iOS
-      visible: 
-        id: "SBSwitcherWindow:Main" # id of the iOS bottom sheet we want to dismiss
-    commands:
-      - swipe:
-          direction: DOWN
-      - waitForAnimationToEnd
+      - tapOn: "Close" # dismiss the bottom sheet


### PR DESCRIPTION
## Description

This PR fixes the _onFlowStart.yaml shared workflow in Maestro. The new Expo dev client UI does not have the same ID for the bottom sheet that we were looking for previously

## Screenshots

<img width="549" height="253" alt="Screenshot 2025-10-22 at 8 41 49 PM" src="https://github.com/user-attachments/assets/dce1970e-a9cf-447c-a5df-1ec94cb0b17e" />

## Checklist

- [x] I have manually tested this, including by generating a new app locally (ran test on both Android and iOS)
