### PR TITLE
fix(boilerplate): eas build profile fails to match the required pattern: `/^[a-z\d][a-z\d._-]*$/`

### DIFF
--- a/boilerplate/eas.json
+++ b/boilerplate/eas.json
@@ -14,7 +14,7 @@
         "simulator": true
       }
     },
-    "development:device": {
+    "development-device": {
       "extends": "development",
       "distribution": "internal",
       "ios": {
@@ -28,7 +28,7 @@
       "ios": { "simulator": true },
       "android": { "buildType": "apk" }
     },
-    "preview:device": {
+    "preview-device": {
       "extends": "preview",
       "ios": { "simulator": false }
     },

--- a/boilerplate/package.json
+++ b/boilerplate/package.json
@@ -22,11 +22,11 @@
     "test:maestro": "maestro test -e MAESTRO_APP_ID=com.helloworld .maestro/flows",
     "adb": "adb reverse tcp:9090 tcp:9090 && adb reverse tcp:3000 tcp:3000 && adb reverse tcp:9001 tcp:9001 && adb reverse tcp:8081 tcp:8081",
     "build:ios:sim": "eas build --profile development --platform ios --local",
-    "build:ios:device": "eas build --profile development:device --platform ios --local",
+    "build:ios:device": "eas build --profile development-device --platform ios --local",
     "build:ios:preview": "eas build --profile preview --platform ios --local",
     "build:ios:prod": "eas build --profile production --platform ios --local",
     "build:android:sim": "eas build --profile development --platform android --local",
-    "build:android:device": "eas build --profile development:device --platform android --local",
+    "build:android:device": "eas build --profile development-device --platform android --local",
     "build:android:preview": "eas build --profile preview --platform android --local",
     "build:android:prod": "eas build --profile production --platform android --local"
   },


### PR DESCRIPTION
## Description

with the last `eas-cli` version we have some restrictions on build channel naming, `:` fails.

- `development:device` raise an error
- `development-device` works

```
❯ npx testflight
Need to install the following packages:
eas-cli@16.28.0
Ok to proceed? (y) y

eas.json is not valid.
- "build.development:device.channel" with value "development:device" fails to match the required pattern: /^[a-z\d][a-z\d._-]*$/
- "build.preview:device.channel" with value "preview:device" fails to match the required pattern: /^[a-z\d][a-z\d._-]*$/
    Error: build command failed.
```

## Screenshots

<img width="721" height="173" alt="CleanShot 2025-12-03 at 10 13 42@2x" src="https://github.com/user-attachments/assets/8750f542-6433-46d9-8d9e-b62af3c8885e" />

## Checklist

<!-- if an item doesn't apply, just delete it -->

- [x] `README.md` and other relevant documentation has been updated with my changes
- [x] I have manually tested this on my other app, including generating a new build for testflight