### PR TITLE
docs: add trailing slashes to Toggle component documentation URLs

### DIFF
--- a/docs/boilerplate/app/components/Radio.md
+++ b/docs/boilerplate/app/components/Radio.md
@@ -6,6 +6,24 @@ import ToggleProps from './\_toggle_props.mdx';
 
 # Radio
 
-The `Radio` component provides a simple way to collect user input for a boolean value.
+This is the `Radio` variant of the [Toggle component](https://github.com/infinitered/ignite/blob/master/boilerplate/app/components/Toggle/Toggle.tsx). It renders a circular toggle with an inner dot indicator.
+
+```tsx
+<Radio value={value} onValueChange={setValue} />
+```
+
+## Radio Props
+
+### `inputDetailStyle`
+
+The `inputDetailStyle` prop allows you to customize the inner dot indicator. This affects the small circular dot that appears when the radio is in the "on" state.
+
+```tsx
+<Radio
+  value={value}
+  onValueChange={setValue}
+  inputDetailStyle={{ backgroundColor: "red", width: 16, height: 16 }}
+/>
+```
 
 <ToggleProps componentName="Radio" />


### PR DESCRIPTION
## Summary

Updated the Radio component documentation to clarify its relationship with the Toggle component system.

## Changes Made

- **docs/boilerplate/app/components/Radio.md**: 
  - Added explanation that Radio is a variant of the Toggle component
  - Documented the `inputDetailStyle` prop for customizing the dot indicator
  - Added usage example

Fixes #3021