### PR TITLE
feat: update boilerplate to expo 55

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,7 +52,7 @@ Nothing makes it into Ignite unless it's been proven on projects that Infinite R
 | React                            | UI Framework         | v19     | The most popular UI framework in the world     |
 | TypeScript                       | Language             | v5      | Static typechecking                            |
 | React Navigation                 | Navigation           | v7      | Performant and consistent navigation framework |
-| Expo                             | SDK                  | v54     | Allows (optional) Expo modules                 |
+| Expo                             | SDK                  | v55     | Allows (optional) Expo modules                 |
 | Expo Font                        | Custom Fonts         | v14     | Import custom fonts                            |
 | Expo Localization                | Internationalization | v17     | i18n support (including RTL!)                  |
 | RN Reanimated                    | Animations           | v4      | Beautiful and performant animations            |

--- a/boilerplate/app/components/Screen.tsx
+++ b/boilerplate/app/components/Screen.tsx
@@ -12,7 +12,10 @@ import {
 } from "react-native"
 import { useScrollToTop } from "@react-navigation/native"
 import { SystemBars, SystemBarsProps, SystemBarStyle } from "react-native-edge-to-edge"
-import { KeyboardAwareScrollView } from "react-native-keyboard-controller"
+import {
+  KeyboardAwareScrollView,
+  type KeyboardAwareScrollViewRef,
+} from "react-native-keyboard-controller"
 
 import { useAppTheme } from "@/theme/context"
 import { $styles } from "@/theme/styles"
@@ -197,7 +200,7 @@ function ScreenWithScrolling(props: ScreenProps) {
     style,
   } = props as ScrollScreenProps
 
-  const ref = useRef<ScrollView>(null)
+  const ref = useRef<KeyboardAwareScrollViewRef>(null)
 
   const { scrollEnabled, onContentSizeChange, onLayout } = useAutoPreset(props as AutoScreenProps)
 

--- a/boilerplate/app/components/Screen.tsx
+++ b/boilerplate/app/components/Screen.tsx
@@ -4,7 +4,6 @@ import {
   KeyboardAvoidingViewProps,
   LayoutChangeEvent,
   Platform,
-  ScrollView,
   ScrollViewProps,
   StyleProp,
   View,

--- a/boilerplate/package.json
+++ b/boilerplate/package.json
@@ -30,39 +30,39 @@
     "build:android:preview": "eas build --profile preview --platform android --local",
     "build:android:prod": "eas build --profile production --platform android --local"
   },
-  "dependencies": {
+    "dependencies": {
     "@expo-google-fonts/space-grotesk": "^0.4.0",
-    "@expo/metro-runtime": "~6.1.2",
+    "@expo/metro-runtime": "~55.0.6",
     "@react-navigation/bottom-tabs": "^7.2.0",
     "@react-navigation/native": "^7.0.14",
     "@react-navigation/native-stack": "^7.2.0",
     "apisauce": "3.1.1",
     "date-fns": "^4.1.0",
-    "expo": "54.0.12",
-    "expo-application": "~7.0.7",
-    "expo-build-properties": "~1.0.9",
-    "expo-dev-client": "~6.0.12",
-    "expo-font": "~14.0.8",
-    "expo-linking": "~8.0.8",
-    "expo-localization": "~17.0.7",
-    "expo-splash-screen": "~31.0.10",
-    "expo-system-ui": "~6.0.7",
+    "expo": "55.0.5",
+    "expo-application": "~55.0.8",
+    "expo-build-properties": "~55.0.9",
+    "expo-dev-client": "~55.0.11",
+    "expo-font": "~55.0.4",
+    "expo-linking": "~55.0.7",
+    "expo-localization": "~55.0.8",
+    "expo-splash-screen": "~55.0.10",
+    "expo-system-ui": "~55.0.9",
     "i18next": "^23.14.0",
     "intl-pluralrules": "^2.0.1",
-    "react": "19.1.0",
-    "react-dom": "19.1.0",
+    "react": "19.2.0",
+    "react-dom": "19.2.0",
     "react-i18next": "^15.0.1",
-    "react-native": "0.81.4",
+    "react-native": "0.83.2",
     "react-native-drawer-layout": "^4.0.1",
     "react-native-edge-to-edge": "~1.6.1",
-    "react-native-gesture-handler": "~2.28.0",
-    "react-native-keyboard-controller": "1.18.5",
+    "react-native-gesture-handler": "~2.30.0",
+    "react-native-keyboard-controller": "1.20.7",
     "react-native-mmkv": "3.3.3",
-    "react-native-reanimated": "~4.1.1",
-    "react-native-safe-area-context": "5.6.0",
-    "react-native-screens": "~4.16.0",
+    "react-native-reanimated": "4.2.1",
+    "react-native-safe-area-context": "~5.6.2",
+    "react-native-screens": "~4.23.0",
     "react-native-web": "~0.21.0",
-    "react-native-worklets": "0.6.1",
+    "react-native-worklets": "0.7.2",
     "setimmediate": "^1.0.5"
   },
   "devDependencies": {
@@ -71,17 +71,17 @@
     "@babel/runtime": "^7.20.0",
     "@testing-library/react-native": "^13.2.0",
     "@types/jest": "^29.5.14",
-    "@types/react": "~19.1.10",
+    "@types/react": "~19.2.10",
     "babel-jest": "^29.2.1",
     "dependency-cruiser": "^17.0.2",
     "eslint": "^8.57.0",
-    "eslint-config-expo": "~10.0.0",
+    "eslint-config-expo": "~55.0.0",
     "eslint-config-prettier": "^9.1.0",
     "eslint-plugin-prettier": "^5.2.1",
     "eslint-plugin-react-native": "^4.1.0",
     "eslint-plugin-reactotron": "^0.1.2",
     "jest": "~29.7.0",
-    "jest-expo": "~54.0.12",
+    "jest-expo": "~55.0.9",
     "prettier": "^3.3.3",
     "react-test-renderer": "19.1.0",
     "reactotron-core-client": "^2.9.4",
@@ -94,12 +94,5 @@
   },
   "engines": {
     "node": ">=20.0.0"
-  },
-  "expo": {
-    "install": {
-      "exclude": [
-        "react-native-worklets"
-      ]
-    }
   }
 }

--- a/boilerplate/package.json
+++ b/boilerplate/package.json
@@ -83,7 +83,7 @@
     "jest": "~29.7.0",
     "jest-expo": "~55.0.9",
     "prettier": "^3.3.3",
-    "react-test-renderer": "19.1.0",
+    "react-test-renderer": "19.2.0",
     "reactotron-core-client": "^2.9.4",
     "reactotron-react-js": "^3.3.11",
     "reactotron-react-native": "^5.0.5",

--- a/docs/README.md
+++ b/docs/README.md
@@ -56,7 +56,7 @@ Nothing makes it into Ignite unless it's been proven on projects that Infinite R
 | React                            | UI Framework         | v19     | The most popular UI framework in the world     |
 | TypeScript                       | Language             | v5      | Static typechecking                            |
 | React Navigation                 | Navigation           | v7      | Performant and consistent navigation framework |
-| Expo                             | SDK                  | v54     | Allows (optional) Expo modules                 |
+| Expo                             | SDK                  | v55     | Allows (optional) Expo modules                 |
 | Expo Font                        | Custom Fonts         | v14     | Import custom fonts                            |
 | Expo Localization                | Internationalization | v17     | i18n support (including RTL!)                  |
 | RN Reanimated                    | Animations           | v4      | Beautiful and performant animations            |

--- a/src/commands/new.ts
+++ b/src/commands/new.ts
@@ -591,7 +591,7 @@ module.exports = {
         // find "expo-localization" line and append "expo-router" line after it
         packageJsonRaw = packageJsonRaw.replace(
           /"expo-localization": ".*",/g,
-          `"expo-localization": "${packageJsonParsed.dependencies["expo-localization"]}",${EOL}    "expo-router":  "~6.0.10",`,
+          `"expo-localization": "${packageJsonParsed.dependencies["expo-localization"]}",${EOL}    "expo-router":  "~55.0.4",`,
         )
 
         // replace "main" entry point from App.js to "expo-router/entry"

--- a/src/tools/demo.ts
+++ b/src/tools/demo.ts
@@ -2,7 +2,7 @@ import { filesystem } from "gluegun"
 
 export const DEMO_MARKUP_PREFIX = "@demo"
 
-export const demoDependenciesToRemove = []
+export const demoDependenciesToRemove = ["expo-application"]
 
 export function findDemoPatches(): string[] {
   const patchesPath = filesystem.path("./patches")

--- a/src/tools/demo.ts
+++ b/src/tools/demo.ts
@@ -2,7 +2,7 @@ import { filesystem } from "gluegun"
 
 export const DEMO_MARKUP_PREFIX = "@demo"
 
-export const demoDependenciesToRemove = ["expo-application"]
+export const demoDependenciesToRemove = []
 
 export function findDemoPatches(): string[] {
   const patchesPath = filesystem.path("./patches")


### PR DESCRIPTION
## Description

Closes https://github.com/infinitered/ignite/issues/3030. The Expo 54 -> Expo 55 upgrade is pretty simple. Ran through it in a test app in https://github.com/coolsoftwaretyler/igniteexpo54to55/pull/1. Had some initial friction from the canary releases, but the final releases smoothed out a lot.

## Screenshots

### Android

[Screen_recording_20260306_190203.webm](https://github.com/user-attachments/assets/eb2e5c65-a3bb-4da5-9d25-35eef0e5b75d)


### iOS


https://github.com/user-attachments/assets/01888262-aefe-4e92-8c5e-748da223636d



### Web

https://github.com/user-attachments/assets/9aa5a6a7-0e7d-4661-a9e3-7a75a8aecb27


## Checklist

- [x] `README.md` and other relevant documentation has been updated with my changes
- [x] I have manually tested this, including by generating a new app locally ([see docs](https://docs.infinite.red/ignite-cli/contributing/Contributing-To-Ignite/#testing-changes-from-your-local-copy-of-ignite)).
