### PR TITLE
fix(scripts): make the test script runnable on Windows

### DIFF
--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
     "lint": "eslint 'src/**' 'test/**'",
     "depcruise": "depcruise src --config .dependency-cruiser.js",
     "depcruise:graph": "depcruise src --include-only \"^src\" --config .dependency-cruiser.js --output-type dot | dot -T svg > ignite-cli-dependency-graph.svg && dot -T png ignite-cli-dependency-graph.svg -o ignite-cli-dependency-graph.png",
-    "test": "TS_JEST_DISABLE_VER_CHECKER=true jest",
+    "test": "jest",
     "watch": "jest --watch",
     "watch:debug": "pnpm run watch --runInBand --verbose",
     "coverage": "jest --coverage",


### PR DESCRIPTION
## Description

`pnpm test` cannot run at all on Windows. The `test` script prefixes jest with a POSIX inline environment variable assignment:

```json
"test": "TS_JEST_DISABLE_VER_CHECKER=true jest"
```

cmd.exe has no equivalent syntax, so the shell tries to execute the assignment as a command and the run dies before jest starts:

```
> ignite-cli@11.5.0 test C:\...\ignite
> TS_JEST_DISABLE_VER_CHECKER=true jest

'TS_JEST_DISABLE_VER_CHECKER' is not recognized as an internal or external command,
operable program or batch file.
 ELIFECYCLE  Test failed.
```

That's a fresh `git clone && pnpm install && pnpm test` on Windows 11 — a contributor on Windows can't run the suite before opening a PR.

### Why removing the variable rather than wrapping it

`TS_JEST_DISABLE_VER_CHECKER` opted out of a TypeScript version-mismatch warning that ts-jest has since dropped. In the ts-jest this repo resolves (**29.4.6**, from `ts-jest: ^29.1.1`), the name appears **only in `CHANGELOG.md`** — `grep -ril ver_checker node_modules/…/ts-jest/dist/` returns nothing. Running jest without it emits no warning of any kind:

```
$ npx jest src/tools          # no env var set
Test Suites: 3 passed, 3 total
Tests:       19 passed, 19 total
```

So the prefix costs a hard failure on Windows and buys nothing.

There's also a consistency argument: `watch`, `watch:debug` and `coverage` already invoke jest bare. `test` was the only one carrying the prefix.

**If you'd rather keep the variable** — say, to stay covered should the checker ever return — the cross-platform form is `cross-env`:

```json
"test": "cross-env TS_JEST_DISABLE_VER_CHECKER=true jest"
```

That needs a new devDependency, which is why I didn't reach for it first. Happy to switch if you prefer it.

- Issues: <!-- none filed; found while running the suite on Windows -->

## Checklist

- [x] `README.md` and other relevant documentation has been updated with my changes — no documentation references this script's env var.
- [ ] I have manually tested this, including by generating a new app locally. — I ran the unit suite (`src/tools`, 19 tests, 3 suites) before and after on Windows 11 / Node 22.23.2 / pnpm 10.9.0. I did **not** run the `test/vanilla` e2e specs, which generate real apps and need a full RN toolchain; this change doesn't touch generation, only how jest is invoked. CI (CircleCI, `cimg/node:20.19.4`) runs Linux only, so the whole suite there is unaffected either way — `jest` picks up the same config with or without the variable.

### Verification

**Before** (on `master`)

```
$ pnpm test
'TS_JEST_DISABLE_VER_CHECKER' is not recognized as an internal or external command
ELIFECYCLE Test failed.        # exit 1, zero tests run
```

**After**

```
$ pnpm test src/tools
Test Suites: 3 passed, 3 total
Tests:       19 passed, 19 total          # exit 0
```

On Linux/macOS the behaviour is unchanged: the variable was already a no-op there, so jest receives exactly the same configuration.
